### PR TITLE
Disable timestamp parsing in livestream chat

### DIFF
--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -42,6 +42,7 @@ type MarkdownProps = {
   className?: string,
   parentCommentId?: string,
   isMarkdownPost?: boolean,
+  disableTimestamps?: boolean,
   stakedLevel?: number,
 };
 
@@ -132,7 +133,17 @@ function isStakeEnoughForPreview(stakedLevel) {
 // ****************************************************************************
 
 const MarkdownPreview = (props: MarkdownProps) => {
-  const { content, strip, simpleLinks, noDataStore, className, parentCommentId, isMarkdownPost, stakedLevel } = props;
+  const {
+    content,
+    strip,
+    simpleLinks,
+    noDataStore,
+    className,
+    parentCommentId,
+    isMarkdownPost,
+    disableTimestamps,
+    stakedLevel,
+  } = props;
   const strippedContent = content
     ? content.replace(REPLACE_REGEX, (iframeHtml, y, iframeSrc) => {
         // Let the browser try to create an iframe to see if the markup is valid
@@ -217,8 +228,8 @@ const MarkdownPreview = (props: MarkdownProps) => {
           // Note: The order is important
           .use(formatedLinks)
           .use(inlineLinks)
-          .use(isMarkdownPost ? null : inlineTimestamp)
-          .use(isMarkdownPost ? null : formattedTimestamp)
+          .use(disableTimestamps || isMarkdownPost ? null : inlineTimestamp)
+          .use(disableTimestamps || isMarkdownPost ? null : formattedTimestamp)
           // Emojis
           .use(remarkEmoji)
           // Render new lines without needing spaces.

--- a/ui/component/livestreamComment/view.jsx
+++ b/ui/component/livestreamComment/view.jsx
@@ -104,7 +104,7 @@ function LivestreamComment(props: Props) {
           )}
 
           <div className="livestream-comment__text">
-            <MarkdownPreview content={message} promptLinks stakedLevel={stakedLevel} />
+            <MarkdownPreview content={message} promptLinks stakedLevel={stakedLevel} disableTimestamps />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Issues
- The current version of the link handler doesn't seem able to control the livestream player's position.
- The "live" position is always 0:00 and everything behind it is a negative timestamp. The current timestamp parser doesn't handle negative values.