### PR TITLE
Fix recsys submission when `user` is null

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -97,6 +97,7 @@
   "About --[tab title in Channel Page]--": "About",
   "About --[link title in Sidebar or Footer]--": "About",
   "Community Guidelines": "Community Guidelines",
+  "FAQ and Support": "FAQ and Support",
   "Share Channel": "Share Channel",
   "Go to page:": "Go to page:",
   "Enter a URL for your thumbnail.": "Enter a URL for your thumbnail.",

--- a/ui/recsys.js
+++ b/ui/recsys.js
@@ -92,7 +92,8 @@ const recsys = {
   createRecsysEntry: function (claimId, parentUuid) {
     if (window && window.store && claimId) {
       const state = window.store.getState();
-      const { id: userId } = selectUser(state);
+      const user = selectUser(state);
+      const userId = user ? user.id : null;
       if (parentUuid) {
         // Make a stub entry that will be filled out on page load
         recsys.entries[claimId] = {


### PR DESCRIPTION
## Issue
Closes [#44 tor browser crash related to recsys?](https://github.com/OdyseeTeam/odysee-frontend/issues/44)

## Reproduce the exact error
Block the request for `me`, `new`, `list_blocked` and `list_filtered` in dev tools.

## Fix
The code was trying to destructure a null object.

The existing code seems to indicate that null ID is expected (it uses null as fallback), so this change shouldn't impact recsys results (I didn't check the recsys docs to confirm).

## Test
Played a few videos this time to be sure.