### PR TITLE
[Comment/Livestream] Markdown and style fixes

### DIFF
--- a/ui/component/commentMenuList/view.jsx
+++ b/ui/component/commentMenuList/view.jsx
@@ -20,6 +20,7 @@ type Props = {
   disableEdit?: boolean,
   disableRemove?: boolean,
   supportAmount?: any,
+  isLiveComment: boolean,
   // --- select ---
   claim: ?Claim,
   claimIsMine: boolean,
@@ -54,6 +55,7 @@ function CommentMenuList(props: Props) {
     disableEdit,
     disableRemove,
     supportAmount,
+    isLiveComment,
     doToast,
     handleEditComment,
     openModal,
@@ -229,7 +231,7 @@ function CommentMenuList(props: Props) {
         </>
       )}
 
-      {IS_WEB && (
+      {IS_WEB && !isLiveComment && (
         <MenuItem className="comment__menu-option" onSelect={handleCopyCommentLink}>
           <div className="menu__link">
             <Icon aria-hidden icon={ICONS.COPY_LINK} />

--- a/ui/component/livestreamComment/view.jsx
+++ b/ui/component/livestreamComment/view.jsx
@@ -119,10 +119,11 @@ function LivestreamComment(props: Props) {
             commentId={commentId}
             authorUri={authorUri}
             commentIsMine={commentIsMine}
-            disableEdit
-            isTopLevel
             isPinned={isPinned}
             disableRemove={supportAmount > 0}
+            isTopLevel
+            disableEdit
+            isLiveComment
           />
         </Menu>
       </div>

--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -268,9 +268,12 @@ $thumbnailWidthSmall: 1rem;
   max-width: 35rem;
   color: var(--color-text);
 
-  ul li,
-  ol li {
-    list-style-position: inside;
+  ul li {
+    list-style-type: disc;
+
+    ul li {
+      list-style-type: circle;
+    }
   }
 
   p {

--- a/ui/scss/component/_livestream.scss
+++ b/ui/scss/component/_livestream.scss
@@ -92,9 +92,20 @@ $recent-msg-button__height: 2rem;
   }
 }
 
+.livestream-comment__info {
+  overflow: hidden;
+}
+
 .livestream-comment--superchat {
   + .livestream-comment--superchat {
     margin-bottom: var(--spacing-xxs);
+  }
+
+  .livestream-comment__body {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: unset;
+    flex: unset;
   }
 
   .livestream-comment__info {
@@ -116,13 +127,10 @@ $recent-msg-button__height: 2rem;
 
 .livestream-comment__body {
   display: flex;
-  align-items: flex-start;
-}
-
-.livestream-comment__body {
-  display: flex;
-  align-items: flex-start;
+  flex-direction: column;
+  flex: 2;
   margin-left: var(--spacing-s);
+  overflow: hidden;
 
   .channel-thumbnail {
     @include handleChannelGif(2rem);
@@ -354,6 +362,7 @@ $recent-msg-button__height: 2rem;
 .livestream-comment__text {
   padding-right: var(--spacing-xl);
   padding-bottom: var(--spacing-xxs);
+
   .markdown-preview {
     p {
       word-break: break-word;

--- a/ui/scss/component/_livestream.scss
+++ b/ui/scss/component/_livestream.scss
@@ -87,6 +87,18 @@ $recent-msg-button__height: 2rem;
   list-style-type: none;
   position: relative;
 
+  @media (min-width: $breakpoint-small) {
+    &:hover {
+      background-color: var(--color-card-background-highlighted);
+    }
+
+    &:not(:hover) {
+      .menu__button:not(:focus):not([aria-expanded='true']) {
+        opacity: 0;
+      }
+    }
+  }
+
   .channel-name {
     font-size: var(--font-xsmall);
   }

--- a/ui/scss/component/_markdown-preview.scss
+++ b/ui/scss/component/_markdown-preview.scss
@@ -1,4 +1,6 @@
 .markdown-preview {
+  word-break: break-all;
+
   > :first-child {
     margin-top: 0;
   }

--- a/ui/util/remark-lbry.js
+++ b/ui/util/remark-lbry.js
@@ -108,15 +108,15 @@ function tokenizeURI(eat, value, silent) {
 
 // Configure tokenizer for lbry urls
 tokenizeURI.locator = locateURI;
-tokenizeURI.notInList = true;
+tokenizeURI.notInList = false;
 tokenizeURI.notInLink = true;
-tokenizeURI.notInBlock = true;
+tokenizeURI.notInBlock = false;
 
 // Configure tokenizer for lbry channels
 tokenizeMention.locator = locateMention;
-tokenizeMention.notInList = true;
+tokenizeMention.notInList = false;
 tokenizeMention.notInLink = true;
-tokenizeMention.notInBlock = true;
+tokenizeMention.notInBlock = false;
 
 const visitor = (node, index, parent) => {
   if (node.type === 'link' && parent && parent.type === 'paragraph') {

--- a/ui/util/remark-lbry.js
+++ b/ui/util/remark-lbry.js
@@ -149,7 +149,7 @@ const transform = (tree) => {
   visit(tree, ['link'], visitor);
 };
 
-export const formatedLinks = () => transform;
+export const formattedLinks = () => transform;
 
 // Main module
 export function inlineLinks() {

--- a/ui/util/remark-lbry.js
+++ b/ui/util/remark-lbry.js
@@ -12,13 +12,19 @@ const mentionRegex = /@[^\s()"]*/gm;
 const invalidRegex = /[-_.+=?!@#$%^&*:;,{}<>\w/\\]/;
 
 function handlePunctuation(value) {
-  const modifierIndex =
-    (value.indexOf(':') >= 0 && value.indexOf(':')) || (value.indexOf('#') >= 0 && value.indexOf('#'));
+  const protocolIndex = value.indexOf('lbry://') === 0 ? protocol.length - 1 : 0;
+  const channelModifierIndex =
+    (value.indexOf(':', protocolIndex) >= 0 && value.indexOf(':', protocolIndex)) ||
+    (value.indexOf('#', protocolIndex) >= 0 && value.indexOf('#', protocolIndex));
+  const claimModifierIndex =
+    (value.indexOf(':', channelModifierIndex + 1) >= 0 && value.indexOf(':', channelModifierIndex + 1)) ||
+    (value.indexOf('#', channelModifierIndex + 1) >= 0 && value.indexOf('#', channelModifierIndex + 1)) ||
+    channelModifierIndex;
 
   let punctuationIndex;
   punctuationMarks.some((p) => {
-    if (modifierIndex) {
-      punctuationIndex = value.indexOf(p, modifierIndex + 1) >= 0 && value.indexOf(p, modifierIndex + 1);
+    if (claimModifierIndex) {
+      punctuationIndex = value.indexOf(p, claimModifierIndex + 1) >= 0 && value.indexOf(p, claimModifierIndex + 1);
     }
     return punctuationIndex;
   });

--- a/ui/util/remark-timestamp.js
+++ b/ui/util/remark-timestamp.js
@@ -108,9 +108,9 @@ function tokenizeTimestamp(eat, value, silent) {
 }
 
 tokenizeTimestamp.locator = locateTimestamp;
-tokenizeTimestamp.notInList = true; // Flag doesn't work? It'll always tokenizes in List and never in Bullet.
+tokenizeTimestamp.notInList = false; // Flag doesn't work? It'll always tokenizes in List and never in Bullet.
 tokenizeTimestamp.notInLink = true;
-tokenizeTimestamp.notInBlock = true;
+tokenizeTimestamp.notInBlock = false;
 
 export function inlineTimestamp() {
   const Parser = this.Parser;

--- a/web/scss/themes/odysee/init/_gui.scss
+++ b/web/scss/themes/odysee/init/_gui.scss
@@ -60,12 +60,8 @@ ol {
     position: relative;
     list-style-position: outside;
     margin: var(--spacing-xs) 0;
-    margin-left: var(--spacing-s);
     margin-bottom: 0;
-
-    @media (min-width: $breakpoint-small) {
-      margin-left: var(--spacing-xl);
-    }
+    margin-left: var(--spacing-xl);
   }
 }
 


### PR DESCRIPTION
## Fixes

Issues: https://github.com/lbryio/lbry-desktop/issues/5560, https://github.com/lbryio/lbry-desktop/issues/5560, https://github.com/lbryio/lbry-desktop/issues/5561

Continuing from https://github.com/lbryio/lbry-desktop/pull/7193

embeds that require channel stake weren't resized properly:
[![image.png](https://i.postimg.cc/zfP6yPQt/image.png)](https://postimg.cc/KKBJVQxB) [![image.png](https://i.postimg.cc/6pJPRvYK/image.png)](https://postimg.cc/hfsMRhkZ)

fixed overflow on embed on super-chat causing scroll issues:
![image](https://user-images.githubusercontent.com/76502841/136565493-26194302-dcad-425b-a270-10a21872667f.png)

removed "copy comment link" from livestream comments:
[![image.png](https://i.postimg.cc/HWPwf1yP/image.png)](https://postimg.cc/8sMf63wh)

multiple quotes will show once and won't break live chat: 
[![image.png](https://i.postimg.cc/hPxtBNj0/image.png)](https://postimg.cc/svjrP65B) [![image.png](https://i.postimg.cc/mD60zZdF/image.png)](https://postimg.cc/CBkv90pF)

mentions and timestamps parsed in lists:
![image](https://user-images.githubusercontent.com/76502841/136962779-5711cbeb-4378-41d2-869e-a22fdf0c218b.png)

- Menu on live comments show on hover for desktop view
- Fixed mention parsing (https://github.com/lbryio/lbry-desktop/pull/7193#discussion_r726251745)

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
