### PR TITLE
Fix 'setting.Get' runaway calls

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -407,7 +407,7 @@ export function CommentCreate(props: Props) {
     if (!channelSettings && channelId) {
       doFetchCreatorSettings(channelId);
     }
-  }, [channelId, channelSettings, doFetchCreatorSettings]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Notifications: Fetch top-level comments to identify if it has been deleted and can reply to it
   React.useEffect(() => {


### PR DESCRIPTION
## Issue
Closes [#60 setting.Get calls spiked since October](https://github.com/OdyseeTeam/odysee-frontend/issues/60)

It was called 24 times per livestream page load.

## Notes
The effect was intended to be a one-time effect (blank array), but the dependency was changed in 2f4dedfb

In the small chance that `channelId` isn't available by first mount, it doesn't really matter since we fetch `setting.Get` again (to update the limits) before finalizing a tip -- I didn't want to add a "hasFetched" variable for something that is already a "best-effort/not-perfect" approach anyway (e.g. small chance that creator changed the settings after our fetch).  

Eventually, this effect will be removed when commentron provides the info via websocket.