### PR TITLE
Improve aesthetics for deleted channel names.

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2179,6 +2179,8 @@
   "Card Last 4": "Card Last 4",
   "Search blocked channel name": "Search blocked channel name",
   "Discuss": "Discuss",
+  "Validating...": "Validating...",
+  "[Removed]": "[Removed]",
   "lbry.tv has been retired. You have been magically transported to Odysee.com. %more%": "lbry.tv has been retired. You have been magically transported to Odysee.com. %more%",
   "Show more livestreams": "Show more livestreams",
   "Creator": "Creator",

--- a/ui/component/uriIndicator/view.jsx
+++ b/ui/component/uriIndicator/view.jsx
@@ -53,7 +53,11 @@ class UriIndicator extends React.PureComponent<Props> {
     } = this.props;
 
     if (!claim) {
-      return <span className="empty">{isResolvingUri ? 'Validating...' : 'Unused'}</span>;
+      return (
+        <span className={classnames('empty', className)}>
+          {isResolvingUri || claim === undefined ? __('Validating...') : __('[Removed]')}
+        </span>
+      );
     }
 
     const isChannelClaim = claim.value_type === 'channel';


### PR DESCRIPTION
## Issue
- Comments: no spacing between the strings.
- "Unused" is not intuitive.

## Changes
- Use "[Removed]" instead.
- Localization.
