### PR TITLE
Fix sidebar appearing on livestreams

### DIFF
--- a/ui/component/page/view.jsx
+++ b/ui/component/page/view.jsx
@@ -72,7 +72,7 @@ function Page(props: Props) {
   try {
     const url = pathname.slice(1).replace(/:/g, '#');
     const { isChannel } = parseURI(url);
-    if (!isChannel) {
+    if (!isChannel || livestream) {
       isOnFilePage = true;
     }
   } catch (e) {}


### PR DESCRIPTION
## Ticket
Closes [#75 Stream video is overtaking chat due to sidebar](https://github.com/OdyseeTeam/odysee-frontend/issues/75)

## Issue
- https://odysee.com/@TurdFlingingMonkey#1/TFMShowLIVEOdyseeStream:7
- https://odysee.com/@TurdFlingingMonkey:1/TFMShowLIVEOdyseeStream:7

`pathname` is incorrect for the first one

## Fix
Since we have a `livestream` flag, use that to correct the logic. This is the more localized fix that requires minimal testing.