### PR TITLE
Fix linked-comment scrolling (again)

### DIFF
--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -117,6 +117,7 @@ function Comment(props: Props) {
     location: { pathname, search },
   } = useHistory();
 
+  const isLinkedComment = linkedCommentId && linkedCommentId === commentId;
   const isInLinkedCommentChain =
     linkedCommentId &&
     linkedCommentAncestors[linkedCommentId] &&
@@ -205,6 +206,18 @@ function Comment(props: Props) {
     replace(`${pathname}?${urlParams.toString()}`);
   }
 
+  const linkedCommentRef = React.useCallback((node) => {
+    if (node !== null && window.pendingLinkedCommentScroll) {
+      const ROUGH_HEADER_HEIGHT = 125; // @see: --header-height
+      delete window.pendingLinkedCommentScroll;
+      window.scrollTo({
+        top: node.getBoundingClientRect().top + window.scrollY - ROUGH_HEADER_HEIGHT,
+        left: 0,
+        behavior: 'smooth',
+      });
+    }
+  }, []);
+
   return (
     <li
       className={classnames('comment', {
@@ -215,8 +228,9 @@ function Comment(props: Props) {
       id={commentId}
     >
       <div
+        ref={isLinkedComment ? linkedCommentRef : undefined}
         className={classnames('comment__content', {
-          [COMMENT_HIGHLIGHTED]: linkedCommentId && linkedCommentId === commentId,
+          [COMMENT_HIGHLIGHTED]: isLinkedComment,
           'comment--slimed': slimedToDeath && !displayDeadComment,
         })}
       >


### PR DESCRIPTION
## Issue
Now that we batch-resolve the comment authors before displaying the comments, the linked-comment scrolling logic didn't work well with nested replies.

## Change
Previously, I didn't want to put the logic at the lowest level (`Comment`) because it was hard for the child to know whether to scroll or not. For example, we don't want to scroll when user changes the comment filters or presses the Refresh Comments button.

Relented and moved the logic to `Comment`, and pass a flag via `window` to indicate whether a scrolling is needed (I know this is frowned upon by some, but it's the cleanest solution I can think of for a non-critical action).

This is now more efficient overall as we don't need to scan the DOM, and scrolls with minimal delay.

## Known issues
In markdown posts with lots of images, a layout shift due to delayed inline-image fetching can cause the scrolling to be inaccurate. This should be fixed by reserving space for markdown post images (which I thought was done, but seems like layout shifts are still happening).