### PR TITLE
Update 'yarn analyze' to do Web instead of Desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "./dist/electron/main.js",
   "scripts": {
-    "analyze": "source-map-explorer --only-mapped dist/electron/webpack/ui*.js --html dist/sourceMap.html",
+    "analyze": "yarn compile && source-map-explorer --no-border-checks web/dist/public/ui*.js --html _analyzeResults.html",
     "compile:electron": "node --max_old_space_size=4096 ./node_modules/webpack/bin/webpack.js --config webpack.electron.config.js",
     "compile:web": "yarn copyenv && cd web && node --max_old_space_size=4096 ./node_modules/webpack/bin/webpack.js --config webpack.config.js",
     "compile": "cross-env NODE_ENV=production yarn compile:electron && cross-env NODE_ENV=production yarn compile:web",


### PR DESCRIPTION
Since it might not be obvious to the user that we need a production build, added `yarn compile` to the step directly.
