### PR TITLE
Theatre mode sidebars background color

### DIFF
--- a/ui/scss/component/_videojs.scss
+++ b/ui/scss/component/_videojs.scss
@@ -1,6 +1,7 @@
 .video-js {
   font-size: 12px;
   overflow: hidden;
+  background-color: var(--color-card-background);
 
   // Control Bar (container)
   .vjs-control-bar {


### PR DESCRIPTION
## Fixes

Issue Number: [#6184](https://github.com/lbryio/lbry-desktop/issues/6184)

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
Theatre mode sidebars are currently black.

## What is the new behavior?
Changes the theatre mode sidebar colors to Odysee theme.

![Screenshot_1202](https://user-images.githubusercontent.com/19220996/137913957-260ac290-8653-4cb1-8eeb-963f1b979d1b.jpg)


## Other information

I am unable to change the "square edge" into "rounded edge".

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
