### PR TITLE
Upgrade codemirror + module sharing

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4593,14 +4593,10 @@ codemirror-spell-checker@1.1.2:
   dependencies:
     typo-js "*"
 
-codemirror@^5.39.2:
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.52.0.tgz#4dbd6aef7f0e63db826b9a23922f0c03ac75c0a7"
-
-codemirror@^5.58.2:
-  version "5.59.2"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.59.2.tgz#ee674d3a4a8d241af38d52afc482625ba7393922"
-  integrity sha512-/D5PcsKyzthtSy2NNKCyJi3b+htRkoKv3idswR/tR6UAvMNKA7SrmyZy6fOONJxSRs1JlUWEDAbxqfdArbK8iA==
+codemirror@^5.39.2, codemirror@^5.58.2:
+  version "5.63.3"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.63.3.tgz#97042a242027fe0c87c09b36bc01931d37b76527"
+  integrity sha512-1C+LELr+5grgJYqwZKqxrcbPsHFHapVaVAloBsFBASbpLnQqLw1U8yXJ3gT5D+rhxIiSpo+kTqN+hQ+9ialIXw==
 
 collapse-white-space@^1.0.2:
   version "1.0.6"


### PR DESCRIPTION
## Issue
Our `<CodeViewer>` and `react-simplemde-editor` uses `codemirror`, and they were each bundling a different version.

## Change
Re-generate yarn.lock for `codemirror`. Since we are upgrading anyway, upgraded to the latest and greatest.

## Test
- [x] Markdown editor -- looks ok. It inherited several fixes for code-blocks.
- [x] Code viewer -- looks ok.