### PR TITLE
Defer blocklists slightly to not block `me`

### DIFF
--- a/ui/index.jsx
+++ b/ui/index.jsx
@@ -262,14 +262,16 @@ function AppWrapper() {
 
   useEffect(() => {
     if (readyToLaunch && persistDone) {
-      if (DEFAULT_LANGUAGE) {
-        app.store.dispatch(doFetchLanguage(DEFAULT_LANGUAGE));
-      }
-
-      app.store.dispatch(doUpdateIsNightAsync());
       app.store.dispatch(doDaemonReady());
-      app.store.dispatch(doBlackListedOutpointsSubscribe());
-      app.store.dispatch(doFilteredOutpointsSubscribe());
+
+      setTimeout(() => {
+        if (DEFAULT_LANGUAGE) {
+          app.store.dispatch(doFetchLanguage(DEFAULT_LANGUAGE));
+        }
+        app.store.dispatch(doUpdateIsNightAsync());
+        app.store.dispatch(doBlackListedOutpointsSubscribe());
+        app.store.dispatch(doFilteredOutpointsSubscribe());
+      }, 25);
 
       analytics.startupEvent(Date.now());
     }


### PR DESCRIPTION
Now, with the exception of connecting to lbry.com (`me`) right after re-opening the browser (i.e. establishing first connection), refreshing Odysee is almost instantaneous.

We are now just dependent on the first `claim_search` and thumbnails to fill up the tile placeholders.

## Future
Is there a way to speed up the initial connection?

<img src="https://user-images.githubusercontent.com/64950861/138431395-4bf8ad97-9d91-4553-989f-bd731a6c980e.png" width="400">
