### PR TITLE
Don't memoize selectors without transformation

### DIFF
--- a/extras/lbryinc/redux/selectors/auth.js
+++ b/extras/lbryinc/redux/selectors/auth.js
@@ -1,7 +1,4 @@
-import { createSelector } from 'reselect';
+const selectState = (state) => state.auth || {};
 
-const selectState = state => state.auth || {};
-
-export const selectAuthToken = createSelector(selectState, state => state.authToken);
-
-export const selectIsAuthenticating = createSelector(selectState, state => state.authenticating);
+export const selectAuthToken = (state) => selectState(state).authToken;
+export const selectIsAuthenticating = (state) => selectState(state).authenticating;

--- a/extras/lbryinc/redux/selectors/blacklist.js
+++ b/extras/lbryinc/redux/selectors/blacklist.js
@@ -1,20 +1,15 @@
 import { createSelector } from 'reselect';
 
-export const selectState = state => state.blacklist || {};
+export const selectState = (state) => state.blacklist || {};
 
-export const selectBlackListedOutpoints = createSelector(
-  selectState,
-  state => state.blackListedOutpoints
-);
+export const selectBlackListedOutpoints = (state) => selectState(state).blackListedOutpoints;
 
-export const selectBlacklistedOutpointMap = createSelector(
-  selectBlackListedOutpoints,
-  outpoints =>
-    outpoints
-      ? outpoints.reduce((acc, val) => {
-          const outpoint = `${val.txid}:${val.nout}`;
-          acc[outpoint] = 1;
-          return acc;
-        }, {})
-      : {}
+export const selectBlacklistedOutpointMap = createSelector(selectBlackListedOutpoints, (outpoints) =>
+  outpoints
+    ? outpoints.reduce((acc, val) => {
+        const outpoint = `${val.txid}:${val.nout}`;
+        acc[outpoint] = 1;
+        return acc;
+      }, {})
+    : {}
 );

--- a/extras/lbryinc/redux/selectors/filtered.js
+++ b/extras/lbryinc/redux/selectors/filtered.js
@@ -1,20 +1,15 @@
 import { createSelector } from 'reselect';
 
-export const selectState = state => state.filtered || {};
+export const selectState = (state) => state.filtered || {};
 
-export const selectFilteredOutpoints = createSelector(
-  selectState,
-  state => state.filteredOutpoints
-);
+export const selectFilteredOutpoints = (state) => selectState(state).filteredOutpoints;
 
-export const selectFilteredOutpointMap = createSelector(
-  selectFilteredOutpoints,
-  outpoints =>
-    outpoints
-      ? outpoints.reduce((acc, val) => {
-          const outpoint = `${val.txid}:${val.nout}`;
-          acc[outpoint] = 1;
-          return acc;
-        }, {})
-      : {}
+export const selectFilteredOutpointMap = createSelector(selectFilteredOutpoints, (outpoints) =>
+  outpoints
+    ? outpoints.reduce((acc, val) => {
+        const outpoint = `${val.txid}:${val.nout}`;
+        acc[outpoint] = 1;
+        return acc;
+      }, {})
+    : {}
 );

--- a/extras/lbryinc/redux/selectors/homepage.js
+++ b/extras/lbryinc/redux/selectors/homepage.js
@@ -1,17 +1,6 @@
-import { createSelector } from 'reselect';
+const selectState = (state) => state.homepage || {};
 
-const selectState = state => state.homepage || {};
-
-export const selectFeaturedUris = createSelector(selectState, state => state.featuredUris);
-
-export const selectFetchingFeaturedUris = createSelector(
-  selectState,
-  state => state.fetchingFeaturedContent
-);
-
-export const selectTrendingUris = createSelector(selectState, state => state.trendingUris);
-
-export const selectFetchingTrendingUris = createSelector(
-  selectState,
-  state => state.fetchingTrendingContent
-);
+export const selectFeaturedUris = (state) => selectState(state).featuredUris;
+export const selectFetchingFeaturedUris = (state) => selectState(state).fetchingFeaturedContent;
+export const selectTrendingUris = (state) => selectState(state).trendingUris;
+export const selectFetchingTrendingUris = (state) => selectState(state).fetchingTrendingContent;

--- a/extras/lbryinc/redux/selectors/sync.js
+++ b/extras/lbryinc/redux/selectors/sync.js
@@ -1,40 +1,13 @@
-import { createSelector } from 'reselect';
+const selectState = (state) => state.sync || {};
 
-const selectState = state => state.sync || {};
-
-export const selectHasSyncedWallet = createSelector(selectState, state => state.hasSyncedWallet);
-
-export const selectSyncHash = createSelector(selectState, state => state.syncHash);
-
-export const selectSyncData = createSelector(selectState, state => state.syncData);
-
-export const selectSetSyncErrorMessage = createSelector(
-  selectState,
-  state => state.setSyncErrorMessage
-);
-
-export const selectGetSyncErrorMessage = createSelector(
-  selectState,
-  state => state.getSyncErrorMessage
-);
-
-export const selectGetSyncIsPending = createSelector(selectState, state => state.getSyncIsPending);
-
-export const selectSetSyncIsPending = createSelector(selectState, state => state.setSyncIsPending);
-
-export const selectHashChanged = createSelector(selectState, state => state.hashChanged);
-
-export const selectSyncApplyIsPending = createSelector(
-  selectState,
-  state => state.syncApplyIsPending
-);
-
-export const selectSyncApplyErrorMessage = createSelector(
-  selectState,
-  state => state.syncApplyErrorMessage
-);
-
-export const selectSyncApplyPasswordError = createSelector(
-  selectState,
-  state => state.syncApplyPasswordError
-);
+export const selectHasSyncedWallet = (state) => selectState(state).hasSyncedWallet;
+export const selectSyncHash = (state) => selectState(state).syncHash;
+export const selectSyncData = (state) => selectState(state).syncData;
+export const selectSetSyncErrorMessage = (state) => selectState(state).setSyncErrorMessage;
+export const selectGetSyncErrorMessage = (state) => selectState(state).getSyncErrorMessage;
+export const selectGetSyncIsPending = (state) => selectState(state).getSyncIsPending;
+export const selectSetSyncIsPending = (state) => selectState(state).setSyncIsPending;
+export const selectHashChanged = (state) => selectState(state).hashChanged;
+export const selectSyncApplyIsPending = (state) => selectState(state).syncApplyIsPending;
+export const selectSyncApplyErrorMessage = (state) => selectState(state).syncApplyErrorMessage;
+export const selectSyncApplyPasswordError = (state) => selectState(state).syncApplyPasswordError;

--- a/extras/lbryinc/redux/selectors/web.js
+++ b/extras/lbryinc/redux/selectors/web.js
@@ -1,10 +1,10 @@
 import { createSelector } from 'reselect';
 
-const selectState = state => state.web || {};
+const selectState = (state) => state.web || {};
 
-export const selectCurrentUploads = createSelector(selectState, state => state.currentUploads);
+export const selectCurrentUploads = (state) => selectState(state).currentUploads;
 
 export const selectUploadCount = createSelector(
   selectCurrentUploads,
-  currentUploads => currentUploads && Object.keys(currentUploads).length
+  (currentUploads) => currentUploads && Object.keys(currentUploads).length
 );

--- a/ui/redux/actions/file.js
+++ b/ui/redux/actions/file.js
@@ -22,7 +22,7 @@ import {
 } from 'redux/selectors/file_info';
 
 type Dispatch = (action: any) => any;
-type GetState = () => { file: FileState };
+type GetState = () => { file: FileState, content: any };
 export function doOpenFileInFolder(path: string) {
   return () => {
     shell.showItemInFolder(path);

--- a/ui/redux/selectors/app.js
+++ b/ui/redux/selectors/app.js
@@ -3,7 +3,7 @@ import { selectClaimsById, selectMyChannelClaims, makeSelectStakedLevelForChanne
 
 export const selectState = (state) => state.app || {};
 
-export const selectPlatform = createSelector(selectState, (state) => state.platform);
+export const selectPlatform = (state) => selectState(state).platform;
 
 export const selectUpdateUrl = createSelector(selectPlatform, (platform) => {
   switch (platform) {
@@ -18,11 +18,9 @@ export const selectUpdateUrl = createSelector(selectPlatform, (platform) => {
   }
 });
 
-export const selectHasClickedComment = createSelector(selectState, (state) => state.hasClickedComment);
-
-export const selectRemoteVersion = createSelector(selectState, (state) => state.remoteVersion);
-
-export const selectIsUpgradeAvailable = createSelector(selectState, (state) => state.isUpgradeAvailable);
+export const selectHasClickedComment = (state) => selectState(state).hasClickedComment;
+export const selectRemoteVersion = (state) => selectState(state).remoteVersion;
+export const selectIsUpgradeAvailable = (state) => selectState(state).isUpgradeAvailable;
 
 export const selectUpgradeFilename = createSelector(selectPlatform, selectRemoteVersion, (platform, version) => {
   switch (platform) {
@@ -37,27 +35,17 @@ export const selectUpgradeFilename = createSelector(selectPlatform, selectRemote
   }
 });
 
-export const selectDownloadProgress = createSelector(selectState, (state) => state.downloadProgress);
-
-export const selectDownloadComplete = createSelector(selectState, (state) => state.upgradeDownloadCompleted);
-
-export const selectIsUpgradeSkipped = createSelector(selectState, (state) => state.isUpgradeSkipped);
-
-export const selectUpgradeDownloadPath = createSelector(selectState, (state) => state.downloadPath);
-
-export const selectUpgradeDownloadItem = createSelector(selectState, (state) => state.downloadItem);
-
-export const selectAutoUpdateDownloaded = createSelector(selectState, (state) => state.autoUpdateDownloaded);
-
-export const selectAutoUpdateDeclined = createSelector(selectState, (state) => state.autoUpdateDeclined);
-
-export const selectDaemonVersionMatched = createSelector(selectState, (state) => state.daemonVersionMatched);
-
-export const selectVolume = createSelector(selectState, (state) => state.volume);
-
-export const selectMute = createSelector(selectState, (state) => state.muted);
-
-export const selectUpgradeTimer = createSelector(selectState, (state) => state.checkUpgradeTimer);
+export const selectDownloadProgress = (state) => selectState(state).downloadProgress;
+export const selectDownloadComplete = (state) => selectState(state).upgradeDownloadCompleted;
+export const selectIsUpgradeSkipped = (state) => selectState(state).isUpgradeSkipped;
+export const selectUpgradeDownloadPath = (state) => selectState(state).downloadPath;
+export const selectUpgradeDownloadItem = (state) => selectState(state).downloadItem;
+export const selectAutoUpdateDownloaded = (state) => selectState(state).autoUpdateDownloaded;
+export const selectAutoUpdateDeclined = (state) => selectState(state).autoUpdateDeclined;
+export const selectDaemonVersionMatched = (state) => selectState(state).daemonVersionMatched;
+export const selectVolume = (state) => selectState(state).volume;
+export const selectMute = (state) => selectState(state).muted;
+export const selectUpgradeTimer = (state) => selectState(state).checkUpgradeTimer;
 
 export const selectModal = createSelector(selectState, (state) => {
   if (!state.modal) {
@@ -70,23 +58,15 @@ export const selectModal = createSelector(selectState, (state) => {
   };
 });
 
-export const selectSearchOptionsExpanded = createSelector(selectState, (state) => state.searchOptionsExpanded);
-
-export const selectWelcomeVersion = createSelector(selectState, (state) => state.welcomeVersion);
-
-export const selectHasNavigated = createSelector(selectState, (state) => state.hasNavigated);
-
-export const selectAllowAnalytics = createSelector(selectState, (state) => state.allowAnalytics);
-
-export const selectScrollStartingPosition = createSelector(selectState, (state) => state.currentScroll);
-
-export const selectIsPasswordSaved = createSelector(selectState, (state) => state.isPasswordSaved);
-
-export const selectInterestedInYoutubeSync = createSelector(selectState, (state) => state.interestedInYoutubeSync);
-
-export const selectSplashAnimationEnabled = createSelector(selectState, (state) => state.splashAnimationEnabled);
-
-export const selectActiveChannelId = createSelector(selectState, (state) => state.activeChannel);
+export const selectSearchOptionsExpanded = (state) => selectState(state).searchOptionsExpanded;
+export const selectWelcomeVersion = (state) => selectState(state).welcomeVersion;
+export const selectHasNavigated = (state) => selectState(state).hasNavigated;
+export const selectAllowAnalytics = (state) => selectState(state).allowAnalytics;
+export const selectScrollStartingPosition = (state) => selectState(state).currentScroll;
+export const selectIsPasswordSaved = (state) => selectState(state).isPasswordSaved;
+export const selectInterestedInYoutubeSync = (state) => selectState(state).interestedInYoutubeSync;
+export const selectSplashAnimationEnabled = (state) => selectState(state).splashAnimationEnabled;
+export const selectActiveChannelId = (state) => selectState(state).activeChannel;
 
 export const selectActiveChannelClaim = createSelector(
   selectActiveChannelId,
@@ -128,9 +108,8 @@ export const selectActiveChannelStakedLevel = createSelector(
 
     const uri = activeChannelClaim.permanent_url;
     const stakedLevel = makeSelectStakedLevelForChannelUri(uri)(state);
-
     return stakedLevel;
   }
 );
 
-export const selectIncognito = createSelector(selectState, (state) => state.incognito);
+export const selectIncognito = (state) => selectState(state).incognito;

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -8,7 +8,7 @@ import * as CLAIM from 'constants/claim';
 
 type State = { claims: any };
 
-const selectState = (state) => state.claims || {};
+const selectState = (state: State) => state.claims || {};
 
 export const selectById = (state: State) => selectState(state).byId || {};
 export const selectPendingClaimsById = (state: State) => selectState(state).pendingById || {};
@@ -18,16 +18,11 @@ export const selectClaimsById = createSelector(selectById, selectPendingClaimsBy
 });
 
 export const selectClaimIdsByUri = (state: State) => selectState(state).claimsByUri || {};
-
-export const selectCurrentChannelPage = createSelector(selectState, (state) => state.currentChannelPage || 1);
-
-export const selectCreatingChannel = createSelector(selectState, (state) => state.creatingChannel);
-
-export const selectCreateChannelError = createSelector(selectState, (state) => state.createChannelError);
-
-export const selectRepostLoading = createSelector(selectState, (state) => state.repostLoading);
-
-export const selectRepostError = createSelector(selectState, (state) => state.repostError);
+export const selectCurrentChannelPage = (state: State) => selectState(state).currentChannelPage || 1;
+export const selectCreatingChannel = (state: State) => selectState(state).creatingChannel;
+export const selectCreateChannelError = (state: State) => selectState(state).createChannelError;
+export const selectRepostLoading = (state: State) => selectState(state).repostLoading;
+export const selectRepostError = (state: State) => selectState(state).repostError;
 
 export const selectClaimsByUri = createSelector(selectClaimIdsByUri, selectClaimsById, (byUri, byId) => {
   const claims = {};
@@ -72,7 +67,7 @@ export const makeSelectClaimIdIsPending = (claimId: string) =>
 export const makeSelectClaimIdForUri = (uri: string) =>
   createSelector(selectClaimIdsByUri, (claimIds) => claimIds[uri]);
 
-export const selectReflectingById = createSelector(selectState, (state) => state.reflectingById);
+export const selectReflectingById = (state: State) => selectState(state).reflectingById;
 
 export const makeSelectClaimForClaimId = (claimId: string) => createSelector(selectClaimsById, (byId) => byId[claimId]);
 
@@ -201,15 +196,11 @@ export const makeSelectClaimIsMine = (rawUri: string) => {
   });
 };
 
-export const selectMyPurchases = createSelector(selectState, (state) => state.myPurchases);
-
-export const selectPurchaseUriSuccess = createSelector(selectState, (state) => state.purchaseUriSuccess);
-
-export const selectMyPurchasesCount = createSelector(selectState, (state) => state.myPurchasesPageTotalResults);
-
-export const selectIsFetchingMyPurchases = createSelector(selectState, (state) => state.fetchingMyPurchases);
-
-export const selectFetchingMyPurchasesError = createSelector(selectState, (state) => state.fetchingMyPurchasesError);
+export const selectMyPurchases = (state: State) => selectState(state).myPurchases;
+export const selectPurchaseUriSuccess = (state: State) => selectState(state).purchaseUriSuccess;
+export const selectMyPurchasesCount = (state: State) => selectState(state).myPurchasesPageTotalResults;
+export const selectIsFetchingMyPurchases = (state: State) => selectState(state).fetchingMyPurchases;
+export const selectFetchingMyPurchasesError = (state: State) => selectState(state).fetchingMyPurchasesError;
 
 export const makeSelectMyPurchasesForPage = (query: ?string, page: number = 1) =>
   createSelector(
@@ -338,7 +329,7 @@ export const makeSelectCoverForUri = (uri: string) =>
     return cover && cover.url ? cover.url.trim().replace(/^http:\/\//i, 'https://') : undefined;
   });
 
-export const selectIsFetchingClaimListMine = createSelector(selectState, (state) => state.isFetchingClaimListMine);
+export const selectIsFetchingClaimListMine = (state: State) => selectState(state).isFetchingClaimListMine;
 
 export const selectMyClaimsPage = createSelector(selectState, (state) => state.myClaimsPageResults || []);
 
@@ -349,12 +340,8 @@ export const selectMyClaimsPageNumber = createSelector(
   (state) => (state.txoPage && state.txoPage.page) || 1
 );
 
-export const selectMyClaimsPageItemCount = createSelector(selectState, (state) => state.myClaimsPageTotalResults || 1);
-
-export const selectFetchingMyClaimsPageError = createSelector(
-  selectState,
-  (state) => state.fetchingClaimListMinePageError
-);
+export const selectMyClaimsPageItemCount = (state: State) => selectState(state).myClaimsPageTotalResults || 1;
+export const selectFetchingMyClaimsPageError = (state: State) => selectState(state).fetchingClaimListMinePageError;
 
 export const selectMyClaims = createSelector(
   selectMyActiveClaims,
@@ -406,9 +393,8 @@ export const selectMyClaimsOutpoints = createSelector(selectMyClaims, (myClaims)
   return outpoints;
 });
 
-export const selectFetchingMyChannels = createSelector(selectState, (state) => state.fetchingMyChannels);
-
-export const selectFetchingMyCollections = createSelector(selectState, (state) => state.fetchingMyCollections);
+export const selectFetchingMyChannels = (state: State) => selectState(state).fetchingMyChannels;
+export const selectFetchingMyCollections = (state: State) => selectState(state).fetchingMyCollections;
 
 export const selectMyChannelClaims = createSelector(selectState, selectClaimsById, (state, byId) => {
   const ids = state.myChannelClaims;
@@ -431,16 +417,16 @@ export const selectMyChannelUrls = createSelector(selectMyChannelClaims, (claims
   claims ? claims.map((claim) => claim.canonical_url || claim.permanent_url) : undefined
 );
 
-export const selectMyCollectionIds = createSelector(selectState, (state) => state.myCollectionClaims);
+export const selectMyCollectionIds = (state: State) => selectState(state).myCollectionClaims;
 
 export const selectResolvingUris = createSelector(selectState, (state) => state.resolvingUris || []);
 
-export const selectChannelImportPending = createSelector(selectState, (state) => state.pendingChannelImport);
+export const selectChannelImportPending = (state: State) => selectState(state).pendingChannelImport;
 
 export const makeSelectIsUriResolving = (uri: string) =>
   createSelector(selectResolvingUris, (resolvingUris) => resolvingUris && resolvingUris.indexOf(uri) !== -1);
 
-export const selectPlayingUri = createSelector(selectState, (state) => state.playingUri);
+export const selectPlayingUri = (state: State) => selectState(state).playingUri;
 
 export const selectChannelClaimCounts = createSelector(selectState, (state) => state.channelClaimCounts || {});
 
@@ -595,9 +581,8 @@ export const makeSelectSupportsForUri = (uri: string) =>
     return total;
   });
 
-export const selectUpdatingChannel = createSelector(selectState, (state) => state.updatingChannel);
-
-export const selectUpdateChannelError = createSelector(selectState, (state) => state.updateChannelError);
+export const selectUpdatingChannel = (state: State) => selectState(state).updatingChannel;
+export const selectUpdateChannelError = (state: State) => selectState(state).updateChannelError;
 
 export const makeSelectReflectingClaimForUri = (uri: string) =>
   createSelector(selectClaimIdsByUri, selectReflectingById, (claimIdsByUri, reflectingById) => {
@@ -670,10 +655,7 @@ export const makeSelectStakedLevelForChannelUri = (uri: string) =>
     return level;
   });
 
-export const selectUpdatingCollection = createSelector(selectState, (state) => state.updatingCollection);
-
-export const selectUpdateCollectionError = createSelector(selectState, (state) => state.updateCollectionError);
-
-export const selectCreatingCollection = createSelector(selectState, (state) => state.creatingCollection);
-
-export const selectCreateCollectionError = createSelector(selectState, (state) => state.createCollectionError);
+export const selectUpdatingCollection = (state: State) => selectState(state).updatingCollection;
+export const selectUpdateCollectionError = (state: State) => selectState(state).updateCollectionError;
+export const selectCreatingCollection = (state: State) => selectState(state).creatingCollection;
+export const selectCreateCollectionError = (state: State) => selectState(state).createCollectionError;

--- a/ui/redux/selectors/coinSwap.js
+++ b/ui/redux/selectors/coinSwap.js
@@ -1,8 +1,7 @@
 // @flow
-import { createSelector } from 'reselect';
 
-const selectState = (state) => state.coinSwap || {};
+type State = { coinSwap: CoinSwapState };
 
-export const selectCoinSwaps = createSelector(selectState, (state: CoinSwapState) => {
-  return state.coinSwaps;
-});
+const selectState = (state: State) => state.coinSwap || {};
+
+export const selectCoinSwaps = (state: State) => selectState(state).coinSwaps;

--- a/ui/redux/selectors/collections.js
+++ b/ui/redux/selectors/collections.js
@@ -4,18 +4,16 @@ import { createSelector } from 'reselect';
 import { selectMyCollectionIds, makeSelectClaimForUri } from 'redux/selectors/claims';
 import { parseURI } from 'util/lbryURI';
 
-const selectState = (state: { collections: CollectionState }) => state.collections;
+type State = { collections: CollectionState };
 
-export const selectSavedCollectionIds = createSelector(selectState, (collectionState) => collectionState.saved);
+const selectState = (state: State) => state.collections;
 
-export const selectBuiltinCollections = createSelector(selectState, (state) => state.builtin);
-export const selectResolvedCollections = createSelector(selectState, (state) => state.resolved);
-
-export const selectMyUnpublishedCollections = createSelector(selectState, (state) => state.unpublished);
-
-export const selectMyEditedCollections = createSelector(selectState, (state) => state.edited);
-
-export const selectPendingCollections = createSelector(selectState, (state) => state.pending);
+export const selectSavedCollectionIds = (state: State) => selectState(state).saved;
+export const selectBuiltinCollections = (state: State) => selectState(state).builtin;
+export const selectResolvedCollections = (state: State) => selectState(state).resolved;
+export const selectMyUnpublishedCollections = (state: State) => selectState(state).unpublished;
+export const selectMyEditedCollections = (state: State) => selectState(state).edited;
+export const selectPendingCollections = (state: State) => selectState(state).pending;
 
 export const makeSelectEditedCollectionForId = (id: string) =>
   createSelector(selectMyEditedCollections, (eLists) => eLists[id]);

--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -18,13 +18,14 @@ import { FORCE_CONTENT_TYPE_PLAYER, FORCE_CONTENT_TYPE_COMIC } from 'constants/c
 const RECENT_HISTORY_AMOUNT = 10;
 const HISTORY_ITEMS_PER_PAGE = 50;
 
-export const selectState = (state: any) => state.content || {};
+type State = { content: any };
 
-export const selectPlayingUri = createSelector(selectState, (state) => state.playingUri);
-export const selectPrimaryUri = createSelector(selectState, (state) => state.primaryUri);
+export const selectState = (state: State) => state.content || {};
 
-export const selectListLoop = createSelector(selectState, (state) => state.loopList);
-export const selectListShuffle = createSelector(selectState, (state) => state.shuffleList);
+export const selectPlayingUri = (state: State) => selectState(state).playingUri;
+export const selectPrimaryUri = (state: State) => selectState(state).primaryUri;
+export const selectListLoop = (state: State) => selectState(state).loopList;
+export const selectListShuffle = (state: State) => selectState(state).shuffleList;
 
 export const makeSelectIsPlaying = (uri: string) =>
   createSelector(selectPrimaryUri, (primaryUri) => primaryUri === uri);

--- a/ui/redux/selectors/file_info.js
+++ b/ui/redux/selectors/file_info.js
@@ -14,7 +14,7 @@ export const selectState = (state) => state.fileInfo || {};
 
 export const selectFileInfosByOutpoint = createSelector(selectState, (state) => state.byOutpoint || {});
 
-export const selectIsFetchingFileList = createSelector(selectState, (state) => state.isFetchingFileList);
+export const selectIsFetchingFileList = (state) => selectState(state).isFetchingFileList;
 
 export const selectIsFetchingFileListDownloadedOrPublished = createSelector(
   selectIsFetchingFileList,
@@ -94,9 +94,8 @@ export const selectTotalDownloadProgress = createSelector(selectDownloadingFileI
 
 export const selectFileInfoErrors = createSelector(selectState, (state) => state.errors || {});
 
-export const selectFileListPublishedSort = createSelector(selectState, (state) => state.fileListPublishedSort);
-
-export const selectFileListDownloadedSort = createSelector(selectState, (state) => state.fileListDownloadedSort);
+export const selectFileListPublishedSort = (state) => selectState(state).fileListPublishedSort;
+export const selectFileListDownloadedSort = (state) => selectState(state).fileListDownloadedSort;
 
 export const selectDownloadedUris = createSelector(
   selectFileInfosDownloaded,

--- a/ui/redux/selectors/livestream.js
+++ b/ui/redux/selectors/livestream.js
@@ -2,7 +2,9 @@
 import { createSelector } from 'reselect';
 import { selectMyClaims, selectPendingClaims } from 'redux/selectors/claims';
 
-const selectState = (state) => state.livestream || {};
+type State = { livestream: any };
+
+const selectState = (state: State) => state.livestream || {};
 
 // select non-pending claims without sources for given channel
 export const makeSelectLivestreamsForChannelId = (channelId: string) =>
@@ -20,8 +22,8 @@ export const makeSelectLivestreamsForChannelId = (channelId: string) =>
       .sort((a, b) => b.timestamp - a.timestamp); // newest first
   });
 
-export const selectFetchingLivestreams = createSelector(selectState, (state) => state.fetchingById);
-export const selectViewersById = createSelector(selectState, (state) => state.viewersById);
+export const selectFetchingLivestreams = (state: State) => selectState(state).fetchingById;
+export const selectViewersById = (state: State) => selectState(state).viewersById;
 
 export const makeSelectIsFetchingLivestreams = (channelId: string) =>
   createSelector(selectFetchingLivestreams, (fetchingLivestreams) => Boolean(fetchingLivestreams[channelId]));
@@ -41,7 +43,7 @@ export const makeSelectPendingLivestreamsForChannelId = (channelId: string) =>
     );
   });
 
-export const selectActiveLivestreams = createSelector(selectState, (state) => state.activeLivestreams);
+export const selectActiveLivestreams = (state: State) => selectState(state).activeLivestreams;
 
 export const makeSelectIsActiveLivestream = (uri: string) =>
   createSelector(selectState, (state) => {

--- a/ui/redux/selectors/notifications.js
+++ b/ui/redux/selectors/notifications.js
@@ -2,11 +2,9 @@ import { createSelector } from 'reselect';
 
 export const selectState = (state) => state.notifications || {};
 
-export const selectNotifications = createSelector(selectState, (state) => state.notifications);
-
-export const selectNotificationsFiltered = createSelector(selectState, (state) => state.notificationsFiltered);
-
-export const selectNotificationCategories = createSelector(selectState, (state) => state.notificationCategories);
+export const selectNotifications = (state) => selectState(state).notifications;
+export const selectNotificationsFiltered = (state) => selectState(state).notificationsFiltered;
+export const selectNotificationCategories = (state) => selectState(state).notificationCategories;
 
 export const makeSelectNotificationForCommentId = (id) =>
   createSelector(selectNotifications, (notifications) => {
@@ -21,7 +19,7 @@ export const makeSelectNotificationForCommentId = (id) =>
     return match;
   });
 
-export const selectIsFetchingNotifications = createSelector(selectState, (state) => state.fetchingNotifications);
+export const selectIsFetchingNotifications = (state) => selectState(state).fetchingNotifications;
 
 export const selectUnreadNotificationCount = createSelector(selectNotifications, (notifications) => {
   return notifications ? notifications.filter((notification) => !notification.is_read).length : 0;

--- a/ui/redux/selectors/reactions.js
+++ b/ui/redux/selectors/reactions.js
@@ -4,9 +4,8 @@ import { makeSelectClaimForUri } from 'redux/selectors/claims';
 
 const selectState = (state) => state.reactions || {};
 
-export const selectReactionsById = createSelector(selectState, (state) => state.reactionsById);
-
-export const selectFetchingReactions = createSelector(selectState, (state) => state.fetchingReactions);
+export const selectReactionsById = (state) => selectState(state).reactionsById;
+export const selectFetchingReactions = (state) => selectState(state).fetchingReactions;
 
 export const makeSelectReactionsForUri = (uri) =>
   createSelector(makeSelectClaimForUri(uri), selectReactionsById, (claim, reactionsById) => {

--- a/ui/redux/selectors/reportContent.js
+++ b/ui/redux/selectors/reportContent.js
@@ -1,13 +1,6 @@
 // @flow
-import { createSelector } from 'reselect';
-
 type State = { reportContent: ReportContentState };
 
 export const selectState = (state: State): ReportContentState => state.reportContent;
-
-export const selectIsReportingContent: (state: State) => boolean = createSelector(
-  selectState,
-  (state) => state.isReporting
-);
-
-export const selectReportContentError: (state: State) => string = createSelector(selectState, (state) => state.error);
+export const selectIsReportingContent: (state: State) => boolean = (state) => selectState(state).isReporting;
+export const selectReportContentError: (state: State) => string = (state) => selectState(state).error;

--- a/ui/redux/selectors/rewards.js
+++ b/ui/redux/selectors/rewards.js
@@ -3,9 +3,8 @@ import REWARDS from 'rewards';
 
 const selectState = (state) => state.rewards || {};
 
-export const selectUnclaimedRewardsByType = createSelector(selectState, (state) => state.unclaimedRewardsByType);
-
-export const selectClaimedRewardsById = createSelector(selectState, (state) => state.claimedRewardsById);
+export const selectUnclaimedRewardsByType = (state) => selectState(state).unclaimedRewardsByType;
+export const selectClaimedRewardsById = (state) => selectState(state).claimedRewardsById;
 
 export const selectClaimedRewards = createSelector(selectClaimedRewardsById, (byId) => Object.values(byId) || []);
 
@@ -17,22 +16,21 @@ export const selectClaimedRewardsByTransactionId = createSelector(selectClaimedR
   }, {})
 );
 
-export const selectUnclaimedRewards = createSelector(selectState, (state) => state.unclaimedRewards);
-
-export const selectFetchingRewards = createSelector(selectState, (state) => !!state.fetching);
+export const selectUnclaimedRewards = (state) => selectState(state).unclaimedRewards;
+export const selectFetchingRewards = (state) => !!selectState(state).fetching;
 
 export const selectUnclaimedRewardValue = createSelector(selectUnclaimedRewards, (rewards) =>
   rewards.reduce((sum, reward) => sum + reward.reward_amount, 0)
 );
 
-export const selectClaimsPendingByType = createSelector(selectState, (state) => state.claimPendingByType);
+export const selectClaimsPendingByType = (state) => selectState(state).claimPendingByType;
 
 const selectIsClaimRewardPending = (state, props) => selectClaimsPendingByType(state, props)[props.reward_type];
 
 export const makeSelectIsRewardClaimPending = () =>
   createSelector(selectIsClaimRewardPending, (isClaiming) => isClaiming);
 
-export const selectClaimErrorsByType = createSelector(selectState, (state) => state.claimErrorsByType);
+export const selectClaimErrorsByType = (state) => selectState(state).claimErrorsByType;
 
 const selectClaimRewardError = (state, props) => selectClaimErrorsByType(state, props)[props.reward_type];
 

--- a/ui/redux/selectors/search.js
+++ b/ui/redux/selectors/search.js
@@ -23,24 +23,14 @@ type State = { search: SearchState };
 
 export const selectState = (state: State): SearchState => state.search;
 
-export const selectSearchValue: (state: State) => string = createSelector(selectState, (state) => state.searchQuery);
-
-export const selectSearchOptions: (state: State) => SearchOptions = createSelector(
-  selectState,
-  (state) => state.options
-);
-
-export const selectIsSearching: (state: State) => boolean = createSelector(selectState, (state) => state.searching);
-
-export const selectSearchResultByQuery: (state: State) => { [string]: Array<string> } = createSelector(
-  selectState,
-  (state) => state.resultsByQuery
-);
-
-export const selectHasReachedMaxResultsLength: (state: State) => { [boolean]: Array<boolean> } = createSelector(
-  selectState,
-  (state) => state.hasReachedMaxResultsLength
-);
+// $FlowFixMe - 'searchQuery' is never populated. Something lost in a merge?
+export const selectSearchValue: (state: State) => string = (state) => selectState(state).searchQuery;
+export const selectSearchOptions: (state: State) => SearchOptions = (state) => selectState(state).options;
+export const selectIsSearching: (state: State) => boolean = (state) => selectState(state).searching;
+export const selectSearchResultByQuery: (state: State) => { [string]: Array<string> } = (state) =>
+  selectState(state).resultsByQuery;
+export const selectHasReachedMaxResultsLength: (state: State) => { [boolean]: Array<boolean> } = (state) =>
+  selectState(state).hasReachedMaxResultsLength;
 
 export const makeSelectSearchUrisForQuery = (query: string): ((state: State) => Array<string>) =>
   createSelector(selectSearchResultByQuery, (byQuery) => {

--- a/ui/redux/selectors/settings.js
+++ b/ui/redux/selectors/settings.js
@@ -8,17 +8,12 @@ const homepages = require('homepages');
 
 const selectState = (state) => state.settings || {};
 
-export const selectDaemonSettings = createSelector(selectState, (state) => state.daemonSettings);
-
-export const selectDaemonStatus = createSelector(selectState, (state) => state.daemonStatus);
-
+export const selectDaemonSettings = (state) => selectState(state).daemonSettings;
+export const selectDaemonStatus = (state) => selectState(state).daemonStatus;
 export const selectFfmpegStatus = createSelector(selectDaemonStatus, (status) => status.ffmpeg_status);
-
-export const selectFindingFFmpeg = createSelector(selectState, (state) => state.findingFFmpeg || false);
-
-export const selectClientSettings = createSelector(selectState, (state) => state.clientSettings || {});
-
-export const selectLoadedLanguages = createSelector(selectState, (state) => state.loadedLanguages || {});
+export const selectFindingFFmpeg = (state) => selectState(state).findingFFmpeg || false;
+export const selectClientSettings = (state) => selectState(state).clientSettings || {};
+export const selectLoadedLanguages = (state) => selectState(state).loadedLanguages || {};
 
 export const makeSelectClientSetting = (setting) =>
   createSelector(selectClientSettings, (settings) => (settings ? settings[setting] : undefined));
@@ -33,11 +28,9 @@ export const selectShowRepostedContent = makeSelectClientSetting(SETTINGS.HIDE_R
 
 export const selectTheme = makeSelectClientSetting(SETTINGS.THEME);
 export const selectAutomaticDarkModeEnabled = makeSelectClientSetting(SETTINGS.AUTOMATIC_DARK_MODE_ENABLED);
-export const selectIsNight = createSelector(selectState, (state) => state.isNight);
-
-export const selectSavedWalletServers = createSelector(selectState, (state) => state.customWalletServers);
-
-export const selectSharedPreferences = createSelector(selectState, (state) => state.sharedPreferences);
+export const selectIsNight = (state) => selectState(state).isNight;
+export const selectSavedWalletServers = (state) => selectState(state).customWalletServers;
+export const selectSharedPreferences = (state) => selectState(state).sharedPreferences;
 
 export const makeSelectSharedPreferencesForKey = (key) =>
   createSelector(selectSharedPreferences, (prefs) => (prefs ? prefs[key] : undefined));

--- a/ui/redux/selectors/subscriptions.js
+++ b/ui/redux/selectors/subscriptions.js
@@ -20,14 +20,14 @@ export const selectSubscriptions = createSelector(
 export const selectFollowing = createSelector(selectState, (state) => state.following && state.following);
 
 // Fetching list of users subscriptions
-export const selectIsFetchingSubscriptions = createSelector(selectState, (state) => state.loading);
+export const selectIsFetchingSubscriptions = (state) => selectState(state).loading;
 
 // The current view mode on the subscriptions page
-export const selectViewMode = createSelector(selectState, (state) => state.viewMode);
+export const selectViewMode = (state) => selectState(state).viewMode;
 
 // Suggested subscriptions from internal apis
-export const selectSuggested = createSelector(selectState, (state) => state.suggested);
-export const selectIsFetchingSuggested = createSelector(selectState, (state) => state.loadingSuggested);
+export const selectSuggested = (state) => selectState(state).suggested;
+export const selectIsFetchingSuggested = (state) => selectState(state).loadingSuggested;
 export const selectSuggestedChannels = createSelector(
   selectSubscriptions,
   selectSuggested,
@@ -80,8 +80,8 @@ export const selectSuggestedChannels = createSelector(
   }
 );
 
-export const selectFirstRunCompleted = createSelector(selectState, (state) => state.firstRunCompleted);
-export const selectshowSuggestedSubs = createSelector(selectState, (state) => state.showSuggestedSubs);
+export const selectFirstRunCompleted = (state) => selectState(state).firstRunCompleted;
+export const selectShowSuggestedSubs = (state) => selectState(state).showSuggestedSubs;
 
 // Fetching any claims that are a part of a users subscriptions
 export const selectSubscriptionsBeingFetched = createSelector(

--- a/ui/redux/selectors/sync.js
+++ b/ui/redux/selectors/sync.js
@@ -1,31 +1,16 @@
-import { createSelector } from 'reselect';
+const selectState = (state) => state.sync || {};
 
-const selectState = state => state.sync || {};
-
-export const selectHasSyncedWallet = createSelector(selectState, state => state.hasSyncedWallet);
-
-export const selectSyncHash = createSelector(selectState, state => state.syncHash);
-
-export const selectSyncData = createSelector(selectState, state => state.syncData);
-
-export const selectSetSyncErrorMessage = createSelector(selectState, state => state.setSyncErrorMessage);
-
-export const selectGetSyncErrorMessage = createSelector(selectState, state => state.getSyncErrorMessage);
-
-export const selectGetSyncIsPending = createSelector(selectState, state => state.getSyncIsPending);
-
-export const selectSetSyncIsPending = createSelector(selectState, state => state.setSyncIsPending);
-
-export const selectHashChanged = createSelector(selectState, state => state.hashChanged);
-
-export const selectSyncApplyIsPending = createSelector(selectState, state => state.syncApplyIsPending);
-
-export const selectSyncApplyErrorMessage = createSelector(selectState, state => state.syncApplyErrorMessage);
-
-export const selectSyncApplyPasswordError = createSelector(selectState, state => state.syncApplyPasswordError);
-
-export const selectSyncIsLocked = createSelector(selectState, state => state.syncLocked);
-
-export const selectPrefsReady = createSelector(selectState, state => state.prefsReady);
-
-export const selectSyncFatalError = createSelector(selectState, state => state.fatalError);
+export const selectHasSyncedWallet = (state) => selectState(state).hasSyncedWallet;
+export const selectSyncHash = (state) => selectState(state).syncHash;
+export const selectSyncData = (state) => selectState(state).syncData;
+export const selectSetSyncErrorMessage = (state) => selectState(state).setSyncErrorMessage;
+export const selectGetSyncErrorMessage = (state) => selectState(state).getSyncErrorMessage;
+export const selectGetSyncIsPending = (state) => selectState(state).getSyncIsPending;
+export const selectSetSyncIsPending = (state) => selectState(state).setSyncIsPending;
+export const selectHashChanged = (state) => selectState(state).hashChanged;
+export const selectSyncApplyIsPending = (state) => selectState(state).syncApplyIsPending;
+export const selectSyncApplyErrorMessage = (state) => selectState(state).syncApplyErrorMessage;
+export const selectSyncApplyPasswordError = (state) => selectState(state).syncApplyPasswordError;
+export const selectSyncIsLocked = (state) => selectState(state).syncLocked;
+export const selectPrefsReady = (state) => selectState(state).prefsReady;
+export const selectSyncFatalError = (state) => selectState(state).fatalError;

--- a/ui/redux/selectors/tags.js
+++ b/ui/redux/selectors/tags.js
@@ -5,8 +5,7 @@ type State = { tags: TagState };
 
 const selectState = (state: State) => state.tags || {};
 
-export const selectKnownTagsByName = createSelector(selectState, (state: TagState): KnownTags => state.knownTags);
-
+export const selectKnownTagsByName = (state: State): KnownTags => selectState(state).knownTags;
 export const selectFollowedTagsList = (state: State) => selectState(state).followedTags;
 
 export const selectFollowedTags = createSelector(selectFollowedTagsList, (followedTags: Array<string>): Array<Tag> =>

--- a/ui/redux/selectors/user.js
+++ b/ui/redux/selectors/user.js
@@ -2,20 +2,12 @@ import { createSelector } from 'reselect';
 
 export const selectState = (state) => state.user || {};
 
-export const selectAuthenticationIsPending = createSelector(selectState, (state) => state.authenticationIsPending);
-
-export const selectUserIsPending = createSelector(selectState, (state) => state.userIsPending);
-
-export const selectUser = createSelector(selectState, (state) => state.user);
-
-export const selectEmailAlreadyExists = createSelector(selectState, (state) => state.emailAlreadyExists);
-
-export const selectEmailDoesNotExist = createSelector(selectState, (state) => state.emailDoesNotExist);
-
-export const selectResendingVerificationEmail = createSelector(
-  selectState,
-  (state) => state.resendingVerificationEmail
-);
+export const selectAuthenticationIsPending = (state) => selectState(state).authenticationIsPending;
+export const selectUserIsPending = (state) => selectState(state).userIsPending;
+export const selectUser = (state) => selectState(state).user;
+export const selectEmailAlreadyExists = (state) => selectState(state).emailAlreadyExists;
+export const selectEmailDoesNotExist = (state) => selectState(state).emailDoesNotExist;
+export const selectResendingVerificationEmail = (state) => selectState(state).resendingVerificationEmail;
 
 export const selectUserEmail = createSelector(selectUser, (user) =>
   user ? user.primary_email || user.latest_claimed_email : null
@@ -41,51 +33,38 @@ export const selectYoutubeChannels = createSelector(selectUser, (user) => (user 
 
 export const selectUserIsRewardApproved = createSelector(selectUser, (user) => user && user.is_reward_approved);
 
-export const selectEmailNewIsPending = createSelector(selectState, (state) => state.emailNewIsPending);
+export const selectEmailNewIsPending = (state) => selectState(state).emailNewIsPending;
 
 export const selectEmailNewErrorMessage = createSelector(selectState, (state) => {
   const error = state.emailNewErrorMessage;
   return typeof error === 'object' && error !== null ? error.message : error;
 });
 
-export const selectPasswordExists = createSelector(selectState, (state) => state.passwordExistsForUser);
-
-export const selectPasswordResetIsPending = createSelector(selectState, (state) => state.passwordResetPending);
-
-export const selectPasswordResetSuccess = createSelector(selectState, (state) => state.passwordResetSuccess);
+export const selectPasswordExists = (state) => selectState(state).passwordExistsForUser;
+export const selectPasswordResetIsPending = (state) => selectState(state).passwordResetPending;
+export const selectPasswordResetSuccess = (state) => selectState(state).passwordResetSuccess;
 
 export const selectPasswordResetError = createSelector(selectState, (state) => {
   const error = state.passwordResetError;
   return typeof error === 'object' && error !== null ? error.message : error;
 });
 
-export const selectPasswordSetIsPending = createSelector(selectState, (state) => state.passwordSetPending);
-
-export const selectPasswordSetSuccess = createSelector(selectState, (state) => state.passwordSetSuccess);
+export const selectPasswordSetIsPending = (state) => selectState(state).passwordSetPending;
+export const selectPasswordSetSuccess = (state) => selectState(state).passwordSetSuccess;
 
 export const selectPasswordSetError = createSelector(selectState, (state) => {
   const error = state.passwordSetError;
   return typeof error === 'object' && error !== null ? error.message : error;
 });
 
-export const selectPhoneNewErrorMessage = createSelector(selectState, (state) => state.phoneNewErrorMessage);
-
-export const selectEmailVerifyIsPending = createSelector(selectState, (state) => state.emailVerifyIsPending);
-
-export const selectEmailVerifyErrorMessage = createSelector(selectState, (state) => state.emailVerifyErrorMessage);
-
-export const selectPhoneNewIsPending = createSelector(selectState, (state) => state.phoneNewIsPending);
-
-export const selectPhoneVerifyIsPending = createSelector(selectState, (state) => state.phoneVerifyIsPending);
-
-export const selectPhoneVerifyErrorMessage = createSelector(selectState, (state) => state.phoneVerifyErrorMessage);
-
-export const selectIdentityVerifyIsPending = createSelector(selectState, (state) => state.identityVerifyIsPending);
-
-export const selectIdentityVerifyErrorMessage = createSelector(
-  selectState,
-  (state) => state.identityVerifyErrorMessage
-);
+export const selectPhoneNewErrorMessage = (state) => selectState(state).phoneNewErrorMessage;
+export const selectEmailVerifyIsPending = (state) => selectState(state).emailVerifyIsPending;
+export const selectEmailVerifyErrorMessage = (state) => selectState(state).emailVerifyErrorMessage;
+export const selectPhoneNewIsPending = (state) => selectState(state).phoneNewIsPending;
+export const selectPhoneVerifyIsPending = (state) => selectState(state).phoneVerifyIsPending;
+export const selectPhoneVerifyErrorMessage = (state) => selectState(state).phoneVerifyErrorMessage;
+export const selectIdentityVerifyIsPending = (state) => selectState(state).identityVerifyIsPending;
+export const selectIdentityVerifyErrorMessage = (state) => selectState(state).identityVerifyErrorMessage;
 
 export const selectUserVerifiedEmail = createSelector(selectUser, (user) => user && user.has_verified_email);
 
@@ -94,36 +73,28 @@ export const selectUserIsVerificationCandidate = createSelector(
   (user) => user && (!user.has_verified_email || !user.is_identity_verified)
 );
 
-export const selectAccessToken = createSelector(selectState, (state) => state.accessToken);
-
-export const selectUserInviteStatusIsPending = createSelector(selectState, (state) => state.inviteStatusIsPending);
-
-export const selectUserInvitesRemaining = createSelector(selectState, (state) => state.invitesRemaining);
-
-export const selectUserInvitees = createSelector(selectState, (state) => state.invitees);
+export const selectAccessToken = (state) => selectState(state).accessToken;
+export const selectUserInviteStatusIsPending = (state) => selectState(state).inviteStatusIsPending;
+export const selectUserInvitesRemaining = (state) => selectState(state).invitesRemaining;
+export const selectUserInvitees = (state) => selectState(state).invitees;
 
 export const selectUserInviteStatusFailed = createSelector(
   selectUserInvitesRemaining,
   () => selectUserInvitesRemaining === null
 );
 
-export const selectUserInviteNewIsPending = createSelector(selectState, (state) => state.inviteNewIsPending);
-
-export const selectUserInviteNewErrorMessage = createSelector(selectState, (state) => state.inviteNewErrorMessage);
-
-export const selectUserInviteReferralLink = createSelector(selectState, (state) => state.referralLink);
+export const selectUserInviteNewIsPending = (state) => selectState(state).inviteNewIsPending;
+export const selectUserInviteNewErrorMessage = (state) => selectState(state).inviteNewErrorMessage;
+export const selectUserInviteReferralLink = (state) => selectState(state).referralLink;
 
 export const selectUserInviteReferralCode = createSelector(selectState, (state) =>
   state.referralCode ? state.referralCode[0] : ''
 );
 
-export const selectYouTubeImportPending = createSelector(selectState, (state) => state.youtubeChannelImportPending);
-
-export const selectYouTubeImportError = createSelector(selectState, (state) => state.youtubeChannelImportErrorMessage);
-
-export const selectSetReferrerPending = createSelector(selectState, (state) => state.referrerSetIsPending);
-
-export const selectSetReferrerError = createSelector(selectState, (state) => state.referrerSetError);
+export const selectYouTubeImportPending = (state) => selectState(state).youtubeChannelImportPending;
+export const selectYouTubeImportError = (state) => selectState(state).youtubeChannelImportErrorMessage;
+export const selectSetReferrerPending = (state) => selectState(state).referrerSetIsPending;
+export const selectSetReferrerError = (state) => selectState(state).referrerSetError;
 
 export const selectYouTubeImportVideosComplete = createSelector(selectState, (state) => {
   const total = state.youtubeChannelImportTotal;

--- a/ui/redux/selectors/wallet.js
+++ b/ui/redux/selectors/wallet.js
@@ -7,20 +7,12 @@ export const selectState = (state) => state.wallet || {};
 
 export const selectWalletState = selectState;
 
-export const selectWalletIsEncrypted = createSelector(selectState, (state) => state.walletIsEncrypted);
-
-export const selectWalletEncryptPending = createSelector(selectState, (state) => state.walletEncryptPending);
-
-export const selectWalletEncryptSucceeded = createSelector(selectState, (state) => state.walletEncryptSucceded);
-
-export const selectPendingSupportTransactions = createSelector(
-  selectState,
-  (state) => state.pendingSupportTransactions
-);
-
-export const selectPendingOtherTransactions = createSelector(selectState, (state) => state.pendingTxos);
-
-export const selectAbandonClaimSupportError = createSelector(selectState, (state) => state.abandonClaimSupportError);
+export const selectWalletIsEncrypted = (state) => selectState(state).walletIsEncrypted;
+export const selectWalletEncryptPending = (state) => selectState(state).walletEncryptPending;
+export const selectWalletEncryptSucceeded = (state) => selectState(state).walletEncryptSucceded;
+export const selectPendingSupportTransactions = (state) => selectState(state).pendingSupportTransactions;
+export const selectPendingOtherTransactions = (state) => selectState(state).pendingTxos;
+export const selectAbandonClaimSupportError = (state) => selectState(state).abandonClaimSupportError;
 
 export const makeSelectPendingAmountByUri = (uri) =>
   createSelector(selectClaimIdsByUri, selectPendingSupportTransactions, (claimIdsByUri, pendingSupports) => {
@@ -30,37 +22,22 @@ export const makeSelectPendingAmountByUri = (uri) =>
     return pendingSupport ? pendingSupport.effective : undefined;
   });
 
-export const selectWalletEncryptResult = createSelector(selectState, (state) => state.walletEncryptResult);
-
-export const selectWalletDecryptPending = createSelector(selectState, (state) => state.walletDecryptPending);
-
-export const selectWalletDecryptSucceeded = createSelector(selectState, (state) => state.walletDecryptSucceded);
-
-export const selectWalletDecryptResult = createSelector(selectState, (state) => state.walletDecryptResult);
-
-export const selectWalletUnlockPending = createSelector(selectState, (state) => state.walletUnlockPending);
-
-export const selectWalletUnlockSucceeded = createSelector(selectState, (state) => state.walletUnlockSucceded);
-
-export const selectWalletUnlockResult = createSelector(selectState, (state) => state.walletUnlockResult);
-
-export const selectWalletLockPending = createSelector(selectState, (state) => state.walletLockPending);
-
-export const selectWalletLockSucceeded = createSelector(selectState, (state) => state.walletLockSucceded);
-
-export const selectWalletLockResult = createSelector(selectState, (state) => state.walletLockResult);
-
-export const selectBalance = createSelector(selectState, (state) => state.balance);
-
-export const selectTotalBalance = createSelector(selectState, (state) => state.totalBalance);
-
-export const selectReservedBalance = createSelector(selectState, (state) => state.reservedBalance);
-
-export const selectClaimsBalance = createSelector(selectState, (state) => state.claimsBalance);
-
-export const selectSupportsBalance = createSelector(selectState, (state) => state.supportsBalance);
-
-export const selectTipsBalance = createSelector(selectState, (state) => state.tipsBalance);
+export const selectWalletEncryptResult = (state) => selectState(state).walletEncryptResult;
+export const selectWalletDecryptPending = (state) => selectState(state).walletDecryptPending;
+export const selectWalletDecryptSucceeded = (state) => selectState(state).walletDecryptSucceded;
+export const selectWalletDecryptResult = (state) => selectState(state).walletDecryptResult;
+export const selectWalletUnlockPending = (state) => selectState(state).walletUnlockPending;
+export const selectWalletUnlockSucceeded = (state) => selectState(state).walletUnlockSucceded;
+export const selectWalletUnlockResult = (state) => selectState(state).walletUnlockResult;
+export const selectWalletLockPending = (state) => selectState(state).walletLockPending;
+export const selectWalletLockSucceeded = (state) => selectState(state).walletLockSucceded;
+export const selectWalletLockResult = (state) => selectState(state).walletLockResult;
+export const selectBalance = (state) => selectState(state).balance;
+export const selectTotalBalance = (state) => selectState(state).totalBalance;
+export const selectReservedBalance = (state) => selectState(state).reservedBalance;
+export const selectClaimsBalance = (state) => selectState(state).claimsBalance;
+export const selectSupportsBalance = (state) => selectState(state).supportsBalance;
+export const selectTipsBalance = (state) => selectState(state).tipsBalance;
 
 export const selectTransactionsById = createSelector(selectState, (state) => state.transactions || {});
 
@@ -177,7 +154,7 @@ export const selectHasTransactions = createSelector(
   (transactions) => transactions && transactions.length > 0
 );
 
-export const selectIsFetchingTransactions = createSelector(selectState, (state) => state.fetchingTransactions);
+export const selectIsFetchingTransactions = (state) => selectState(state).fetchingTransactions;
 
 /**
  * CSV of 'selectTransactionItems'.
@@ -197,12 +174,9 @@ export const selectTransactionsFile = createSelector(selectTransactionItems, (tr
   return parsed;
 });
 
-export const selectIsSendingSupport = createSelector(selectState, (state) => state.sendingSupport);
-
-export const selectReceiveAddress = createSelector(selectState, (state) => state.receiveAddress);
-
-export const selectGettingNewAddress = createSelector(selectState, (state) => state.gettingNewAddress);
-
+export const selectIsSendingSupport = (state) => selectState(state).sendingSupport;
+export const selectReceiveAddress = (state) => selectState(state).receiveAddress;
+export const selectGettingNewAddress = (state) => selectState(state).gettingNewAddress;
 export const selectDraftTransaction = createSelector(selectState, (state) => state.draftTransaction || {});
 
 export const selectDraftTransactionAmount = createSelector(selectDraftTransaction, (draft) => draft.amount);
@@ -211,9 +185,8 @@ export const selectDraftTransactionAddress = createSelector(selectDraftTransacti
 
 export const selectDraftTransactionError = createSelector(selectDraftTransaction, (draft) => draft.error);
 
-export const selectBlocks = createSelector(selectState, (state) => state.blocks);
-
-export const selectCurrentHeight = createSelector(selectState, (state) => state.latestBlock);
+export const selectBlocks = (state) => selectState(state).blocks;
+export const selectCurrentHeight = (state) => selectState(state).latestBlock;
 
 export const selectTransactionListFilter = createSelector(selectState, (state) => state.transactionListFilter || '');
 
@@ -227,7 +200,7 @@ export const selectFilteredTransactions = createSelector(
   }
 );
 
-export const selectTxoPageParams = createSelector(selectState, (state) => state.txoFetchParams);
+export const selectTxoPageParams = (state) => selectState(state).txoFetchParams;
 
 export const selectTxoPage = createSelector(selectState, (state) => (state.txoPage && state.txoPage.items) || []);
 
@@ -238,9 +211,8 @@ export const selectTxoItemCount = createSelector(
   (state) => (state.txoPage && state.txoPage.total_items) || 1
 );
 
-export const selectFetchingTxosError = createSelector(selectState, (state) => state.fetchingTxosError);
-
-export const selectIsFetchingTxos = createSelector(selectState, (state) => state.fetchingTxos);
+export const selectFetchingTxosError = (state) => selectState(state).fetchingTxosError;
+export const selectIsFetchingTxos = (state) => selectState(state).fetchingTxos;
 
 export const makeSelectFilteredTransactionsForPage = (page = 1) =>
   createSelector(selectFilteredTransactions, (filteredTransactions) => {
@@ -258,16 +230,10 @@ export const selectFilteredTransactionCount = createSelector(
   (filteredTransactions) => filteredTransactions.length
 );
 
-export const selectIsWalletReconnecting = createSelector(selectState, (state) => state.walletReconnecting);
-
-export const selectIsFetchingUtxoCounts = createSelector(selectState, (state) => state.fetchingUtxoCounts);
-
-export const selectIsConsolidatingUtxos = createSelector(selectState, (state) => state.consolidatingUtxos);
-
-export const selectIsMassClaimingTips = createSelector(selectState, (state) => state.massClaimingTips);
-
-export const selectPendingConsolidateTxid = createSelector(selectState, (state) => state.pendingConsolidateTxid);
-
-export const selectPendingMassClaimTxid = createSelector(selectState, (state) => state.pendingMassClaimTxid);
-
-export const selectUtxoCounts = createSelector(selectState, (state) => state.utxoCounts);
+export const selectIsWalletReconnecting = (state) => selectState(state).walletReconnecting;
+export const selectIsFetchingUtxoCounts = (state) => selectState(state).fetchingUtxoCounts;
+export const selectIsConsolidatingUtxos = (state) => selectState(state).consolidatingUtxos;
+export const selectIsMassClaimingTips = (state) => selectState(state).massClaimingTips;
+export const selectPendingConsolidateTxid = (state) => selectState(state).pendingConsolidateTxid;
+export const selectPendingMassClaimTxid = (state) => selectState(state).pendingMassClaimTxid;
+export const selectUtxoCounts = (state) => selectState(state).utxoCounts;


### PR DESCRIPTION
It was not meant to be used for these cases -- wasting resources creating and going through the cache for each simple direct access.