### PR TITLE
Handle re-reselect warning on null/undefined key

### DIFF
--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -106,7 +106,7 @@ export const selectClaimForUri = createCachedSelector(
       }
     }
   }
-)((state, uri, returnRepost = true) => `${uri}:${returnRepost ? '1' : '0'}`);
+)((state, uri, returnRepost = true) => `${String(uri)}:${returnRepost ? '1' : '0'}`);
 
 export const makeSelectClaimForUri = (uri: string, returnRepost: boolean = true) =>
   createSelector(selectClaimIdsByUri, selectClaimsById, (byUri, byId) => {
@@ -264,7 +264,7 @@ export const makeSelectTotalPagesInChannelSearch = (uri: string) =>
 export const selectMetadataForUri = createCachedSelector(selectClaimForUri, (claim, uri) => {
   const metadata = claim && claim.value;
   return metadata || (claim === undefined ? undefined : null);
-})((state, uri) => uri);
+})((state, uri) => String(uri));
 
 export const makeSelectMetadataForUri = (uri: string) =>
   createSelector(makeSelectClaimForUri(uri), (claim) => {
@@ -297,7 +297,7 @@ export const selectDateForUri = createCachedSelector(
     const dateObj = new Date(timestamp);
     return dateObj;
   }
-)((state, uri) => uri);
+)((state, uri) => String(uri));
 
 export const makeSelectAmountForUri = (uri: string) =>
   createSelector(makeSelectClaimForUri(uri), (claim) => {
@@ -530,7 +530,7 @@ export const makeSelectMyChannelPermUrlForName = (name: string) =>
 
 export const selectTagsForUri = createCachedSelector(selectMetadataForUri, (metadata: ?GenericMetadata) => {
   return (metadata && metadata.tags) || [];
-})((state, uri) => uri);
+})((state, uri) => String(uri));
 
 export const makeSelectTagsForUri = (uri: string) =>
   createSelector(makeSelectMetadataForUri(uri), (metadata: ?GenericMetadata) => {

--- a/ui/redux/selectors/comments.js
+++ b/ui/redux/selectors/comments.js
@@ -67,7 +67,7 @@ export const selectPinnedCommentsForUri = createCachedSelector(
 
     return pinnedComments;
   }
-)((state, uri) => uri);
+)((state, uri) => String(uri));
 
 export const selectModerationBlockList = createSelector(
   (state) => selectState(state).moderationBlockList,
@@ -205,7 +205,7 @@ export const selectCommentsForUri = createCachedSelector(
     const comments = byClaimId && byClaimId[claimId];
     return filterComments(comments, claimId, filterInputs);
   }
-)((state, uri) => uri);
+)((state, uri) => String(uri));
 
 export const selectTopLevelCommentsForUri = createCachedSelector(
   (state, uri) => uri,
@@ -219,7 +219,7 @@ export const selectTopLevelCommentsForUri = createCachedSelector(
     const filtered = filterComments(comments, claimId, filterInputs);
     return maxCount > 0 ? filtered.slice(0, maxCount) : filtered;
   }
-)((state, uri, maxCount = -1) => `${uri}:${maxCount}`);
+)((state, uri, maxCount = -1) => `${String(uri)}:${maxCount}`);
 
 export const makeSelectTopLevelTotalCommentsForUri = (uri: string) =>
   createSelector(selectState, selectCommentsByUri, (state, byUri) => {
@@ -251,7 +251,7 @@ export const selectRepliesForParentId = createCachedSelector(
 
     return filterComments(comments, undefined, filterInputs);
   }
-)((state, id: string) => id);
+)((state, id: string) => String(id));
 
 /**
  * filterComments


### PR DESCRIPTION
Should be a harmless warning, but cleaning up nonetheless.