### PR TITLE
Remove React.memo usages in favor of fixing the selectors.

### DIFF
--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -290,34 +290,4 @@ function ClaimPreviewTile(props: Props) {
   );
 }
 
-export default React.memo<Props>(withRouter(ClaimPreviewTile), areEqual);
-
-const BLOCKLIST_KEYS = ['blackListedOutpoints', 'filteredOutpoints', 'blockedChannelUris'];
-const HANDLED_KEYS = [...BLOCKLIST_KEYS, 'date'];
-
-function areEqual(prev: Props, next: Props) {
-  for (let i = 0; i < BLOCKLIST_KEYS.length; ++i) {
-    const key = BLOCKLIST_KEYS[i];
-    const a = prev[key];
-    const b = next[key];
-
-    if (((!a || !b) && a !== b) || (a && b && a.length !== b.length)) {
-      // The arrays are huge, so just compare the length instead of each entry.
-      return false;
-    }
-  }
-
-  if (Number(prev.date) !== Number(next.date)) {
-    return false;
-  }
-
-  const propKeys = Object.keys(next);
-  for (let i = 0; i < propKeys.length; ++i) {
-    const pk = propKeys[i];
-    if (!HANDLED_KEYS.includes(pk) && prev[pk] !== next[pk]) {
-      return false;
-    }
-  }
-
-  return true;
-}
+export default withRouter(ClaimPreviewTile);

--- a/ui/component/recommendedContent/view.jsx
+++ b/ui/component/recommendedContent/view.jsx
@@ -24,7 +24,7 @@ type Props = {
   claimId: string,
 };
 
-export default React.memo<Props>(function RecommendedContent(props: Props) {
+export default function RecommendedContent(props: Props) {
   const {
     uri,
     doFetchRecommendedContent,
@@ -126,41 +126,4 @@ export default React.memo<Props>(function RecommendedContent(props: Props) {
       }
     />
   );
-}, areEqual);
-
-function areEqual(prevProps: Props, nextProps: Props) {
-  const a = prevProps;
-  const b = nextProps;
-
-  if (
-    a.uri !== b.uri ||
-    a.nextRecommendedUri !== b.nextRecommendedUri ||
-    a.isAuthenticated !== b.isAuthenticated ||
-    a.isSearching !== b.isSearching ||
-    (a.recommendedContentUris && !b.recommendedContentUris) ||
-    (!a.recommendedContentUris && b.recommendedContentUris) ||
-    (a.claim && !b.claim) ||
-    (!a.claim && b.claim)
-  ) {
-    return false;
-  }
-
-  if (a.claim && b.claim && a.claim.claim_id !== b.claim.claim_id) {
-    return false;
-  }
-
-  if (a.recommendedContentUris && b.recommendedContentUris) {
-    if (a.recommendedContentUris.length !== b.recommendedContentUris.length) {
-      return false;
-    }
-
-    let i = a.recommendedContentUris.length;
-    while (i--) {
-      if (a.recommendedContentUris[i] !== b.recommendedContentUris[i]) {
-        return false;
-      }
-    }
-  }
-
-  return true;
 }


### PR DESCRIPTION
Now that we know that our selectors are not memoizing correctly, we should fix things there instead of adding these hacks.

These are also not maintainable (a burden for the next person), and was actually broken from recent recsys changes.
