### PR TITLE
Reduce impact of scanning blocklists

### DIFF
--- a/extras/lbryinc/index.js
+++ b/extras/lbryinc/index.js
@@ -56,6 +56,7 @@ export { selectFilteredOutpoints, selectFilteredOutpointMap } from './redux/sele
 //   selectFetchingTrendingUris,
 // } from './redux/selectors/homepage';
 export { selectViewCount, makeSelectViewCountForUri, makeSelectSubCountForUri } from './redux/selectors/stats';
+export { selectBanStateForUri } from './redux/selectors/ban';
 export {
   selectHasSyncedWallet,
   selectSyncData,

--- a/extras/lbryinc/redux/selectors/ban.js
+++ b/extras/lbryinc/redux/selectors/ban.js
@@ -1,0 +1,96 @@
+// @flow
+
+// TODO: This should be in 'redux/selectors/claim.js'. Temporarily putting it
+// here to get past importing issues with 'lbryinc', which the real fix might
+// involve moving it from 'extras' to 'ui' (big change).
+
+import { createCachedSelector } from 're-reselect';
+import { selectClaimForUri } from 'redux/selectors/claims';
+import { selectMutedChannels } from 'redux/selectors/blocked';
+import { selectModerationBlockList } from 'redux/selectors/comments';
+import { selectBlackListedOutpoints, selectFilteredOutpoints } from 'lbryinc';
+import { isURIEqual } from 'util/lbryURI';
+
+const selectClaimExistsForUri = (state, uri) => {
+  return Boolean(selectClaimForUri(state, uri));
+};
+
+const selectTxidForUri = (state, uri) => {
+  const claim = selectClaimForUri(state, uri);
+  const signingChannel = claim && claim.signing_channel;
+  return signingChannel ? signingChannel.txid : claim ? claim.txid : undefined;
+};
+
+const selectNoutForUri = (state, uri) => {
+  const claim = selectClaimForUri(state, uri);
+  const signingChannel = claim && claim.signing_channel;
+  return signingChannel ? signingChannel.nout : claim ? claim.nout : undefined;
+};
+
+const selectPermanentUrlForUri = (state, uri) => {
+  const claim = selectClaimForUri(state, uri);
+  const signingChannel = claim && claim.signing_channel;
+  return signingChannel ? signingChannel.permanent_url : claim ? claim.permanent_url : undefined;
+};
+
+export const selectBanStateForUri = createCachedSelector(
+  // Break apart 'selectClaimForUri' into 4 cheaper selectors that return
+  // primitives for values that we care about. The Claim object itself is easily
+  // invalidated due to constantly-changing fields like 'confirmation'.
+  selectClaimExistsForUri,
+  selectTxidForUri,
+  selectNoutForUri,
+  selectPermanentUrlForUri,
+  selectBlackListedOutpoints,
+  selectFilteredOutpoints,
+  selectMutedChannels,
+  selectModerationBlockList,
+  (
+    claimExists,
+    txid,
+    nout,
+    permanentUrl,
+    blackListedOutpoints,
+    filteredOutpoints,
+    mutedChannelUris,
+    personalBlocklist
+  ) => {
+    const banState = {};
+
+    if (!claimExists) {
+      return banState;
+    }
+
+    // This will be replaced once blocking is done at the wallet server level.
+    if (blackListedOutpoints) {
+      if (blackListedOutpoints.some((outpoint) => outpoint.txid === txid && outpoint.nout === nout)) {
+        banState['blacklisted'] = true;
+      }
+    }
+
+    // We're checking to see if the stream outpoint or signing channel outpoint
+    // is in the filter list.
+    if (filteredOutpoints) {
+      if (filteredOutpoints.some((outpoint) => outpoint.txid === txid && outpoint.nout === nout)) {
+        banState['filtered'] = true;
+      }
+    }
+
+    // block stream claims
+    // block channel claims if we can't control for them in claim search
+    if (mutedChannelUris.length) {
+      if (mutedChannelUris.some((blockedUri) => isURIEqual(blockedUri, permanentUrl))) {
+        banState['muted'] = true;
+      }
+    }
+
+    // Commentron blocklist
+    if (personalBlocklist.length) {
+      if (personalBlocklist.some((blockedUri) => isURIEqual(blockedUri, permanentUrl))) {
+        banState['blocked'] = true;
+      }
+    }
+
+    return banState;
+  }
+)((state, uri) => String(uri));

--- a/ui/component/claimPreview/index.js
+++ b/ui/component/claimPreview/index.js
@@ -21,13 +21,11 @@ import {
 import { doResolveUri } from 'redux/actions/claims';
 import { doCollectionEdit } from 'redux/actions/collections';
 import { doFileGet } from 'redux/actions/file';
-import { selectMutedChannels, makeSelectChannelIsMuted } from 'redux/selectors/blocked';
-import { selectBlackListedOutpoints, selectFilteredOutpoints } from 'lbryinc';
+import { selectBanStateForUri } from 'lbryinc';
 import { makeSelectIsActiveLivestream } from 'redux/selectors/livestream';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import { makeSelectHasVisitedUri } from 'redux/selectors/content';
 import { makeSelectIsSubscribed } from 'redux/selectors/subscriptions';
-import { selectModerationBlockList } from 'redux/selectors/comments';
 import ClaimPreview from './view';
 import formatMediaDuration from 'util/formatMediaDuration';
 
@@ -48,12 +46,8 @@ const select = (state, props) => {
     isResolvingUri: props.uri && makeSelectIsUriResolving(props.uri)(state),
     isResolvingRepost: props.uri && makeSelectIsUriResolving(props.repostUrl)(state),
     nsfw: props.uri && makeSelectClaimIsNsfw(props.uri)(state),
-    blackListedOutpoints: selectBlackListedOutpoints(state),
-    filteredOutpoints: selectFilteredOutpoints(state),
-    mutedUris: selectMutedChannels(state),
-    blockedUris: selectModerationBlockList(state),
+    banState: selectBanStateForUri(state, props.uri),
     hasVisitedUri: props.uri && makeSelectHasVisitedUri(props.uri)(state),
-    channelIsBlocked: props.uri && makeSelectChannelIsMuted(props.uri)(state),
     isSubscribed: props.uri && makeSelectIsSubscribed(props.uri, true)(state),
     streamingUrl: props.uri && makeSelectStreamingUrlForUri(props.uri)(state),
     wasPurchased: props.uri && makeSelectClaimWasPurchased(props.uri)(state),

--- a/ui/component/claimPreviewTile/index.js
+++ b/ui/component/claimPreviewTile/index.js
@@ -11,8 +11,7 @@ import {
 } from 'redux/selectors/claims';
 import { doFileGet } from 'redux/actions/file';
 import { doResolveUri } from 'redux/actions/claims';
-import { selectMutedChannels } from 'redux/selectors/blocked';
-import { makeSelectViewCountForUri, selectBlackListedOutpoints, selectFilteredOutpoints } from 'lbryinc';
+import { makeSelectViewCountForUri, selectBanStateForUri } from 'lbryinc';
 import { makeSelectIsActiveLivestream } from 'redux/selectors/livestream';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import ClaimPreviewTile from './view';
@@ -31,9 +30,7 @@ const select = (state, props) => {
     isResolvingUri: props.uri && makeSelectIsUriResolving(props.uri)(state),
     thumbnail: props.uri && makeSelectThumbnailForUri(props.uri)(state),
     title: props.uri && makeSelectTitleForUri(props.uri)(state),
-    blackListedOutpoints: selectBlackListedOutpoints(state),
-    filteredOutpoints: selectFilteredOutpoints(state),
-    blockedChannelUris: selectMutedChannels(state),
+    banState: selectBanStateForUri(state, props.uri),
     showMature: selectShowMatureContent(state),
     isMature: makeSelectClaimIsNsfw(props.uri)(state),
     isLivestream: makeSelectClaimIsStreamPlaceholder(props.uri)(state),


### PR DESCRIPTION
## Issue
- Each tile was checking against 4 blocklists (blacklisted, filtered, muted, commentron) on every render. 
    - Loading the front-page with Cheese alone caused 1040 calls, and with my large muted list, it already took up 3/4 of a second from the precious startup time.
    - <img src="https://user-images.githubusercontent.com/64950861/138651947-60a6c1ee-f79f-4b37-8224-572818f84b9a.png" width="300">
- This is also part of the reason why pressing Back into the tile list takes forever.
    - <img src="https://user-images.githubusercontent.com/64950861/138652079-fdb11d92-0a54-4120-be03-0eea785fba4f.png" width="300">

## Changes
Renders are hard to avoid, so cache the operation.

## Notes
In some cases, we are actually double filtering, because we do pass in the muted + blocked uris to `claim_search`.  But we don't consistently do so, plus the list sometimes includes pinned/prefix/livestream uris that are not from `claim_search`.  If we can organize things a bit, maybe we can avoid the loop.