### PR TITLE
Don't instantiate messaging SDK if service worker is unavailable (Fir…

### DIFF
--- a/web/src/push-notifications.js
+++ b/web/src/push-notifications.js
@@ -11,8 +11,12 @@ import { firebaseConfig, vapidKey } from '$web/src/firebase-config';
 import { addRegistration, removeRegistration, hasRegistration } from '$web/src/fcm-management';
 import { browserData } from '$web/src/ua';
 
-const app = initializeApp(firebaseConfig);
-const messaging = getMessaging(app);
+let messaging = null;
+
+if ('serviceWorker' in navigator) {
+  const app = initializeApp(firebaseConfig);
+  messaging = getMessaging(app);
+}
 
 const subscriptionMetaData = () => {
   const isMobile = window.navigator.userAgentData?.mobile || false;


### PR DESCRIPTION
## Fixes

Fixes issue where firebase SDK can't be instantiated in Firefox private browser windows.

Issue Number:

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
