### PR TITLE
limit collections to show to 24

### DIFF
--- a/ui/component/collectionsListMine/view.jsx
+++ b/ui/component/collectionsListMine/view.jsx
@@ -25,7 +25,7 @@ const ALL = 'All';
 const PRIVATE = 'Private';
 const PUBLIC = 'Public';
 const COLLECTION_FILTERS = [ALL, PRIVATE, PUBLIC];
-COLLECTION_SHOW_COUNT = 24;
+const COLLECTION_SHOW_COUNT = 24;
 
 export default function CollectionsListMine(props: Props) {
   const {


### PR DESCRIPTION
A user had many collections (>100) bogging down rendering.
Since we have a search field, we can limit to 24.
