### PR TITLE
Split `secondary.js`

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -6,14 +6,16 @@ import classnames from 'classnames';
 import analytics from 'analytics';
 import { buildURI, parseURI } from 'util/lbryURI';
 import { SIMPLE_SITE } from 'config';
-import Nag from 'component/common/nag';
 import Router from 'component/router/index';
+import ModalRouter from 'modal/modalRouter';
 import ReactModal from 'react-modal';
 import { openContextMenu } from 'util/context-menu';
 import useKonamiListener from 'util/enhanced-layout';
+import Yrbl from 'component/yrbl';
 import FileRenderFloating from 'component/fileRenderFloating';
 import { withRouter } from 'react-router';
 import usePrevious from 'effects/use-previous';
+import Nag from 'component/common/nag';
 import REWARDS from 'rewards';
 import usePersistedState from 'effects/use-persisted-state';
 import Spinner from 'component/spinner';
@@ -23,8 +25,8 @@ import LANGUAGES from 'constants/languages';
 import useZoom from 'effects/use-zoom';
 import useHistoryNav from 'effects/use-history-nav';
 // @endif
-
 // @if TARGET='web'
+import YoutubeWelcome from 'web/component/youtubeReferralWelcome';
 import {
   useDegradedPerformance,
   STATUS_OK,
@@ -33,33 +35,22 @@ import {
   STATUS_DOWN,
 } from 'web/effects/use-degraded-performance';
 // @endif
-
 import LANGUAGE_MIGRATIONS from 'constants/language-migrations';
 
-const FileDrop = lazyImport(() => import('component/fileDrop' /* webpackChunkName: "secondary" */));
-const ModalRouter = lazyImport(() => import('modal/modalRouter' /* webpackChunkName: "secondary" */));
-const NagContinueFirstRun = lazyImport(() =>
-  import('component/nagContinueFirstRun' /* webpackChunkName: "secondary" */)
-);
-const OpenInAppLink = lazyImport(() => import('web/component/openInAppLink' /* webpackChunkName: "secondary" */));
+const FileDrop = lazyImport(() => import('component/fileDrop' /* webpackChunkName: "fileDrop" */));
+const NagContinueFirstRun = lazyImport(() => import('component/nagContinueFirstRun' /* webpackChunkName: "nagCFR" */));
+const OpenInAppLink = lazyImport(() => import('web/component/openInAppLink' /* webpackChunkName: "openInAppLink" */));
 
 // @if TARGET='web'
-const NagDataCollection = lazyImport(() =>
-  import('web/component/nag-data-collection' /* webpackChunkName: "secondary" */)
-);
+const NagDataCollection = lazyImport(() => import('web/component/nag-data-collection' /* webpackChunkName: "nagDC" */));
 const NagDegradedPerformance = lazyImport(() =>
-  import('web/component/nag-degraded-performance' /* webpackChunkName: "secondary" */)
+  import('web/component/nag-degraded-performance' /* webpackChunkName: "NagDegradedPerformance" */)
 );
 const NagNoUser = lazyImport(() => import('web/component/nag-no-user' /* webpackChunkName: "nag-no-user" */));
-const NagSunset = lazyImport(() => import('web/component/nag-sunset' /* webpackChunkName: "nag-no-user" */));
-const YoutubeWelcome = lazyImport(() =>
-  import('web/component/youtubeReferralWelcome' /* webpackChunkName: "secondary" */)
-);
-
+const NagSunset = lazyImport(() => import('web/component/nag-sunset' /* webpackChunkName: "nag-sunset" */));
 // @endif
 
 const SyncFatalError = lazyImport(() => import('component/syncFatalError' /* webpackChunkName: "syncFatalError" */));
-const Yrbl = lazyImport(() => import('component/yrbl' /* webpackChunkName: "yrbl" */));
 
 // ****************************************************************************
 
@@ -453,20 +444,16 @@ function App(props: Props) {
       onContextMenu={IS_WEB ? undefined : (e) => openContextMenu(e)}
     >
       {IS_WEB && lbryTvApiStatus === STATUS_DOWN ? (
-        <React.Suspense fallback={null}>
-          <Yrbl
-            className="main--empty"
-            title={__('lbry.tv is currently down')}
-            subtitle={__('My wheel broke, but the good news is that someone from LBRY is working on it.')}
-          />
-        </React.Suspense>
+        <Yrbl
+          className="main--empty"
+          title={__('lbry.tv is currently down')}
+          subtitle={__('My wheel broke, but the good news is that someone from LBRY is working on it.')}
+        />
       ) : (
         <React.Fragment>
           <Router />
-          <React.Suspense fallback={null}>
-            <ModalRouter />
-            {renderFiledrop && <FileDrop />}
-          </React.Suspense>
+          <ModalRouter />
+          <React.Suspense fallback={null}>{renderFiledrop && <FileDrop />}</React.Suspense>
           <FileRenderFloating />
           <React.Suspense fallback={null}>
             {isEnhancedLayout && <Yrbl className="yrbl--enhanced" />}

--- a/ui/component/page/view.jsx
+++ b/ui/component/page/view.jsx
@@ -14,7 +14,7 @@ import { useHistory } from 'react-router';
 import { useIsMobile, useIsMediumScreen } from 'effects/use-screensize';
 import { parseURI } from 'util/lbryURI';
 
-const Footer = lazyImport(() => import('web/component/footer' /* webpackChunkName: "secondary" */));
+const Footer = lazyImport(() => import('web/component/footer' /* webpackChunkName: "footer" */));
 
 export const MAIN_CLASS = 'main';
 type Props = {

--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -24,72 +24,77 @@ const TOSPage = lazyImport(() => import('web/page/tos' /* webpackChunkName: "tos
 const YouTubeTOSPage = lazyImport(() => import('web/page/youtubetos' /* webpackChunkName: "youtubetos" */));
 // @endif
 
-// Chunk: "secondary"
-const SignInPage = lazyImport(() => import('page/signIn' /* webpackChunkName: "secondary" */));
+const SignInPage = lazyImport(() => import('page/signIn' /* webpackChunkName: "signIn" */));
 const SignInWalletPasswordPage = lazyImport(() =>
-  import('page/signInWalletPassword' /* webpackChunkName: "secondary" */)
+  import('page/signInWalletPassword' /* webpackChunkName: "signInWalletPassword" */)
 );
-const SignUpPage = lazyImport(() => import('page/signUp' /* webpackChunkName: "secondary" */));
-const SignInVerifyPage = lazyImport(() => import('page/signInVerify' /* webpackChunkName: "secondary" */));
+const SignUpPage = lazyImport(() => import('page/signUp' /* webpackChunkName: "signUp" */));
+const SignInVerifyPage = lazyImport(() => import('page/signInVerify' /* webpackChunkName: "signInVerify" */));
 
-// Chunk: "wallet/secondary"
-const BuyPage = lazyImport(() => import('page/buy' /* webpackChunkName: "secondary" */));
-const ReceivePage = lazyImport(() => import('page/receive' /* webpackChunkName: "secondary" */));
-const SendPage = lazyImport(() => import('page/send' /* webpackChunkName: "secondary" */));
-const SwapPage = lazyImport(() => import('page/swap' /* webpackChunkName: "secondary" */));
-const WalletPage = lazyImport(() => import('page/wallet' /* webpackChunkName: "secondary" */));
+const BuyPage = lazyImport(() => import('page/buy' /* webpackChunkName: "buy" */));
+const ReceivePage = lazyImport(() => import('page/receive' /* webpackChunkName: "receive" */));
+const SendPage = lazyImport(() => import('page/send' /* webpackChunkName: "send" */));
+const SwapPage = lazyImport(() => import('page/swap' /* webpackChunkName: "swap" */));
+const WalletPage = lazyImport(() => import('page/wallet' /* webpackChunkName: "wallet" */));
 
-// Chunk: none
-const NotificationsPage = lazyImport(() => import('page/notifications' /* webpackChunkName: "secondary" */));
-const CollectionPage = lazyImport(() => import('page/collection' /* webpackChunkName: "secondary" */));
-const ChannelNew = lazyImport(() => import('page/channelNew' /* webpackChunkName: "secondary" */));
+const NotificationsPage = lazyImport(() => import('page/notifications' /* webpackChunkName: "notifications" */));
+const CollectionPage = lazyImport(() => import('page/collection' /* webpackChunkName: "collection" */));
+const ChannelNew = lazyImport(() => import('page/channelNew' /* webpackChunkName: "channelNew" */));
 const ChannelsFollowingDiscoverPage = lazyImport(() =>
-  import('page/channelsFollowingDiscover' /* webpackChunkName: "secondary" */)
+  import('page/channelsFollowingDiscover' /* webpackChunkName: "channelsFollowingDiscover" */)
 );
-const ChannelsFollowingPage = lazyImport(() => import('page/channelsFollowing' /* webpackChunkName: "secondary" */));
-const ChannelsPage = lazyImport(() => import('page/channels' /* webpackChunkName: "secondary" */));
+const ChannelsFollowingPage = lazyImport(() =>
+  import('page/channelsFollowing' /* webpackChunkName: "channelsFollowing" */)
+);
+const ChannelsPage = lazyImport(() => import('page/channels' /* webpackChunkName: "channels" */));
 const CheckoutPage = lazyImport(() => import('page/checkoutPage' /* webpackChunkName: "checkoutPage" */));
-const CreatorDashboard = lazyImport(() => import('page/creatorDashboard' /* webpackChunkName: "secondary" */));
-const DiscoverPage = lazyImport(() => import('page/discover' /* webpackChunkName: "secondary" */));
-const EmbedWrapperPage = lazyImport(() => import('page/embedWrapper' /* webpackChunkName: "secondary" */));
-const FileListPublished = lazyImport(() => import('page/fileListPublished' /* webpackChunkName: "secondary" */));
+const CreatorDashboard = lazyImport(() => import('page/creatorDashboard' /* webpackChunkName: "creatorDashboard" */));
+const DiscoverPage = lazyImport(() => import('page/discover' /* webpackChunkName: "discover" */));
+const EmbedWrapperPage = lazyImport(() => import('page/embedWrapper' /* webpackChunkName: "embedWrapper" */));
+const FileListPublished = lazyImport(() =>
+  import('page/fileListPublished' /* webpackChunkName: "fileListPublished" */)
+);
 const FourOhFourPage = lazyImport(() => import('page/fourOhFour' /* webpackChunkName: "fourOhFour" */));
 const HelpPage = lazyImport(() => import('page/help' /* webpackChunkName: "help" */));
-const InvitePage = lazyImport(() => import('page/invite' /* webpackChunkName: "secondary" */));
-const InvitedPage = lazyImport(() => import('page/invited' /* webpackChunkName: "secondary" */));
-const LibraryPage = lazyImport(() => import('page/library' /* webpackChunkName: "secondary" */));
-const ListBlockedPage = lazyImport(() => import('page/listBlocked' /* webpackChunkName: "secondary" */));
-const ListsPage = lazyImport(() => import('page/lists' /* webpackChunkName: "secondary" */));
-const LiveStreamSetupPage = lazyImport(() => import('page/livestreamSetup' /* webpackChunkName: "secondary" */));
-const LivestreamCurrentPage = lazyImport(() => import('page/livestreamCurrent' /* webpackChunkName: "secondary" */));
+const InvitePage = lazyImport(() => import('page/invite' /* webpackChunkName: "invite" */));
+const InvitedPage = lazyImport(() => import('page/invited' /* webpackChunkName: "invited" */));
+const LibraryPage = lazyImport(() => import('page/library' /* webpackChunkName: "library" */));
+const ListBlockedPage = lazyImport(() => import('page/listBlocked' /* webpackChunkName: "listBlocked" */));
+const ListsPage = lazyImport(() => import('page/lists' /* webpackChunkName: "lists" */));
+const LiveStreamSetupPage = lazyImport(() => import('page/livestreamSetup' /* webpackChunkName: "livestreamSetup" */));
+const LivestreamCurrentPage = lazyImport(() =>
+  import('page/livestreamCurrent' /* webpackChunkName: "livestreamCurrent" */)
+);
 const OwnComments = lazyImport(() => import('page/ownComments' /* webpackChunkName: "ownComments" */));
-const PasswordResetPage = lazyImport(() => import('page/passwordReset' /* webpackChunkName: "secondary" */));
-const PasswordSetPage = lazyImport(() => import('page/passwordSet' /* webpackChunkName: "secondary" */));
-const PublishPage = lazyImport(() => import('page/publish' /* webpackChunkName: "secondary" */));
-const ReportContentPage = lazyImport(() => import('page/reportContent' /* webpackChunkName: "secondary" */));
-const ReportPage = lazyImport(() => import('page/report' /* webpackChunkName: "secondary" */));
-const RepostNew = lazyImport(() => import('page/repost' /* webpackChunkName: "secondary" */));
-const RewardsPage = lazyImport(() => import('page/rewards' /* webpackChunkName: "secondary" */));
-const RewardsVerifyPage = lazyImport(() => import('page/rewardsVerify' /* webpackChunkName: "secondary" */));
-const SearchPage = lazyImport(() => import('page/search' /* webpackChunkName: "secondary" */));
-const SettingsStripeCard = lazyImport(() => import('page/settingsStripeCard' /* webpackChunkName: "secondary" */));
+const PasswordResetPage = lazyImport(() => import('page/passwordReset' /* webpackChunkName: "passwordReset" */));
+const PasswordSetPage = lazyImport(() => import('page/passwordSet' /* webpackChunkName: "passwordSet" */));
+const PublishPage = lazyImport(() => import('page/publish' /* webpackChunkName: "publish" */));
+const ReportContentPage = lazyImport(() => import('page/reportContent' /* webpackChunkName: "reportContent" */));
+const ReportPage = lazyImport(() => import('page/report' /* webpackChunkName: "report" */));
+const RepostNew = lazyImport(() => import('page/repost' /* webpackChunkName: "repost" */));
+const RewardsPage = lazyImport(() => import('page/rewards' /* webpackChunkName: "rewards" */));
+const RewardsVerifyPage = lazyImport(() => import('page/rewardsVerify' /* webpackChunkName: "rewardsVerify" */));
+const SearchPage = lazyImport(() => import('page/search' /* webpackChunkName: "search" */));
+const SettingsStripeCard = lazyImport(() =>
+  import('page/settingsStripeCard' /* webpackChunkName: "settingsStripeCard" */)
+);
 const SettingsStripeAccount = lazyImport(() =>
-  import('page/settingsStripeAccount' /* webpackChunkName: "secondary" */)
+  import('page/settingsStripeAccount' /* webpackChunkName: "settingsStripeAccount" */)
 );
-const SettingsCreatorPage = lazyImport(() => import('page/settingsCreator' /* webpackChunkName: "secondary" */));
+const SettingsCreatorPage = lazyImport(() => import('page/settingsCreator' /* webpackChunkName: "settingsCreator" */));
 const SettingsNotificationsPage = lazyImport(() =>
-  import('page/settingsNotifications' /* webpackChunkName: "secondary" */)
+  import('page/settingsNotifications' /* webpackChunkName: "settingsNotifications" */)
 );
-const SettingsPage = lazyImport(() => import('page/settings' /* webpackChunkName: "secondary" */));
-const ShowPage = lazyImport(() => import('page/show' /* webpackChunkName: "secondary" */));
+const SettingsPage = lazyImport(() => import('page/settings' /* webpackChunkName: "settings" */));
+const ShowPage = lazyImport(() => import('page/show' /* webpackChunkName: "show" */));
 const TagsFollowingManagePage = lazyImport(() =>
-  import('page/tagsFollowingManage' /* webpackChunkName: "secondary" */)
+  import('page/tagsFollowingManage' /* webpackChunkName: "tagsFollowingManage" */)
 );
-const TagsFollowingPage = lazyImport(() => import('page/tagsFollowing' /* webpackChunkName: "secondary" */));
-const TopPage = lazyImport(() => import('page/top' /* webpackChunkName: "secondary" */));
+const TagsFollowingPage = lazyImport(() => import('page/tagsFollowing' /* webpackChunkName: "tagsFollowing" */));
+const TopPage = lazyImport(() => import('page/top' /* webpackChunkName: "top" */));
 const UpdatePasswordPage = lazyImport(() => import('page/passwordUpdate' /* webpackChunkName: "passwordUpdate" */));
-const Welcome = lazyImport(() => import('page/welcome' /* webpackChunkName: "secondary" */));
-const YoutubeSyncPage = lazyImport(() => import('page/youtubeSync' /* webpackChunkName: "secondary" */));
+const Welcome = lazyImport(() => import('page/welcome' /* webpackChunkName: "welcome" */));
+const YoutubeSyncPage = lazyImport(() => import('page/youtubeSync' /* webpackChunkName: "youtubeSync" */));
 
 // Tell the browser we are handling scroll restoration
 if ('scrollRestoration' in history) {

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -603,7 +603,8 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       // ford ad
       // 612fb75a42715a07645a614c
 
-      const macroUrl1 = 'https://gov.aniview.com/api/adserver/vast3/' +
+      const macroUrl1 =
+        'https://gov.aniview.com/api/adserver/vast3/' +
         '?AV_PUBLISHERID=60afcbc58cfdb065440d2426' +
         '&AV_CHANNELID=60b354389c7adb506d0bd9a4' +
         `&AV_URL=${encodeURIComponent(window.location.href)}` +
@@ -640,7 +641,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       }
 
       // kick player in the butt, sometimes it doesn't always autoplay when it should
-      player.on('loadstart', function(event) {
+      player.on('loadstart', function (event) {
         if (autoplay) {
           player.play();
         }

--- a/ui/component/wunderbar/view.jsx
+++ b/ui/component/wunderbar/view.jsx
@@ -6,7 +6,7 @@ import { useIsMobile } from 'effects/use-screensize';
 
 const Button = lazyImport(() => import('component/button' /* webpackChunkName: "button" */));
 const Icon = lazyImport(() => import('component/common/icon' /* webpackChunkName: "icon" */));
-const WunderbarSuggestions = lazyImport(() => import('component/wunderbarSuggestions' /* webpackChunkName: "secondary" */));
+const WunderbarSuggestions = lazyImport(() => import('component/wunderbarSuggestions' /* webpackChunkName: "wb" */));
 
 type Props = {
   doOpenMobileSearch: (any) => void,

--- a/ui/page/show/view.jsx
+++ b/ui/page/show/view.jsx
@@ -9,6 +9,7 @@ import ChannelPage from 'page/channel';
 import Page from 'component/page';
 import Button from 'component/button';
 import Card from 'component/common/card';
+import Yrbl from 'component/yrbl';
 import { formatLbryUrlForWeb } from 'util/url';
 import { parseURI } from 'util/lbryURI';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
@@ -18,7 +19,6 @@ const AbandonedChannelPreview = lazyImport(() =>
 );
 const FilePage = lazyImport(() => import('page/file' /* webpackChunkName: "filePage" */));
 const LivestreamPage = lazyImport(() => import('page/livestream' /* webpackChunkName: "livestream" */));
-const Yrbl = lazyImport(() => import('component/yrbl' /* webpackChunkName: "yrbl" */));
 const isDev = process.env.NODE_ENV !== 'production';
 
 type Props = {

--- a/ui/scss/component/_videojs.scss
+++ b/ui/scss/component/_videojs.scss
@@ -83,7 +83,7 @@
     width: 125%;
     font-size: 12px;
 
-    @media (max-width:652px)  {
+    @media (max-width: 652px) {
       font-size: 10px;
     }
   }
@@ -160,7 +160,7 @@
 [dir] .video-js .vjs-control {
   font-size: 14px;
 
-  @media (max-width:813px)  {
+  @media (max-width: 813px) {
     font-size: 12px;
   }
 }
@@ -174,7 +174,7 @@
   margin-top: 3px;
   font-size: 12px !important;
 
-  @media (max-width:813px)  {
+  @media (max-width: 813px) {
     margin-top: 3px !important;
     font-size: 10px !important;
   }
@@ -195,7 +195,7 @@
 .vjs-quality-selector > .vjs-menu > .vjs-menu-content {
   font-size: 12px;
 
-  @media (max-width:652px)  {
+  @media (max-width: 652px) {
     font-size: 10px;
   }
 }
@@ -214,7 +214,7 @@
   position: absolute;
   top: 4px;
 
-  @media (max-width:813px)  {
+  @media (max-width: 813px) {
     top: 0px;
   }
 }


### PR DESCRIPTION
## Issue
95% of `secondary.js` is unused code.
  - It was meant to reduce network overhead by chunking up files that are mostly likely needed after bootup, and also to reduce the number of `vendor-*.js` files.
  - But it ended up accidentally grabbing lots of stuff, thus defeating the purpose of code-splitting.

![image](https://user-images.githubusercontent.com/64950861/139636990-c7742e92-8db1-42b0-b88a-76bf533d9a30.png)

## Change
Don't bother grouping up the chunks for now

