### PR TITLE
URI parsing improvements

### DIFF
--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -167,7 +167,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
       </span>
     );
   }, [channelSubCount]);
-  const isValid = uri && isURIValid(uri);
+  const isValid = uri && isURIValid(uri, false);
 
   // $FlowFixMe
   const isPlayable =

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -77,10 +77,11 @@ export const selectClaimForUri = createCachedSelector(
   (state, uri) => uri,
   (state, uri, returnRepost = true) => returnRepost,
   (byUri, byId, uri, returnRepost) => {
-    const validUri = isURIValid(uri);
+    const validUri = isURIValid(uri, false);
 
     if (validUri && byUri) {
-      const claimId = uri && byUri[normalizeURI(uri)];
+      const normalizedUri = normalizeURI(uri);
+      const claimId = uri && byUri[normalizedUri];
       const claim = byId[claimId];
 
       // Make sure to return the claim as is so apps can check if it's been resolved before (null) or still needs to be resolved (undefined)
@@ -97,7 +98,7 @@ export const selectClaimForUri = createCachedSelector(
 
         return {
           ...repostedClaim,
-          repost_url: normalizeURI(uri),
+          repost_url: normalizedUri,
           repost_channel_url: channelUrl,
           repost_bid_amount: claim && claim.meta && claim.meta.effective_amount,
         };
@@ -108,12 +109,14 @@ export const selectClaimForUri = createCachedSelector(
   }
 )((state, uri, returnRepost = true) => `${String(uri)}:${returnRepost ? '1' : '0'}`);
 
+// Note: this is deprecated. Use "selectClaimForUri(state, uri)" instead.
 export const makeSelectClaimForUri = (uri: string, returnRepost: boolean = true) =>
   createSelector(selectClaimIdsByUri, selectClaimsById, (byUri, byId) => {
-    const validUri = isURIValid(uri);
+    const validUri = isURIValid(uri, false);
 
     if (validUri && byUri) {
-      const claimId = uri && byUri[normalizeURI(uri)];
+      const normalizedUri = normalizeURI(uri);
+      const claimId = uri && byUri[normalizedUri];
       const claim = byId[claimId];
 
       // Make sure to return the claim as is so apps can check if it's been resolved before (null) or still needs to be resolved (undefined)
@@ -130,7 +133,7 @@ export const makeSelectClaimForUri = (uri: string, returnRepost: boolean = true)
 
         return {
           ...repostedClaim,
-          repost_url: normalizeURI(uri),
+          repost_url: normalizedUri,
           repost_channel_url: channelUrl,
           repost_bid_amount: claim && claim.meta && claim.meta.effective_amount,
         };
@@ -184,7 +187,7 @@ export const makeSelectClaimIsMine = (rawUri: string) => {
   } catch (e) {}
 
   return createSelector(selectClaimsByUri, selectMyActiveClaims, (claims, myClaims) => {
-    if (!isURIValid(uri)) {
+    if (!isURIValid(uri, false)) {
       return false;
     }
 

--- a/ui/util/lbryURI.js
+++ b/ui/util/lbryURI.js
@@ -323,15 +323,7 @@ export function splitBySeparator(uri: string) {
 }
 
 export function isURIEqual(uriA: string, uriB: string) {
-  const parseA = parseURI(normalizeURI(uriA));
-  const parseB = parseURI(normalizeURI(uriB));
-  if (parseA.isChannel) {
-    if (parseB.isChannel && parseA.channelClaimId === parseB.channelClaimId) {
-      return true;
-    }
-  } else if (parseA.streamClaimId === parseB.streamClaimId) {
-    return true;
-  } else {
-    return false;
-  }
+  const a = uriA && uriA.replace(/:/g, '#');
+  const b = uriB && uriB.replace(/:/g, '#');
+  return a === b;
 }

--- a/ui/util/lbryURI.js
+++ b/ui/util/lbryURI.js
@@ -265,9 +265,9 @@ export function normalizeURI(URL: string) {
   });
 }
 
-export function isURIValid(URL: string): boolean {
+export function isURIValid(URL: string, normalize: boolean = true): boolean {
   try {
-    parseURI(normalizeURI(URL));
+    parseURI(normalize ? normalizeURI(URL) : URL);
   } catch (error) {
     return false;
   }


### PR DESCRIPTION
## Ticket
Closes [#129 "Total Blocking Time" doubled after redux-consolidation commit](https://github.com/OdyseeTeam/odysee-frontend/issues/129)

## Changes
See commit messages.  Unsure if I covered all cases for the `isURIEqual` replacement.  Will there be any odd encodings that would break it?

## Results
- Before:  pausing a video took ~200ms
    - <img src="https://user-images.githubusercontent.com/64950861/139851451-595b3271-5f6a-40ca-804f-b6e2acf44940.png" width="300">
- After:  pausing a video takes ~80ms
    - <img src="https://user-images.githubusercontent.com/64950861/139851523-5d511f64-2025-4486-9478-77a1e4c5bab9.png" width="300">
