### PR TITLE
Fix crash with ModalError

### DIFF
--- a/ui/modal/modalRouter/view.jsx
+++ b/ui/modal/modalRouter/view.jsx
@@ -97,6 +97,99 @@ const ModalYoutubeWelcome = lazyImport(() =>
   import('modal/modalYoutubeWelcome' /* webpackChunkName: "modalYoutubeWelcome" */)
 );
 
+function getModal(id) {
+  switch (id) {
+    case MODALS.CONFIRM:
+      return ModalConfirm;
+    case MODALS.UPGRADE:
+      return ModalUpgrade;
+    case MODALS.DOWNLOADING:
+      return ModalDownloading;
+    case MODALS.AUTO_GENERATE_THUMBNAIL:
+      return ModalAutoGenerateThumbnail;
+    case MODALS.AUTO_UPDATE_DOWNLOADED:
+      return ModalAutoUpdateDownloaded;
+    case MODALS.ERROR:
+      return ModalError;
+    case MODALS.FILE_TIMEOUT:
+      return ModalFileTimeout;
+    case MODALS.FIRST_REWARD:
+      return ModalFirstReward;
+    case MODALS.TRANSACTION_FAILED:
+      return ModalTransactionFailed;
+    case MODALS.CONFIRM_FILE_REMOVE:
+      return ModalRemoveFile;
+    case MODALS.AFFIRM_PURCHASE:
+      return ModalAffirmPurchase;
+    case MODALS.CONFIRM_CLAIM_REVOKE:
+      return ModalRevokeClaim;
+    case MODALS.PHONE_COLLECTION:
+      return ModalPhoneCollection;
+    case MODALS.FIRST_SUBSCRIPTION:
+      return ModalFirstSubscription;
+    case MODALS.SEND_TIP:
+      return ModalSendTip;
+    case MODALS.SOCIAL_SHARE:
+      return ModalSocialShare;
+    case MODALS.PUBLISH:
+      return ModalPublish;
+    case MODALS.PUBLISH_PREVIEW:
+      return ModalPublishPreview;
+    case MODALS.CONFIRM_EXTERNAL_RESOURCE:
+      return ModalOpenExternalResource;
+    case MODALS.CONFIRM_TRANSACTION:
+      return ModalConfirmTransaction;
+    case MODALS.CONFIRM_THUMBNAIL_UPLOAD:
+      return ModalConfirmThumbnailUpload;
+    case MODALS.WALLET_ENCRYPT:
+      return ModalWalletEncrypt;
+    case MODALS.WALLET_DECRYPT:
+      return ModalWalletDecrypt;
+    case MODALS.WALLET_UNLOCK:
+      return ModalWalletUnlock;
+    case MODALS.WALLET_PASSWORD_UNSAVE:
+      return ModalPasswordUnsave;
+    case MODALS.REWARD_GENERATED_CODE:
+      return ModalRewardCode;
+    case MODALS.COMMENT_ACKNOWEDGEMENT:
+      return ModalCommentAcknowledgement;
+    case MODALS.YOUTUBE_WELCOME:
+      return ModalYoutubeWelcome;
+    case MODALS.SET_REFERRER:
+      return ModalSetReferrer;
+    case MODALS.SIGN_OUT:
+      return ModalSignOut;
+    case MODALS.CONFIRM_AGE:
+      return ModalConfirmAge;
+    case MODALS.FILE_SELECTION:
+      return ModalFileSelection;
+    case MODALS.LIQUIDATE_SUPPORTS:
+      return ModalSupportsLiquidate;
+    case MODALS.IMAGE_UPLOAD:
+      return ModalImageUpload;
+    case MODALS.SYNC_ENABLE:
+      return ModalSyncEnable;
+    case MODALS.MOBILE_SEARCH:
+      return ModalMobileSearch;
+    case MODALS.VIEW_IMAGE:
+      return ModalViewImage;
+    case MODALS.MASS_TIP_UNLOCK:
+      return ModalMassTipsUnlock;
+    case MODALS.BLOCK_CHANNEL:
+      return ModalBlockChannel;
+    case MODALS.COLLECTION_ADD:
+      return ModalClaimCollectionAdd;
+    case MODALS.COLLECTION_DELETE:
+      return ModalDeleteCollection;
+    case MODALS.CONFIRM_REMOVE_CARD:
+      return ModalRemoveCard;
+    case MODALS.CONFIRM_REMOVE_COMMENT:
+      return ModalRemoveComment;
+    default:
+      return null;
+  }
+}
+
 type Props = {
   modal: { id: string, modalProps: {} },
   error: { message: string },
@@ -113,104 +206,15 @@ function ModalRouter(props: Props) {
   }, [pathname, hideModal]);
 
   if (error) {
-    return <ModalError {...error} />;
+    return (
+      <React.Suspense fallback={<LoadingBarOneOff />}>
+        <ModalError {...error} />
+      </React.Suspense>
+    );
   }
 
   if (!modal) {
     return null;
-  }
-
-  function getModal(id) {
-    switch (id) {
-      case MODALS.CONFIRM:
-        return ModalConfirm;
-      case MODALS.UPGRADE:
-        return ModalUpgrade;
-      case MODALS.DOWNLOADING:
-        return ModalDownloading;
-      case MODALS.AUTO_GENERATE_THUMBNAIL:
-        return ModalAutoGenerateThumbnail;
-      case MODALS.AUTO_UPDATE_DOWNLOADED:
-        return ModalAutoUpdateDownloaded;
-      case MODALS.ERROR:
-        return ModalError;
-      case MODALS.FILE_TIMEOUT:
-        return ModalFileTimeout;
-      case MODALS.FIRST_REWARD:
-        return ModalFirstReward;
-      case MODALS.TRANSACTION_FAILED:
-        return ModalTransactionFailed;
-      case MODALS.CONFIRM_FILE_REMOVE:
-        return ModalRemoveFile;
-      case MODALS.AFFIRM_PURCHASE:
-        return ModalAffirmPurchase;
-      case MODALS.CONFIRM_CLAIM_REVOKE:
-        return ModalRevokeClaim;
-      case MODALS.PHONE_COLLECTION:
-        return ModalPhoneCollection;
-      case MODALS.FIRST_SUBSCRIPTION:
-        return ModalFirstSubscription;
-      case MODALS.SEND_TIP:
-        return ModalSendTip;
-      case MODALS.SOCIAL_SHARE:
-        return ModalSocialShare;
-      case MODALS.PUBLISH:
-        return ModalPublish;
-      case MODALS.PUBLISH_PREVIEW:
-        return ModalPublishPreview;
-      case MODALS.CONFIRM_EXTERNAL_RESOURCE:
-        return ModalOpenExternalResource;
-      case MODALS.CONFIRM_TRANSACTION:
-        return ModalConfirmTransaction;
-      case MODALS.CONFIRM_THUMBNAIL_UPLOAD:
-        return ModalConfirmThumbnailUpload;
-      case MODALS.WALLET_ENCRYPT:
-        return ModalWalletEncrypt;
-      case MODALS.WALLET_DECRYPT:
-        return ModalWalletDecrypt;
-      case MODALS.WALLET_UNLOCK:
-        return ModalWalletUnlock;
-      case MODALS.WALLET_PASSWORD_UNSAVE:
-        return ModalPasswordUnsave;
-      case MODALS.REWARD_GENERATED_CODE:
-        return ModalRewardCode;
-      case MODALS.COMMENT_ACKNOWEDGEMENT:
-        return ModalCommentAcknowledgement;
-      case MODALS.YOUTUBE_WELCOME:
-        return ModalYoutubeWelcome;
-      case MODALS.SET_REFERRER:
-        return ModalSetReferrer;
-      case MODALS.SIGN_OUT:
-        return ModalSignOut;
-      case MODALS.CONFIRM_AGE:
-        return ModalConfirmAge;
-      case MODALS.FILE_SELECTION:
-        return ModalFileSelection;
-      case MODALS.LIQUIDATE_SUPPORTS:
-        return ModalSupportsLiquidate;
-      case MODALS.IMAGE_UPLOAD:
-        return ModalImageUpload;
-      case MODALS.SYNC_ENABLE:
-        return ModalSyncEnable;
-      case MODALS.MOBILE_SEARCH:
-        return ModalMobileSearch;
-      case MODALS.VIEW_IMAGE:
-        return ModalViewImage;
-      case MODALS.MASS_TIP_UNLOCK:
-        return ModalMassTipsUnlock;
-      case MODALS.BLOCK_CHANNEL:
-        return ModalBlockChannel;
-      case MODALS.COLLECTION_ADD:
-        return ModalClaimCollectionAdd;
-      case MODALS.COLLECTION_DELETE:
-        return ModalDeleteCollection;
-      case MODALS.CONFIRM_REMOVE_CARD:
-        return ModalRemoveCard;
-      case MODALS.CONFIRM_REMOVE_COMMENT:
-        return ModalRemoveComment;
-      default:
-        return null;
-    }
   }
 
   const { id, modalProps } = modal;


### PR DESCRIPTION
## Issue
There was one instance of ModalError that wasn't wrapped in the Suspense.

## Fix
- Moved `getModal` outside to make the code cleaner. Due to the length of `getModal`, I didn't notice the early return statement.
- Fix ModalError's Suspense.
