### PR TITLE
Fixes the play/pause on drag issue with the floating player.

### DIFF
--- a/ui/component/fileRenderFloating/view.jsx
+++ b/ui/component/fileRenderFloating/view.jsx
@@ -295,10 +295,13 @@ export default function FileRenderFloating(props: Props) {
   }
 
   function handleDragMove(e, ui) {
-    setWasDragging(true);
     const { x, y } = position;
     const newX = x + ui.deltaX;
     const newY = y + ui.deltaY;
+    // Mark as dragging if the position changed and we were not dragging before.
+    if (!wasDragging && (newX !== x || newY !== y)) {
+      setWasDragging(true);
+    }
     setPosition({
       x: newX,
       y: newY,
@@ -307,7 +310,6 @@ export default function FileRenderFloating(props: Props) {
 
   function handleDragStop(e) {
     if (wasDragging) {
-      e.stopPropagation();
       setWasDragging(false);
       setRelativePos({
         x: position.x / getScreenWidth(),
@@ -334,6 +336,7 @@ export default function FileRenderFloating(props: Props) {
           'content__viewer--inline': !isFloating,
           'content__viewer--secondary': isComment,
           'content__viewer--theater-mode': !isFloating && videoTheaterMode,
+          'content__viewer--disable-click': wasDragging,
         })}
         style={
           !isFloating && fileViewerRect

--- a/ui/scss/component/_content.scss
+++ b/ui/scss/component/_content.scss
@@ -4,6 +4,10 @@
   top: var(--spacing-s);
 }
 
+.content__viewer--disable-click {
+  pointer-events: none;
+}
+
 .content__viewer--inline {
   max-height: var(--inline-player-max-height);
   border: none;


### PR DESCRIPTION
## Fixes

Issue Number:206

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
Dragging the floating video player plays/pauses the video upon release.

## What is the new behavior?
Dragging the floating video player no longer plays/pauses the video upon release.

## Other information

I tried to use event.preventDefault on the click handler but that didn't 
work. So instead I'm using css 'pointer-events: none' to disable click 
events on the player while the player is being dragged.

https://github.com/OdyseeTeam/odysee-frontend/issues/206

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
