### PR TITLE
Handle huge superchat list

### DIFF
--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -49,7 +49,7 @@ function ChannelThumbnail(props: Props) {
     ThumbUploadError,
   } = props;
   const [thumbLoadError, setThumbLoadError] = React.useState(ThumbUploadError);
-  const shouldResolve = claim === undefined;
+  const shouldResolve = !isResolving && claim === undefined;
   const thumbnail = rawThumbnail && rawThumbnail.trim().replace(/^http:\/\//i, 'https://');
   const thumbnailPreview = rawThumbnailPreview && rawThumbnailPreview.trim().replace(/^http:\/\//i, 'https://');
   const defaultAvatar = AVATAR_DEFAULT || Gerbil;

--- a/ui/component/commentsList/index.js
+++ b/ui/component/commentsList/index.js
@@ -4,7 +4,7 @@ import {
   makeSelectClaimForUri,
   makeSelectClaimIsMine,
   selectFetchingMyChannels,
-  selectMyChannelClaims,
+  selectMyClaimIdsRaw,
 } from 'redux/selectors/claims';
 import {
   selectTopLevelCommentsForUri,
@@ -35,7 +35,7 @@ const select = (state, props) => {
   return {
     topLevelComments,
     resolvedComments,
-    myChannels: selectMyChannelClaims(state),
+    myChannelIds: selectMyClaimIdsRaw(state),
     allCommentIds: makeSelectCommentIdsForUri(props.uri)(state),
     pinnedComments: selectPinnedCommentsForUri(state, props.uri),
     topLevelTotalPages: makeSelectTopLevelTotalPagesForUri(props.uri)(state),

--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -35,7 +35,7 @@ type Props = {
   uri: string,
   claim: ?Claim,
   claimIsMine: boolean,
-  myChannels: ?Array<ChannelClaim>,
+  myChannelIds: ?Array<string>,
   isFetchingComments: boolean,
   isFetchingCommentsById: boolean,
   isFetchingReacts: boolean,
@@ -64,7 +64,7 @@ function CommentList(props: Props) {
     topLevelTotalPages,
     claim,
     claimIsMine,
-    myChannels,
+    myChannelIds,
     isFetchingComments,
     isFetchingReacts,
     linkedCommentId,
@@ -256,9 +256,7 @@ function CommentList(props: Props) {
         message={comment.comment}
         timePosted={comment.timestamp * 1000}
         claimIsMine={claimIsMine}
-        commentIsMine={
-          comment.channel_id && myChannels && myChannels.some(({ claim_id }) => claim_id === comment.channel_id)
-        }
+        commentIsMine={comment.channel_id && myChannelIds && myChannelIds.includes(comment.channel_id)}
         linkedCommentId={linkedCommentId}
         isPinned={comment.is_pinned}
         supportAmount={comment.support_amount}

--- a/ui/component/livestreamComments/index.js
+++ b/ui/component/livestreamComments/index.js
@@ -5,8 +5,8 @@ import { doCommentList, doSuperChatList } from 'redux/actions/comments';
 import {
   selectTopLevelCommentsForUri,
   selectIsFetchingComments,
-  makeSelectSuperChatsForUri,
-  makeSelectSuperChatTotalAmountForUri,
+  selectSuperChatsForUri,
+  selectSuperChatTotalAmountForUri,
   selectPinnedCommentsForUri,
 } from 'redux/selectors/comments';
 import LivestreamComments from './view';
@@ -18,8 +18,8 @@ const select = (state, props) => ({
   comments: selectTopLevelCommentsForUri(state, props.uri, MAX_LIVESTREAM_COMMENTS),
   pinnedComments: selectPinnedCommentsForUri(state, props.uri),
   fetchingComments: selectIsFetchingComments(state),
-  superChats: makeSelectSuperChatsForUri(props.uri)(state),
-  superChatsTotalAmount: makeSelectSuperChatTotalAmountForUri(props.uri)(state),
+  superChats: selectSuperChatsForUri(state, props.uri),
+  superChatsTotalAmount: selectSuperChatTotalAmountForUri(state, props.uri),
   myChannels: selectMyChannelClaims(state),
 });
 

--- a/ui/component/livestreamComments/index.js
+++ b/ui/component/livestreamComments/index.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { doResolveUris } from 'redux/actions/claims';
 import { selectClaimForUri, selectMyClaimIdsRaw } from 'redux/selectors/claims';
 import { doCommentSocketConnect, doCommentSocketDisconnect } from 'redux/actions/websocket';
 import { doCommentList, doSuperChatList } from 'redux/actions/comments';
@@ -28,4 +29,5 @@ export default connect(select, {
   doCommentSocketDisconnect,
   doCommentList,
   doSuperChatList,
+  doResolveUris,
 })(LivestreamComments);

--- a/ui/component/livestreamComments/index.js
+++ b/ui/component/livestreamComments/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { selectClaimForUri, selectMyChannelClaims } from 'redux/selectors/claims';
+import { selectClaimForUri, selectMyClaimIdsRaw } from 'redux/selectors/claims';
 import { doCommentSocketConnect, doCommentSocketDisconnect } from 'redux/actions/websocket';
 import { doCommentList, doSuperChatList } from 'redux/actions/comments';
 import {
@@ -20,7 +20,7 @@ const select = (state, props) => ({
   fetchingComments: selectIsFetchingComments(state),
   superChats: selectSuperChatsForUri(state, props.uri),
   superChatsTotalAmount: selectSuperChatTotalAmountForUri(state, props.uri),
-  myChannels: selectMyChannelClaims(state),
+  myChannelIds: selectMyClaimIdsRaw(state),
 });
 
 export default connect(select, {

--- a/ui/component/livestreamComments/view.jsx
+++ b/ui/component/livestreamComments/view.jsx
@@ -26,7 +26,7 @@ type Props = {
   fetchingComments: boolean,
   doSuperChatList: (string) => void,
   superChats: Array<Comment>,
-  myChannels: ?Array<ChannelClaim>,
+  myChannelIds: ?Array<string>,
 };
 
 const VIEW_MODE_CHAT = 'view_chat';
@@ -45,7 +45,7 @@ export default function LivestreamComments(props: Props) {
     doCommentList,
     fetchingComments,
     doSuperChatList,
-    myChannels,
+    myChannelIds,
     superChats: superChatsByTipAmount,
   } = props;
 
@@ -152,14 +152,7 @@ export default function LivestreamComments(props: Props) {
 
   // todo: implement comment_list --mine in SDK so redux can grab with selectCommentIsMine
   function isMyComment(channelId: string) {
-    if (myChannels != null && channelId != null) {
-      for (let i = 0; i < myChannels.length; i++) {
-        if (myChannels[i].claim_id === channelId) {
-          return true;
-        }
-      }
-    }
-    return false;
+    return myChannelIds ? myChannelIds.includes(channelId) : false;
   }
 
   if (!claim) {

--- a/ui/redux/reducers/claims.js
+++ b/ui/redux/reducers/claims.js
@@ -197,7 +197,7 @@ function handleClaimAction(state: State, action: any): State {
     claimsByUri: byUri,
     channelClaimCounts,
     resolvingUris: Array.from(newResolvingUrls),
-    myClaims: Array.from(myClaimIds),
+    ...(!state.myClaims || myClaimIds.size !== state.myClaims.length ? { myClaims: Array.from(myClaimIds) } : {}),
   });
 }
 

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -143,6 +143,9 @@ export const makeSelectClaimForUri = (uri: string, returnRepost: boolean = true)
     }
   });
 
+// Returns your claim IDs without handling pending and abandoned claims.
+export const selectMyClaimIdsRaw = (state: State) => selectState(state).myClaims;
+
 export const selectMyClaimsRaw = createSelector(selectState, selectClaimsById, (state, byId) => {
   const ids = state.myClaims;
   if (!ids) {

--- a/ui/redux/selectors/comments.js
+++ b/ui/redux/selectors/comments.js
@@ -4,7 +4,7 @@ import { createCachedSelector } from 're-reselect';
 import { selectMutedChannels } from 'redux/selectors/blocked';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import { selectBlacklistedOutpointMap, selectFilteredOutpointMap } from 'lbryinc';
-import { selectClaimsById, selectMyActiveClaims } from 'redux/selectors/claims';
+import { selectClaimsById, selectMyClaimIdsRaw } from 'redux/selectors/claims';
 import { isClaimNsfw } from 'util/claim';
 
 type State = { comments: CommentsState };
@@ -180,7 +180,7 @@ export const makeSelectCommentIdsForUri = (uri: string) =>
 
 const filterCommentsDepOnList = {
   claimsById: selectClaimsById,
-  myClaims: selectMyActiveClaims,
+  myClaimIds: selectMyClaimIdsRaw,
   mutedChannels: selectMutedChannels,
   personalBlockList: selectModerationBlockList,
   blacklistedMap: selectBlacklistedOutpointMap,
@@ -258,7 +258,7 @@ export const selectRepliesForParentId = createCachedSelector(
  *
  * @param comments List of comments to filter.
  * @param claimId The claim that `comments` reside in.
- * @oaram filterInputs Values returned by filterCommentsDepOnList.
+ * @param filterInputs Values returned by filterCommentsDepOnList.
  */
 const filterComments = (comments: Array<Comment>, claimId?: string, filterInputs: any) => {
   const filterProps = filterInputs.reduce(function (acc, cur, i) {
@@ -268,7 +268,7 @@ const filterComments = (comments: Array<Comment>, claimId?: string, filterInputs
 
   const {
     claimsById,
-    myClaims,
+    myClaimIds,
     mutedChannels,
     personalBlockList,
     blacklistedMap,
@@ -287,8 +287,8 @@ const filterComments = (comments: Array<Comment>, claimId?: string, filterInputs
 
         // Return comment if `channelClaim` doesn't exist so the component knows to resolve the author
         if (channelClaim) {
-          if (myClaims && myClaims.size > 0) {
-            const claimIsMine = channelClaim.is_my_output || myClaims.has(channelClaim.claim_id);
+          if (myClaimIds && myClaimIds.size > 0) {
+            const claimIsMine = channelClaim.is_my_output || myClaimIds.includes(channelClaim.claim_id);
             if (claimIsMine) {
               return true;
             }
@@ -308,7 +308,7 @@ const filterComments = (comments: Array<Comment>, claimId?: string, filterInputs
         }
 
         if (claimId) {
-          const claimIdIsMine = myClaims && myClaims.size > 0 && myClaims.has(claimId);
+          const claimIdIsMine = myClaimIds && myClaimIds.size > 0 && myClaimIds.includes(claimId);
           if (!claimIdIsMine) {
             if (personalBlockList.includes(comment.channel_url)) {
               return false;

--- a/ui/redux/selectors/comments.js
+++ b/ui/redux/selectors/comments.js
@@ -368,25 +368,17 @@ export const makeSelectUriIsBlockingOrUnBlocking = (uri: string) =>
     return blockingByUri[uri] || unBlockingByUri[uri];
   });
 
-export const makeSelectSuperChatDataForUri = (uri: string) =>
-  createSelector(selectSuperchatsByUri, (byUri) => {
-    return byUri[uri];
-  });
+export const selectSuperChatDataForUri = (state: State, uri: string) => {
+  const byUri = selectSuperchatsByUri(state);
+  return byUri[uri];
+};
 
-export const makeSelectSuperChatsForUri = (uri: string) =>
-  createSelector(makeSelectSuperChatDataForUri(uri), (superChatData) => {
-    if (!superChatData) {
-      return undefined;
-    }
+export const selectSuperChatsForUri = (state: State, uri: string) => {
+  const superChatData = selectSuperChatDataForUri(state, uri);
+  return superChatData ? superChatData.comments : undefined;
+};
 
-    return superChatData.comments;
-  });
-
-export const makeSelectSuperChatTotalAmountForUri = (uri: string) =>
-  createSelector(makeSelectSuperChatDataForUri(uri), (superChatData) => {
-    if (!superChatData) {
-      return 0;
-    }
-
-    return superChatData.totalAmount;
-  });
+export const selectSuperChatTotalAmountForUri = (state: State, uri: string) => {
+  const superChatData = selectSuperChatDataForUri(state, uri);
+  return superChatData ? superChatData.totalAmount : 0;
+};

--- a/ui/scss/component/_livestream.scss
+++ b/ui/scss/component/_livestream.scss
@@ -297,6 +297,11 @@ $recent-msg-button__height: 2rem;
 
 .livestream-superchats__inner {
   display: flex;
+
+  .close-button {
+    padding-left: var(--spacing-m);
+    padding-right: var(--spacing-l);
+  }
 }
 
 .livestream-superchat {


### PR DESCRIPTION
## Ticket
Closes [#210 livestream page lag / batch resolve comment claims? ](https://github.com/OdyseeTeam/odysee-frontend/issues/210)

## Root-cause
It's the classic store invalidation and re-render.  
- The superchat row is re-mounted on each render --> components call resolve --> invalidates the store (flags, etc) --> re-renders the gui --> The superchat row is re-mounted on each render --> rinse and repeat

If the resolve list is huge, the invalidation won't settle fast enough to cut the chain.

## Changes
- Fixed some of the invalidation stuff ... the remaining is hard to change without refactoring.
- Shortened initial superchat list to 10, and batch-resolve before opening the full list.

## Future
- Will need to paginate the list.
- Look into using Immutable.js in reducers to handle the invalidation issue.