### PR TITLE
Allow moderators to delete comment

### DIFF
--- a/flow-typed/Comment.js
+++ b/flow-typed/Comment.js
@@ -169,8 +169,10 @@ declare type CommentAbandonParams = {
   comment_id: string,
   creator_channel_id?: string,
   creator_channel_name?: string,
-  channel_id?: string,
-  hexdata?: string,
+  signature?: string,
+  signing_ts?: string,
+  mod_channel_id?: string,
+  mod_channel_name?: string,
 };
 
 declare type CommentCreateParams = {

--- a/ui/component/commentMenuList/index.js
+++ b/ui/component/commentMenuList/index.js
@@ -4,11 +4,7 @@ import { doCommentPin, doCommentModAddDelegate } from 'redux/actions/comments';
 import { doOpenModal } from 'redux/actions/app';
 import { doSetPlayingUri } from 'redux/actions/content';
 import { doToast } from 'redux/actions/notifications';
-import {
-  makeSelectChannelPermUrlForClaimUri,
-  makeSelectClaimIsMine,
-  makeSelectClaimForUri,
-} from 'redux/selectors/claims';
+import { makeSelectClaimIsMine, makeSelectClaimForUri } from 'redux/selectors/claims';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
 import { selectModerationDelegatorsById } from 'redux/selectors/comments';
 import { selectPlayingUri } from 'redux/selectors/content';
@@ -17,7 +13,6 @@ import CommentMenuList from './view';
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
   claimIsMine: makeSelectClaimIsMine(props.uri)(state),
-  contentChannelPermanentUrl: makeSelectChannelPermUrlForClaimUri(props.uri)(state),
   activeChannelClaim: selectActiveChannelClaim(state),
   playingUri: selectPlayingUri(state),
   moderationDelegatorsById: selectModerationDelegatorsById(state),

--- a/ui/component/commentMenuList/view.jsx
+++ b/ui/component/commentMenuList/view.jsx
@@ -24,7 +24,6 @@ type Props = {
   // --- select ---
   claim: ?Claim,
   claimIsMine: boolean,
-  contentChannelPermanentUrl: any,
   activeChannelClaim: ?ChannelClaim,
   playingUri: ?PlayingUri,
   moderationDelegatorsById: { [string]: { global: boolean, delegators: { name: string, claimId: string } } },
@@ -47,7 +46,6 @@ function CommentMenuList(props: Props) {
     commentIsMine,
     commentId,
     activeChannelClaim,
-    contentChannelPermanentUrl,
     isTopLevel,
     isPinned,
     playingUri,
@@ -71,6 +69,8 @@ function CommentMenuList(props: Props) {
   } = useHistory();
 
   const contentChannelClaim = getChannelFromClaim(claim);
+  const contentChannelPermanentUrl = contentChannelClaim && contentChannelClaim.permanent_url;
+
   const activeModeratorInfo = activeChannelClaim && moderationDelegatorsById[activeChannelClaim.claim_id];
   const activeChannelIsCreator = activeChannelClaim && activeChannelClaim.permanent_url === contentChannelPermanentUrl;
   const activeChannelIsAdmin = activeChannelClaim && activeModeratorInfo && activeModeratorInfo.global;
@@ -84,10 +84,12 @@ function CommentMenuList(props: Props) {
     if (playingUri && playingUri.source === 'comment') {
       clearPlayingUri();
     }
+
     openModal(MODALS.CONFIRM_REMOVE_COMMENT, {
       commentId,
-      commentIsMine,
-      contentChannelPermanentUrl,
+      deleterClaim: activeChannelClaim,
+      deleterIsModOrAdmin: activeChannelIsAdmin || activeChannelIsModerator,
+      creatorClaim: commentIsMine ? undefined : contentChannelClaim,
       supportAmount,
       setQuickReply,
     });
@@ -201,7 +203,8 @@ function CommentMenuList(props: Props) {
 
       {!disableRemove &&
         activeChannelClaim &&
-        (activeChannelClaim.permanent_url === authorUri ||
+        (activeChannelIsModerator ||
+          activeChannelClaim.permanent_url === authorUri ||
           activeChannelClaim.permanent_url === contentChannelPermanentUrl) && (
           <MenuItem className="comment__menu-option" onSelect={handleDeleteComment}>
             <div className="menu__link">

--- a/ui/modal/modalRemoveComment/index.js
+++ b/ui/modal/modalRemoveComment/index.js
@@ -3,9 +3,9 @@ import { doHideModal } from 'redux/actions/app';
 import ModalRemoveComment from './view';
 import { doCommentAbandon } from 'redux/actions/comments';
 
-const perform = (dispatch) => ({
-  closeModal: () => dispatch(doHideModal()),
-  deleteComment: (commentId, creatorChannelUrl) => dispatch(doCommentAbandon(commentId, creatorChannelUrl)),
-});
+const perform = {
+  doHideModal,
+  doCommentAbandon,
+};
 
 export default connect(null, perform)(ModalRemoveComment);

--- a/ui/modal/modalRemoveComment/view.jsx
+++ b/ui/modal/modalRemoveComment/view.jsx
@@ -6,27 +6,30 @@ import Card from 'component/common/card';
 
 type Props = {
   commentId: string, // sha256 digest identifying the comment
-  commentIsMine: boolean, // if this comment was signed by an owned channel
-  contentChannelPermanentUrl: any,
-  closeModal: () => void,
-  deleteComment: (string, ?string) => void,
+  deleterClaim: Claim,
+  deleterIsModOrAdmin?: boolean,
+  creatorClaim?: Claim,
   supportAmount?: any,
   setQuickReply: (any) => void,
+  // --- redux ---
+  doHideModal: () => void,
+  doCommentAbandon: (string, Claim, ?boolean, ?Claim) => void,
 };
 
 function ModalRemoveComment(props: Props) {
   const {
     commentId,
-    commentIsMine,
-    contentChannelPermanentUrl,
-    closeModal,
-    deleteComment,
+    deleterClaim,
+    deleterIsModOrAdmin,
+    creatorClaim,
     supportAmount,
     setQuickReply,
+    doHideModal,
+    doCommentAbandon,
   } = props;
 
   return (
-    <Modal isOpen contentLabel={__('Confirm Comment Deletion')} type="card" onAborted={closeModal}>
+    <Modal isOpen contentLabel={__('Confirm Comment Deletion')} type="card" onAborted={doHideModal}>
       <Card
         title={__('Remove Comment')}
         body={
@@ -46,12 +49,14 @@ function ModalRemoveComment(props: Props) {
                 button="primary"
                 label={__('Remove')}
                 onClick={() => {
-                  closeModal();
-                  deleteComment(commentId, commentIsMine ? undefined : contentChannelPermanentUrl);
-                  if (setQuickReply) setQuickReply(undefined);
+                  doHideModal();
+                  doCommentAbandon(commentId, deleterClaim, deleterIsModOrAdmin, creatorClaim);
+                  if (setQuickReply) {
+                    setQuickReply(undefined);
+                  }
                 }}
               />
-              <Button button="link" label={__('Cancel')} onClick={closeModal} />
+              <Button button="link" label={__('Cancel')} onClick={doHideModal} />
             </div>
           </>
         }


### PR DESCRIPTION
## Ticket
Closes [#223 Add ability for delegated moderators to delete comments](https://github.com/OdyseeTeam/odysee-frontend/issues/223)

## Note
I believe the API also allows Admins to delete as well, but wasn't sure if that's what we want, so I left that out.
If yes, it's just another 1-liner to allow it.

## Changes
- Refactored doCommentAbandon's signature so we don't end up converting between "uri" and "Claim" several times and needing to lookup redux when the client can already provide us the exact values that we need.
- Pass the new moderator fields to the API.
- Remove the need to call 'makeSelectChannelPermUrlForClaimUri' since it's a simple field query when we already have the claim.

## Test
`kp`
