### PR TITLE
`byId[]` fixes to reduce invalidation

### DIFF
--- a/ui/redux/selectors/app.js
+++ b/ui/redux/selectors/app.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { selectClaimsById, selectMyChannelClaims, makeSelectStakedLevelForChannelUri } from 'redux/selectors/claims';
+import { selectClaimWithId, selectMyChannelClaims, makeSelectStakedLevelForChannelUri } from 'redux/selectors/claims';
 
 export const selectState = (state) => state.app || {};
 
@@ -70,15 +70,13 @@ export const selectSplashAnimationEnabled = (state) => selectState(state).splash
 export const selectActiveChannelId = (state) => selectState(state).activeChannel;
 
 export const selectActiveChannelClaim = createSelector(
-  selectActiveChannelId,
-  selectClaimsById,
+  (state) => selectClaimWithId(state, selectActiveChannelId(state)), // i.e. 'byId[activeChannelId]' specifically, instead of just 'byId'.
   selectMyChannelClaims,
-  (activeChannelClaimId, claimsById, myChannelClaims) => {
-    if (!activeChannelClaimId || !claimsById || !myChannelClaims || !myChannelClaims.length) {
+  (activeChannelClaim, myChannelClaims) => {
+    if (!activeChannelClaim || !myChannelClaims || !myChannelClaims.length) {
       return undefined;
     }
 
-    const activeChannelClaim = claimsById[activeChannelClaimId];
     if (activeChannelClaim) {
       return activeChannelClaim;
     }

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -419,14 +419,26 @@ export const selectFetchingMyCollections = (state: State) => selectState(state).
 
 export const selectMyChannelClaimIds = (state: State) => selectState(state).myChannelClaims;
 
-export const selectMyChannelClaims = createSelector(selectState, selectClaimsById, (state, byId) => {
-  const ids = state.myChannelClaims;
-  if (!ids) {
-    return ids;
+export const selectMyChannelClaims = createSelector(selectMyChannelClaimIds, (myChannelClaimIds) => {
+  if (!myChannelClaimIds) {
+    return myChannelClaimIds;
   }
 
+  if (!window || !window.store) {
+    return undefined;
+  }
+
+  // Note: Grabbing the store and running the selector this way is anti-pattern,
+  // but it is _needed_ and works only because we know for sure that 'byId[]'
+  // will be populated with the same claims as when 'myChannelClaimIds' is populated.
+  // If we put 'state' or 'byId' as the input selector, it essentially
+  // recalculates every time. Putting 'state' as input to createSelector() is
+  // always wrong from a memoization standpoint.
+  const state = window.store.getState();
+  const byId = selectClaimsById(state);
+
   const claims = [];
-  ids.forEach((id) => {
+  myChannelClaimIds.forEach((id) => {
     if (byId[id]) {
       // I'm not sure why this check is necessary, but it ought to be a quick fix for https://github.com/lbryio/lbry-desktop/issues/544
       claims.push(byId[id]);

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -43,6 +43,21 @@ export const selectClaimsByUri = createSelector(selectClaimIdsByUri, selectClaim
   return claims;
 });
 
+/**
+ * Returns the claim with the specified ID. The claim could be undefined if does
+ * not exist or have not fetched. Take note of the second parameter, which means
+ * an inline function or helper would be required when used as an input to
+ * 'createSelector'.
+ *
+ * @param state
+ * @param claimId
+ * @returns {*}
+ */
+export const selectClaimWithId = (state: State, claimId: string) => {
+  const byId = selectClaimsById(state);
+  return byId[claimId];
+};
+
 export const selectAllClaimsByChannel = createSelector(selectState, (state) => state.paginatedClaimsByChannel || {});
 
 export const selectPendingIds = createSelector(selectState, (state) => Object.keys(state.pendingById) || []);


### PR DESCRIPTION
Closes #116

See commit messages for full details, but it's basically it's `byId[]` invalidation fixes, then fixing up 2 frequently-running selectors as a test.  

There are lots of others selectors that depend on byId.  Will continue with the rest once this is passes, as the rest would just be a rinse-and-repeat operation of cleaning up the selectors.

## Test
`kp`