### PR TITLE
Avoid user_state_populate when there is no change.

### DIFF
--- a/ui/component/app/index.js
+++ b/ui/component/app/index.js
@@ -22,15 +22,9 @@ import {
   selectIsReloadRequired,
 } from 'redux/selectors/app';
 import { selectUploadCount } from 'redux/selectors/publish';
-import { doGetWalletSyncPreference, doSetLanguage } from 'redux/actions/settings';
+import { doSetLanguage } from 'redux/actions/settings';
 import { doSyncLoop } from 'redux/actions/sync';
-import {
-  doDownloadUpgradeRequested,
-  doSignIn,
-  doGetAndPopulatePreferences,
-  doSetActiveChannel,
-  doSetIncognito,
-} from 'redux/actions/app';
+import { doDownloadUpgradeRequested, doSignIn, doSetActiveChannel, doSetIncognito } from 'redux/actions/app';
 import { doFetchModBlockedList, doFetchCommentModAmIList } from 'redux/actions/comments';
 import App from './view';
 
@@ -62,8 +56,6 @@ const perform = (dispatch) => ({
   setLanguage: (language) => dispatch(doSetLanguage(language)),
   signIn: () => dispatch(doSignIn()),
   requestDownloadUpgrade: () => dispatch(doDownloadUpgradeRequested()),
-  updatePreferences: () => dispatch(doGetAndPopulatePreferences()),
-  getWalletSyncPref: () => dispatch(doGetWalletSyncPreference()),
   syncLoop: (noInterval) => dispatch(doSyncLoop(noInterval)),
   setReferrer: (referrer, doClaim) => dispatch(doUserSetReferrer(referrer, doClaim)),
   setActiveChannelIfNotSet: () => dispatch(doSetActiveChannel()),

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -543,6 +543,7 @@ export function doSignIn() {
       pushNotifications.validate(user.id);
     }
 
+    dispatch(doGetAndPopulatePreferences());
     dispatch(doNotificationSocketConnect(true));
     dispatch(doNotificationList());
     dispatch(doCheckPendingClaims());
@@ -674,9 +675,8 @@ export function doGetAndPopulatePreferences() {
 export function doHandleSyncComplete(error, hasNewData) {
   return (dispatch) => {
     if (!error) {
-      dispatch(doGetAndPopulatePreferences());
-
       if (hasNewData) {
+        dispatch(doGetAndPopulatePreferences());
         // we just got sync data, better update our channels
         dispatch(doFetchChannelListMine());
       }

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -9,7 +9,7 @@ import * as MODALS from 'constants/modal_types';
 import * as SETTINGS from 'constants/settings';
 import * as DAEMON_SETTINGS from 'constants/daemon_settings';
 import * as SHARED_PREFERENCES from 'constants/shared_preferences';
-import { DOMAIN, SIMPLE_SITE } from 'config';
+import { DOMAIN } from 'config';
 import Lbry from 'lbry';
 import { doFetchChannelListMine, doFetchCollectionListMine, doCheckPendingClaims } from 'redux/actions/claims';
 import { selectClaimForUri, selectClaimIsMineForUri, selectMyChannelClaims } from 'redux/selectors/claims';
@@ -543,20 +543,12 @@ export function doSignIn() {
       pushNotifications.validate(user.id);
     }
 
-    const notificationsEnabled = SIMPLE_SITE || user.experimental_ui;
-
-    dispatch(doNotificationSocketConnect(notificationsEnabled));
-
-    if (notificationsEnabled) {
-      dispatch(doNotificationList());
-    }
+    dispatch(doNotificationSocketConnect(true));
+    dispatch(doNotificationList());
     dispatch(doCheckPendingClaims());
-
-    // @if TARGET='web'
     dispatch(doBalanceSubscribe());
     dispatch(doFetchChannelListMine());
     dispatch(doFetchCollectionListMine());
-    // @endif
   };
 }
 

--- a/ui/redux/actions/sync.js
+++ b/ui/redux/actions/sync.js
@@ -4,7 +4,12 @@ import * as SETTINGS from 'constants/settings';
 import { Lbryio } from 'lbryinc';
 import Lbry from 'lbry';
 import { doWalletEncrypt, doWalletDecrypt } from 'redux/actions/wallet';
-import { selectGetSyncIsPending, selectSetSyncIsPending, selectSyncIsLocked } from 'redux/selectors/sync';
+import {
+  selectSyncHash,
+  selectGetSyncIsPending,
+  selectSetSyncIsPending,
+  selectSyncIsLocked,
+} from 'redux/selectors/sync';
 import { makeSelectClientSetting } from 'redux/selectors/settings';
 import { getSavedPassword, getAuthToken } from 'util/saved-passwords';
 import { doAnalyticsTagSync, doHandleSyncComplete } from 'redux/actions/app';
@@ -166,7 +171,10 @@ export function doGetSync(passedPassword?: string, callback?: (any, ?boolean) =>
   }
   // @endif
 
-  return (dispatch: Dispatch) => {
+  return (dispatch: Dispatch, getState: GetState) => {
+    const state = getState();
+    const localHash = selectSyncHash(state);
+
     dispatch({
       type: ACTIONS.GET_SYNC_STARTED,
     });
@@ -194,7 +202,7 @@ export function doGetSync(passedPassword?: string, callback?: (any, ?boolean) =>
         const syncHash = response.hash;
         data.syncHash = syncHash;
         data.syncData = response.data;
-        data.changed = response.changed;
+        data.changed = response.changed || syncHash !== localHash;
         data.hasSyncedWallet = true;
 
         if (response.changed) {

--- a/ui/redux/reducers/blocked.js
+++ b/ui/redux/reducers/blocked.js
@@ -26,14 +26,6 @@ export default handleActions(
     [ACTIONS.USER_STATE_POPULATE]: (state: BlocklistState, action: { data: { blocked: ?Array<string> } }) => {
       const { blocked } = action.data;
       const sanitizedBlocked = blocked && blocked.filter((e) => typeof e === 'string');
-
-      const next = sanitizedBlocked;
-      const prev = state.blockedChannels;
-
-      if (next && prev && prev.length === next.length && prev.every((value, index) => value === next[index])) {
-        return state;
-      }
-
       return {
         ...state,
         blockedChannels: sanitizedBlocked || state.blockedChannels,

--- a/ui/redux/reducers/tags.js
+++ b/ui/redux/reducers/tags.js
@@ -65,15 +65,7 @@ export default handleActions(
     [ACTIONS.USER_STATE_POPULATE]: (state: TagState, action: { data: { tags: ?Array<string> } }) => {
       const { tags } = action.data;
       if (Array.isArray(tags)) {
-        const next = tags && tags.filter((tag) => typeof tag === 'string');
-        const prev = state.followedTags;
-
-        if (next && prev && prev.length === next.length && prev.every((value, index) => value === next[index])) {
-          // No changes
-          return state;
-        }
-
-        // New state
+        const next = tags.filter((tag) => typeof tag === 'string');
         return {
           ...state,
           followedTags: next || [],


### PR DESCRIPTION
## Issue
Every time the app goes into focus and syncs, the GUI updates and does a lot of re-calculations even when the sync hash indicates "no change".

## Changes
At first, I moved `doGetAndPopulated` preferences under the `hasNewData` if-block, since from the function standpoint, it makes sense to not update when there is no new data.

However, I realized the app is stuck in the "still preparing" state at startup, which probably means that it needs to populate at least once.

I found a place that already does that one-off action, but it's for Desktop only. Enabling that does fix the issue, but I think `getWalletSyncPref` is for Desktop only, so I did a simpler version that just updates the prefs.