### PR TITLE
Fix livestream state issues. Create unified long polling mechanism.

### DIFF
--- a/ui/component/claimPreview/index.js
+++ b/ui/component/claimPreview/index.js
@@ -22,23 +22,21 @@ import { doResolveUri } from 'redux/actions/claims';
 import { doCollectionEdit } from 'redux/actions/collections';
 import { doFileGet } from 'redux/actions/file';
 import { selectBanStateForUri } from 'lbryinc';
+import { makeSelectIsActiveLivestream } from 'redux/selectors/livestream';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import { makeSelectHasVisitedUri } from 'redux/selectors/content';
 import { makeSelectIsSubscribed } from 'redux/selectors/subscriptions';
 import ClaimPreview from './view';
 import formatMediaDuration from 'util/formatMediaDuration';
-import { selectActiveChannelClaim } from 'redux/selectors/app';
 
 const select = (state, props) => {
   const claim = props.uri && selectClaimForUri(state, props.uri);
-  const { claim_id: channelId } = selectActiveChannelClaim(state) || {};
   const media = claim && claim.value && (claim.value.video || claim.value.audio);
   const mediaDuration = media && media.duration && formatMediaDuration(media.duration, { screenReader: true });
 
   return {
     claim,
     mediaDuration,
-    channelId,
     date: props.uri && selectDateForUri(state, props.uri),
     title: props.uri && makeSelectTitleForUri(props.uri)(state),
     pending: props.uri && makeSelectClaimIsPending(props.uri)(state),
@@ -54,6 +52,7 @@ const select = (state, props) => {
     streamingUrl: props.uri && makeSelectStreamingUrlForUri(props.uri)(state),
     wasPurchased: props.uri && makeSelectClaimWasPurchased(props.uri)(state),
     isLivestream: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
+    isLivestreamActive: makeSelectIsActiveLivestream(props.uri)(state),
     isCollectionMine: makeSelectCollectionIsMine(props.collectionId)(state),
     collectionUris: makeSelectUrlsForCollectionId(props.collectionId)(state),
     collectionIndex: makeSelectIndexForUrlInCollection(props.uri, props.collectionId)(state),

--- a/ui/component/claimPreview/index.js
+++ b/ui/component/claimPreview/index.js
@@ -22,21 +22,23 @@ import { doResolveUri } from 'redux/actions/claims';
 import { doCollectionEdit } from 'redux/actions/collections';
 import { doFileGet } from 'redux/actions/file';
 import { selectBanStateForUri } from 'lbryinc';
-import { makeSelectIsActiveLivestream } from 'redux/selectors/livestream';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import { makeSelectHasVisitedUri } from 'redux/selectors/content';
 import { makeSelectIsSubscribed } from 'redux/selectors/subscriptions';
 import ClaimPreview from './view';
 import formatMediaDuration from 'util/formatMediaDuration';
+import { selectActiveChannelClaim } from 'redux/selectors/app';
 
 const select = (state, props) => {
   const claim = props.uri && selectClaimForUri(state, props.uri);
+  const { claim_id: channelId } = selectActiveChannelClaim(state) || {};
   const media = claim && claim.value && (claim.value.video || claim.value.audio);
   const mediaDuration = media && media.duration && formatMediaDuration(media.duration, { screenReader: true });
 
   return {
     claim,
     mediaDuration,
+    channelId,
     date: props.uri && selectDateForUri(state, props.uri),
     title: props.uri && makeSelectTitleForUri(props.uri)(state),
     pending: props.uri && makeSelectClaimIsPending(props.uri)(state),
@@ -52,7 +54,6 @@ const select = (state, props) => {
     streamingUrl: props.uri && makeSelectStreamingUrlForUri(props.uri)(state),
     wasPurchased: props.uri && makeSelectClaimWasPurchased(props.uri)(state),
     isLivestream: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
-    isLivestreamActive: makeSelectIsActiveLivestream(props.uri)(state),
     isCollectionMine: makeSelectCollectionIsMine(props.collectionId)(state),
     collectionUris: makeSelectUrlsForCollectionId(props.collectionId)(state),
     collectionIndex: makeSelectIndexForUrlInCollection(props.uri, props.collectionId)(state),

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -1,6 +1,6 @@
 // @flow
 import type { Node } from 'react';
-import React, { useEffect, forwardRef, useState } from 'react';
+import React, { useEffect, forwardRef } from 'react';
 import { NavLink, withRouter } from 'react-router-dom';
 import { isEmpty } from 'util/object';
 import { lazyImport } from 'util/lazyImport';
@@ -31,7 +31,6 @@ import ClaimPreviewNoContent from './claim-preview-no-content';
 import { ENABLE_NO_SOURCE_CLAIMS } from 'config';
 import Button from 'component/button';
 import * as ICONS from 'constants/icons';
-import watchLivestreamStatus from '$web/src/livestreaming/long-polling';
 
 const AbandonedChannelPreview = lazyImport(() =>
   import('component/abandonedChannelPreview' /* webpackChunkName: "abandonedChannelPreview" */)
@@ -41,7 +40,6 @@ const AbandonedChannelPreview = lazyImport(() =>
 type Props = {
   uri: string,
   claim: ?Claim,
-  channelId: string,
   active: boolean,
   obscureNsfw: boolean,
   showUserBlocked: boolean,
@@ -76,6 +74,7 @@ type Props = {
   repostUrl?: string,
   hideMenu?: boolean,
   isLivestream?: boolean,
+  isLivestreamActive: boolean,
   collectionId?: string,
   editCollection: (string, CollectionEditParams) => void,
   isCollectionMine: boolean,
@@ -93,7 +92,6 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     // core
     uri,
     claim,
-    channelId,
     isResolvingUri,
     // core actions
     getFile,
@@ -138,6 +136,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     hideMenu = false,
     // repostUrl,
     isLivestream,
+    isLivestreamActive,
     collectionId,
     collectionIndex,
     editCollection,
@@ -147,13 +146,6 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     indexInContainer,
     channelSubCount,
   } = props;
-
-  const [isLivestreamActive, setIsLivestreamActive] = useState(false);
-
-  useEffect(() => {
-    if (!isLivestream) return;
-    return watchLivestreamStatus(channelId, (state) => setIsLivestreamActive(state));
-  }, [channelId, setIsLivestreamActive, isLivestream]);
 
   const isCollection = claim && claim.value_type === 'collection';
   const collectionClaimId = isCollection && claim && claim.claim_id;
@@ -491,7 +483,8 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
           </div>
         </div>
 
-        {claim && isLivestream && isLivestreamActive && <ClaimPreviewReset uri={uri} />}
+        {/* Todo: check isLivestreamActive once we have that data consistently everywhere. */}
+        {claim && isLivestream && <ClaimPreviewReset uri={uri} />}
 
         {!hideMenu && <ClaimMenuList uri={uri} collectionId={listId} />}
       </>

--- a/ui/component/claimPreviewReset/index.js
+++ b/ui/component/claimPreviewReset/index.js
@@ -1,13 +1,15 @@
 import { connect } from 'react-redux';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
+import { makeSelectClaimIsMine } from 'redux/selectors/claims';
 import { doToast } from 'redux/actions/notifications';
 import ClaimPreviewReset from './view';
 
-const select = (state) => {
+const select = (state, props) => {
   const { claim_id: channelId, name: channelName } = selectActiveChannelClaim(state) || {};
   return {
     channelName,
     channelId,
+    claimIsMine: props.uri && makeSelectClaimIsMine(props.uri)(state),
   };
 };
 

--- a/ui/component/claimPreviewReset/view.jsx
+++ b/ui/component/claimPreviewReset/view.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { SITE_HELP_EMAIL } from 'config';
 import Button from 'component/button';
 import { killStream } from '$web/src/livestreaming';
+import watchLivestreamStatus from '$web/src/livestreaming/long-polling';
 import 'scss/component/claim-preview-reset.scss';
 
 type Props = {
@@ -16,7 +17,13 @@ type Props = {
 const ClaimPreviewReset = (props: Props) => {
   const { channelId, channelName, claimIsMine, doToast } = props;
 
-  if (!claimIsMine) return null;
+  const [isLivestreaming, setIsLivestreaming] = React.useState(false);
+
+  React.useEffect(() => {
+    return watchLivestreamStatus(channelId, (state) => setIsLivestreaming(state));
+  }, [channelId, setIsLivestreaming]);
+
+  if (!claimIsMine || !isLivestreaming) return null;
 
   const handleClick = async () => {
     try {

--- a/ui/component/claimPreviewReset/view.jsx
+++ b/ui/component/claimPreviewReset/view.jsx
@@ -1,65 +1,26 @@
 // @flow
 
 import React from 'react';
-import Lbry from 'lbry';
-import { LIVESTREAM_KILL } from 'constants/livestream';
 import { SITE_HELP_EMAIL } from 'config';
-import { toHex } from 'util/hex';
 import Button from 'component/button';
+import { killStream } from '$web/src/livestreaming';
 import 'scss/component/claim-preview-reset.scss';
-
-// @Todo: move out of component.
-const getStreamData = async (channelId: string, channelName: string) => {
-  if (!channelId || !channelName) throw new Error('Invalid channel data provided.');
-
-  const channelNameHex = toHex(channelName);
-  let channelSignature;
-
-  try {
-    channelSignature = await Lbry.channel_sign({ channel_id: channelId, hexdata: channelNameHex });
-    if (!channelSignature || !channelSignature.signature || !channelSignature.signing_ts) {
-      throw new Error('Error getting channel signature.');
-    }
-  } catch (e) {
-    throw e;
-  }
-
-  return {
-    d: channelNameHex,
-    s: channelSignature.signature,
-    t: channelSignature.signing_ts,
-  };
-};
-
-// @Todo: move out of component.
-const killStream = async (channelId: string, payload: any) => {
-  fetch(`${LIVESTREAM_KILL}/${channelId}`, {
-    method: 'POST',
-    mode: 'no-cors',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams(payload),
-  })
-    .then((res) => {
-      if (!res.status === 200) throw new Error('Kill stream API failed.');
-    })
-    .catch((e) => {
-      throw e;
-    });
-};
 
 type Props = {
   channelId: string,
   channelName: string,
+  claimIsMine: boolean,
   doToast: ({ message: string, isError?: boolean }) => void,
 };
 
 const ClaimPreviewReset = (props: Props) => {
-  const { channelId, channelName, doToast } = props;
+  const { channelId, channelName, claimIsMine, doToast } = props;
+
+  if (!claimIsMine) return null;
 
   const handleClick = async () => {
     try {
-      const streamData = await getStreamData(channelId, channelName);
-      await killStream(channelId, streamData);
+      await killStream(channelId, channelName);
       doToast({ message: __('Live stream successfully reset.'), isError: false });
     } catch {
       doToast({ message: __('There was an error resetting the live stream.'), isError: true });

--- a/ui/component/fileSubtitle/view.jsx
+++ b/ui/component/fileSubtitle/view.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import DateTime from 'component/dateTime';
 import FileViewCount from 'component/fileViewCount';
 import FileActions from 'component/fileActions';
+import ClaimPreviewReset from 'component/claimPreviewReset';
 
 type Props = {
   uri: string,
@@ -15,15 +16,18 @@ function FileSubtitle(props: Props) {
   const { uri, livestream = false, activeViewers, isLive = false } = props;
 
   return (
-    <div className="media__subtitle--between">
-      <div className="file__viewdate">
-        {livestream ? <span>{__('Right now')}</span> : <DateTime uri={uri} show={DateTime.SHOW_DATE} />}
+    <>
+      <div className="media__subtitle--between">
+        <div className="file__viewdate">
+          {livestream ? <span>{__('Right now')}</span> : <DateTime uri={uri} show={DateTime.SHOW_DATE} />}
 
-        <FileViewCount uri={uri} livestream={livestream} activeViewers={activeViewers} isLive={isLive} />
+          <FileViewCount uri={uri} livestream={livestream} activeViewers={activeViewers} isLive={isLive} />
+        </div>
+
+        <FileActions uri={uri} hideRepost={livestream} livestream={livestream} />
       </div>
-
-      <FileActions uri={uri} hideRepost={livestream} livestream={livestream} />
-    </div>
+      {livestream && isLive && <ClaimPreviewReset uri={uri} />}
+    </>
   );
 }
 

--- a/ui/scss/component/claim-preview-reset.scss
+++ b/ui/scss/component/claim-preview-reset.scss
@@ -3,6 +3,7 @@
 .claimPreviewReset {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   padding-top: var(--spacing-xs);
   color: var(--color-text-subtitle);
   font-size: var(--font-small);

--- a/web/src/livestreaming/index.js
+++ b/web/src/livestreaming/index.js
@@ -1,0 +1,55 @@
+// @flow
+
+import Lbry from 'lbry';
+import { LIVESTREAM_KILL, LIVESTREAM_LIVE_API } from 'constants/livestream';
+import { toHex } from 'util/hex';
+
+type StreamData = {
+  d: string,
+  s: string,
+  t: string,
+};
+
+export const getStreamData = async (channelId: string, channelName: string): Promise<StreamData> => {
+  if (!channelId || !channelName) throw new Error('Invalid channel data provided.');
+
+  const channelNameHex = toHex(channelName);
+  let channelSignature;
+
+  try {
+    channelSignature = await Lbry.channel_sign({ channel_id: channelId, hexdata: channelNameHex });
+    if (!channelSignature || !channelSignature.signature || !channelSignature.signing_ts) {
+      throw new Error('Error getting channel signature.');
+    }
+  } catch (e) {
+    throw e;
+  }
+
+  return { d: channelNameHex, s: channelSignature.signature, t: channelSignature.signing_ts };
+};
+
+export const killStream = async (channelId: string, channelName: string) => {
+  try {
+    const streamData = await getStreamData(channelId, channelName);
+    fetch(`${LIVESTREAM_KILL}/${channelId}`, {
+      method: 'POST',
+      mode: 'no-cors',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams(streamData),
+    }).then((res) => {
+      if (res.status !== 200) throw new Error('Kill stream API failed.');
+    });
+  } catch (e) {
+    throw e;
+  }
+};
+
+export const isLiveStreaming = async (channelId: string): Promise<boolean> => {
+  try {
+    const response = await fetch(`${LIVESTREAM_LIVE_API}/${channelId}`);
+    const stream = await response.json();
+    return stream.data?.live;
+  } catch {
+    return false;
+  }
+};

--- a/web/src/livestreaming/long-polling.js
+++ b/web/src/livestreaming/long-polling.js
@@ -1,0 +1,67 @@
+// @flow
+
+/*
+ * This module is responsible for long polling the server to determine if a channel is actively streaming.
+ *
+ * One or many entities can subscribe to the live status while instantiating just one long poll interval per channel.
+ * Once all interested parties have disconnected the poll will shut down. For this reason, be sure to always call the
+ * disconnect function returned upon connecting.
+ */
+
+import { isLiveStreaming } from '$web/src/livestreaming';
+
+const POLL_INTERVAL = 10000;
+const pollers = {};
+
+const pollingMechanism = {
+  streaming: false,
+
+  startPolling() {
+    if (this.interval !== 0) return;
+    const poll = async () => {
+      this.streaming = await isLiveStreaming(this.channelId);
+      this.subscribers.forEach((cb) => {
+        if (cb) cb(this.streaming);
+      });
+    };
+    poll();
+    this.interval = setInterval(poll, POLL_INTERVAL);
+  },
+
+  stopPolling() {
+    clearInterval(this.interval);
+    this.interval = 0;
+  },
+
+  connect(cb): number {
+    cb(this.streaming);
+    this.startPolling();
+    return this.subscribers.push(cb) - 1;
+  },
+
+  disconnect(subscriberIndex: number) {
+    this.subscribers[subscriberIndex] = null;
+    if (this.subscribers.every((item) => item === null)) {
+      this.stopPolling();
+      delete pollers[this.channelId];
+    }
+  },
+};
+
+const generateLongPoll = (channelId: string) => {
+  if (pollers[channelId]) return pollers[channelId];
+
+  pollers[channelId] = Object.create({
+    channelId,
+    interval: 0,
+    subscribers: [],
+    ...pollingMechanism,
+  });
+  return pollers[channelId];
+};
+
+export default (channelId: string, cb: (boolean) => void) => {
+  const poll = generateLongPoll(channelId);
+  const subscriberIndex = poll.connect(cb);
+  return () => poll.disconnect(subscriberIndex);
+};

--- a/web/src/livestreaming/long-polling.js
+++ b/web/src/livestreaming/long-polling.js
@@ -60,8 +60,11 @@ const generateLongPoll = (channelId: string) => {
   return pollers[channelId];
 };
 
-export default (channelId: string, cb: (boolean) => void) => {
+const watchLivestreamStatus = (channelId: ?string, cb: (boolean) => void) => {
+  if (!channelId || typeof cb !== 'function') return undefined;
   const poll = generateLongPoll(channelId);
   const subscriberIndex = poll.connect(cb);
   return () => poll.disconnect(subscriberIndex);
 };
+
+export default watchLivestreamStatus;


### PR DESCRIPTION
## Fixes

Issue Number:

1) 
- Move long polling mechanism out of React components and in to reusable module.

2) 
- Kill switch now uses long polling and shows only when stream is active. 
- Also shows on watch page. 

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

## What is the new behavior?

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
