### PR TITLE
Remove mouse-back/forward listeners

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -46,10 +46,6 @@ const SyncFatalError = lazyImport(() => import('component/syncFatalError' /* web
 export const MAIN_WRAPPER_CLASS = 'main-wrapper';
 export const IS_MAC = navigator.userAgent.indexOf('Mac OS X') !== -1;
 
-// button numbers pulled from https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
-const MOUSE_BACK_BTN = 3;
-const MOUSE_FORWARD_BTN = 4;
-
 const imaLibraryPath = 'https://imasdk.googleapis.com/js/sdkloader/ima3.js';
 
 type Props = {
@@ -58,13 +54,7 @@ type Props = {
   theme: string,
   user: ?{ id: string, has_verified_email: boolean, is_reward_approved: boolean },
   location: { pathname: string, hash: string, search: string },
-  history: {
-    goBack: () => void,
-    goForward: () => void,
-    index: number,
-    length: number,
-    push: (string) => void,
-  },
+  history: { push: (string) => void },
   fetchAccessToken: () => void,
   fetchChannelListMine: () => void,
   fetchCollectionListMine: () => void,
@@ -195,22 +185,6 @@ function App(props: Props) {
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [uploadCount]);
-
-  // allows user to navigate history using the forward and backward buttons on a mouse
-  useEffect(() => {
-    const handleForwardAndBackButtons = (e) => {
-      switch (e.button) {
-        case MOUSE_BACK_BTN:
-          history.index > 0 && history.goBack();
-          break;
-        case MOUSE_FORWARD_BTN:
-          history.index < history.length - 1 && history.goForward();
-          break;
-      }
-    };
-    window.addEventListener('mouseup', handleForwardAndBackButtons);
-    return () => window.removeEventListener('mouseup', handleForwardAndBackButtons);
-  });
 
   // allows user to pause miniplayer using the spacebar without the page scrolling down
   useEffect(() => {


### PR DESCRIPTION
- Not needed for web since the browser does it, and should have been gated under 'app'
- This reverts lbry-desktop 3744.