### PR TITLE
`selectClaimIsMineForUri` to replace `makeSelectClaimIsMine`

### DIFF
--- a/ui/component/channelContent/index.js
+++ b/ui/component/channelContent/index.js
@@ -3,7 +3,7 @@ import { PAGE_SIZE } from 'constants/claim';
 import {
   makeSelectClaimsInChannelForPage,
   makeSelectFetchingChannelClaims,
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   makeSelectTotalPagesInChannelSearch,
   makeSelectClaimForUri,
 } from 'redux/selectors/claims';
@@ -24,7 +24,7 @@ const select = (state, props) => {
     pageOfClaimsInChannel: makeSelectClaimsInChannelForPage(props.uri, page)(state),
     fetching: makeSelectFetchingChannelClaims(props.uri)(state),
     totalPages: makeSelectTotalPagesInChannelSearch(props.uri, PAGE_SIZE)(state),
-    channelIsMine: makeSelectClaimIsMine(props.uri)(state),
+    channelIsMine: selectClaimIsMineForUri(state, props.uri),
     channelIsBlocked: makeSelectChannelIsMuted(props.uri)(state),
     claim: props.uri && makeSelectClaimForUri(props.uri)(state),
     isAuthenticated: selectUserVerifiedEmail(state),

--- a/ui/component/claimMenuList/index.js
+++ b/ui/component/claimMenuList/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectClaimIsMine } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectClaimIsMineForUri } from 'redux/selectors/claims';
 import { doCollectionEdit, doFetchItemsInCollection } from 'redux/actions/collections';
 import { doPrepareEdit } from 'redux/actions/publish';
 import {
@@ -51,7 +51,7 @@ const select = (state, props) => {
     contentClaim,
     contentSigningChannel,
     contentChannelUri,
-    claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+    claimIsMine: selectClaimIsMineForUri(state, props.uri),
     hasClaimInWatchLater: makeSelectCollectionForIdHasClaimUrl(
       COLLECTIONS_CONSTS.WATCH_LATER_ID,
       contentPermanentUri

--- a/ui/component/claimPreview/index.js
+++ b/ui/component/claimPreview/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import {
   selectClaimForUri,
   makeSelectIsUriResolving,
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   makeSelectClaimIsPending,
   makeSelectClaimIsNsfw,
   makeSelectReflectingClaimForUri,
@@ -42,7 +42,7 @@ const select = (state, props) => {
     pending: props.uri && makeSelectClaimIsPending(props.uri)(state),
     reflectingProgress: props.uri && makeSelectReflectingClaimForUri(props.uri)(state),
     obscureNsfw: selectShowMatureContent(state) === false,
-    claimIsMine: props.uri && makeSelectClaimIsMine(props.uri)(state),
+    claimIsMine: props.uri && selectClaimIsMineForUri(state, props.uri),
     isResolvingUri: props.uri && makeSelectIsUriResolving(props.uri)(state),
     isResolvingRepost: props.uri && makeSelectIsUriResolving(props.repostUrl)(state),
     nsfw: props.uri && makeSelectClaimIsNsfw(props.uri)(state),

--- a/ui/component/claimPreviewReset/index.js
+++ b/ui/component/claimPreviewReset/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
-import { makeSelectClaimIsMine } from 'redux/selectors/claims';
+import { selectClaimIsMineForUri } from 'redux/selectors/claims';
 import { doToast } from 'redux/actions/notifications';
 import ClaimPreviewReset from './view';
 
@@ -9,7 +9,7 @@ const select = (state, props) => {
   return {
     channelName,
     channelId,
-    claimIsMine: props.uri && makeSelectClaimIsMine(props.uri)(state),
+    claimIsMine: props.uri && selectClaimIsMineForUri(state, props.uri),
   };
 };
 

--- a/ui/component/claimProperties/index.js
+++ b/ui/component/claimProperties/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimIsMine, makeSelectClaimForUri } from 'redux/selectors/claims';
+import { selectClaimIsMineForUri, makeSelectClaimForUri } from 'redux/selectors/claims';
 import { makeSelectIsSubscribed } from 'redux/selectors/subscriptions';
 import ClaimProperties from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
   isSubscribed: makeSelectIsSubscribed(props.uri)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
 });
 
 export default connect(select, null)(ClaimProperties);

--- a/ui/component/collectionContentSidebar/index.js
+++ b/ui/component/collectionContentSidebar/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import CollectionContent from './view';
-import { makeSelectClaimForUri, makeSelectClaimIsMine } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectClaimIsMineForUri } from 'redux/selectors/claims';
 import {
   makeSelectUrlsForCollectionId,
   makeSelectNameForCollectionId,
@@ -24,7 +24,7 @@ const select = (state, props) => {
     collection: makeSelectCollectionForId(props.id)(state),
     collectionUrls: makeSelectUrlsForCollectionId(props.id)(state),
     collectionName: makeSelectNameForCollectionId(props.id)(state),
-    isMine: makeSelectClaimIsMine(url)(state),
+    isMine: selectClaimIsMineForUri(state, url),
     loop,
     shuffle,
   };

--- a/ui/component/commentCreate/index.js
+++ b/ui/component/commentCreate/index.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import {
   makeSelectClaimForUri,
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   selectHasChannels,
   selectFetchingMyChannels,
   makeSelectTagInClaimOrChannelForUri,
@@ -18,7 +18,7 @@ const select = (state, props) => ({
   activeChannelClaim: selectActiveChannelClaim(state),
   hasChannels: selectHasChannels(state),
   claim: makeSelectClaimForUri(props.uri)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
   isFetchingChannels: selectFetchingMyChannels(state),
   settingsByChannelId: selectSettingsByChannelId(state),
   supportDisabled: makeSelectTagInClaimOrChannelForUri(props.uri, DISABLE_SUPPORT_TAG)(state),

--- a/ui/component/commentMenuList/index.js
+++ b/ui/component/commentMenuList/index.js
@@ -4,7 +4,7 @@ import { doCommentPin, doCommentModAddDelegate } from 'redux/actions/comments';
 import { doOpenModal } from 'redux/actions/app';
 import { doSetPlayingUri } from 'redux/actions/content';
 import { doToast } from 'redux/actions/notifications';
-import { makeSelectClaimIsMine, makeSelectClaimForUri } from 'redux/selectors/claims';
+import { selectClaimIsMineForUri, makeSelectClaimForUri } from 'redux/selectors/claims';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
 import { selectModerationDelegatorsById } from 'redux/selectors/comments';
 import { selectPlayingUri } from 'redux/selectors/content';
@@ -12,7 +12,7 @@ import CommentMenuList from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
   activeChannelClaim: selectActiveChannelClaim(state),
   playingUri: selectPlayingUri(state),
   moderationDelegatorsById: selectModerationDelegatorsById(state),

--- a/ui/component/commentReactions/index.js
+++ b/ui/component/commentReactions/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import Comment from './view';
-import { makeSelectClaimIsMine, makeSelectClaimForUri } from 'redux/selectors/claims';
+import { selectClaimIsMineForUri, makeSelectClaimForUri } from 'redux/selectors/claims';
 import { doResolveUri } from 'redux/actions/claims';
 import { doToast } from 'redux/actions/notifications';
 import { selectMyReactsForComment, selectOthersReactsForComment } from 'redux/selectors/comments';
@@ -14,7 +14,7 @@ const select = (state, props) => {
 
   return {
     claim: makeSelectClaimForUri(props.uri)(state),
-    claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+    claimIsMine: selectClaimIsMineForUri(state, props.uri),
     myReacts: selectMyReactsForComment(state, reactionKey),
     othersReacts: selectOthersReactsForComment(state, reactionKey),
     activeChannelId,

--- a/ui/component/commentsList/index.js
+++ b/ui/component/commentsList/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { doResolveUris } from 'redux/actions/claims';
 import {
   makeSelectClaimForUri,
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   selectFetchingMyChannels,
   selectMyClaimIdsRaw,
 } from 'redux/selectors/claims';
@@ -41,7 +41,7 @@ const select = (state, props) => {
     topLevelTotalPages: makeSelectTopLevelTotalPagesForUri(props.uri)(state),
     totalComments: makeSelectTotalCommentsCountForUri(props.uri)(state),
     claim: makeSelectClaimForUri(props.uri)(state),
-    claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+    claimIsMine: selectClaimIsMineForUri(state, props.uri),
     isFetchingComments: selectIsFetchingComments(state),
     isFetchingCommentsById: selectIsFetchingCommentsById(state),
     isFetchingReacts: selectIsFetchingReacts(state),

--- a/ui/component/commentsReplies/index.js
+++ b/ui/component/commentsReplies/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { doResolveUris } from 'redux/actions/claims';
-import { makeSelectClaimIsMine, selectMyChannelClaimIds, makeSelectClaimForUri } from 'redux/selectors/claims';
+import { selectClaimIsMineForUri, selectMyChannelClaimIds, makeSelectClaimForUri } from 'redux/selectors/claims';
 import { selectIsFetchingCommentsByParentId, selectRepliesForParentId } from 'redux/selectors/comments';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import CommentsReplies from './view';
@@ -15,7 +15,7 @@ const select = (state, props) => {
   return {
     fetchedReplies,
     resolvedReplies,
-    claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+    claimIsMine: selectClaimIsMineForUri(state, props.uri),
     userCanComment: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
     myChannelIds: selectMyChannelClaimIds(state),
     isFetchingByParentId: selectIsFetchingCommentsByParentId(state),

--- a/ui/component/fileActions/index.js
+++ b/ui/component/fileActions/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import {
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   makeSelectClaimForUri,
   selectHasChannels,
   makeSelectClaimIsStreamPlaceholder,
@@ -19,7 +19,7 @@ import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
   fileInfo: makeSelectFileInfoForUri(props.uri)(state),
   renderMode: makeSelectFileRenderModeForUri(props.uri)(state),
   costInfo: makeSelectCostInfoForUri(props.uri)(state),

--- a/ui/component/fileDescription/index.js
+++ b/ui/component/fileDescription/index.js
@@ -1,9 +1,5 @@
 import { connect } from 'react-redux';
-import {
-  makeSelectClaimForUri,
-  makeSelectMetadataForUri,
-  makeSelectClaimIsMine,
-} from 'redux/selectors/claims';
+import { makeSelectClaimForUri, makeSelectMetadataForUri, selectClaimIsMineForUri } from 'redux/selectors/claims';
 import { makeSelectPendingAmountByUri } from 'redux/selectors/wallet';
 import { doOpenModal } from 'redux/actions/app';
 import { selectUser } from 'redux/selectors/user';
@@ -11,7 +7,7 @@ import FileDescription from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
   metadata: makeSelectMetadataForUri(props.uri)(state),
   user: selectUser(state),
   pendingAmount: makeSelectPendingAmountByUri(props.uri)(state),

--- a/ui/component/fileDownloadLink/index.js
+++ b/ui/component/fileDownloadLink/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimIsMine, makeSelectClaimForUri, makeSelectClaimWasPurchased } from 'redux/selectors/claims';
+import { selectClaimIsMineForUri, makeSelectClaimForUri, makeSelectClaimWasPurchased } from 'redux/selectors/claims';
 import {
   makeSelectFileInfoForUri,
   makeSelectDownloadingForUri,
@@ -15,7 +15,7 @@ const select = (state, props) => ({
   fileInfo: makeSelectFileInfoForUri(props.uri)(state),
   downloading: makeSelectDownloadingForUri(props.uri)(state),
   loading: makeSelectLoadingForUri(props.uri)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
   claim: makeSelectClaimForUri(props.uri)(state),
   costInfo: makeSelectCostInfoForUri(props.uri)(state),
   claimWasPurchased: makeSelectClaimWasPurchased(props.uri)(state),

--- a/ui/component/filePrice/index.js
+++ b/ui/component/filePrice/index.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectClaimWasPurchased, makeSelectClaimIsMine } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, makeSelectClaimWasPurchased, selectClaimIsMineForUri } from 'redux/selectors/claims';
 import { makeSelectCostInfoForUri, doFetchCostInfoForUri, makeSelectFetchingCostInfoForUri } from 'lbryinc';
 import FilePrice from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
   claimWasPurchased: makeSelectClaimWasPurchased(props.uri)(state),
   costInfo: makeSelectCostInfoForUri(props.uri)(state),
   fetching: makeSelectFetchingCostInfoForUri(props.uri)(state),

--- a/ui/component/fileValues/index.js
+++ b/ui/component/fileValues/index.js
@@ -3,7 +3,7 @@ import {
   makeSelectClaimForUri,
   makeSelectContentTypeForUri,
   makeSelectMetadataForUri,
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
 } from 'redux/selectors/claims';
 import { makeSelectPendingAmountByUri } from 'redux/selectors/wallet';
 import { makeSelectFileInfoForUri } from 'redux/selectors/file_info';
@@ -19,7 +19,7 @@ const select = (state, props) => ({
   metadata: makeSelectMetadataForUri(props.uri)(state),
   user: selectUser(state),
   pendingAmount: makeSelectPendingAmountByUri(props.uri)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/postViewer/index.js
+++ b/ui/component/postViewer/index.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectClaimIsMine } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectClaimIsMineForUri } from 'redux/selectors/claims';
 import PostViewer from './view';
 import { doOpenModal } from 'redux/actions/app';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
 });
 
 export default connect(select, {

--- a/ui/component/previewLink/index.js
+++ b/ui/component/previewLink/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import {
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   makeSelectTitleForUri,
   makeSelectThumbnailForUri,
   makeSelectClaimForUri,
@@ -18,7 +18,7 @@ const select = (state, props) => {
     title: makeSelectTitleForUri(props.uri)(state),
     thumbnail: makeSelectThumbnailForUri(props.uri)(state),
     description: makeSelectMetadataItemForUri(props.uri, 'description')(state),
-    channelIsMine: makeSelectClaimIsMine(props.uri)(state),
+    channelIsMine: selectClaimIsMineForUri(state, props.uri),
     isResolvingUri: makeSelectIsUriResolving(props.uri)(state),
     blackListedOutpoints: selectBlackListedOutpoints(state),
   };

--- a/ui/component/previewOverlayProperties/index.js
+++ b/ui/component/previewOverlayProperties/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimIsMine, makeSelectClaimForUri } from 'redux/selectors/claims';
+import { selectClaimIsMineForUri, makeSelectClaimForUri } from 'redux/selectors/claims';
 import { makeSelectFilePartlyDownloaded } from 'redux/selectors/file_info';
 import { makeSelectEditedCollectionForId } from 'redux/selectors/collections';
 import { makeSelectIsSubscribed } from 'redux/selectors/subscriptions';
@@ -13,7 +13,7 @@ const select = (state, props) => {
     editedCollection: makeSelectEditedCollectionForId(claimId)(state),
     downloaded: makeSelectFilePartlyDownloaded(props.uri)(state),
     isSubscribed: makeSelectIsSubscribed(props.uri)(state),
-    claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+    claimIsMine: selectClaimIsMineForUri(state, props.uri),
   };
 };
 

--- a/ui/component/walletSendTip/index.js
+++ b/ui/component/walletSendTip/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import {
   makeSelectTitleForUri,
   makeSelectClaimForUri,
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   selectFetchingMyChannels,
 } from 'redux/selectors/claims';
 import { doHideModal } from 'redux/actions/app';
@@ -18,7 +18,7 @@ const select = (state, props) => ({
   activeChannelClaim: selectActiveChannelClaim(state),
   balance: selectBalance(state),
   claim: makeSelectClaimForUri(props.uri, false)(state),
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
   fetchingChannels: selectFetchingMyChannels(state),
   incognito: selectIncognito(state),
   instantTipEnabled: makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_ENABLED)(state),

--- a/ui/modal/modalRemoveCollection/index.js
+++ b/ui/modal/modalRemoveCollection/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import {
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   makeSelectIsAbandoningClaimForUri,
   makeSelectClaimForClaimId,
 } from 'redux/selectors/claims';
@@ -15,7 +15,7 @@ const select = (state, props) => {
   return {
     claim,
     uri,
-    claimIsMine: makeSelectClaimIsMine(uri)(state),
+    claimIsMine: selectClaimIsMineForUri(state, uri),
     isAbandoning: makeSelectIsAbandoningClaimForUri(uri)(state),
     collectionName: makeSelectNameForCollectionId(props.collectionId)(state),
   };

--- a/ui/modal/modalRemoveFile/index.js
+++ b/ui/modal/modalRemoveFile/index.js
@@ -4,14 +4,14 @@ import {
   makeSelectTitleForUri,
   makeSelectClaimForUri,
   makeSelectIsAbandoningClaimForUri,
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
 } from 'redux/selectors/claims';
 import { doResolveUri } from 'redux/actions/claims';
 import { doHideModal } from 'redux/actions/app';
 import ModalRemoveFile from './view';
 
 const select = (state, props) => ({
-  claimIsMine: makeSelectClaimIsMine(props.uri)(state),
+  claimIsMine: selectClaimIsMineForUri(state, props.uri),
   title: makeSelectTitleForUri(props.uri)(state),
   claim: makeSelectClaimForUri(props.uri)(state),
   isAbandoning: makeSelectIsAbandoningClaimForUri(props.uri)(state),

--- a/ui/page/channel/index.js
+++ b/ui/page/channel/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import {
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   makeSelectTitleForUri,
   makeSelectThumbnailForUri,
   makeSelectCoverForUri,
@@ -21,7 +21,7 @@ const select = (state, props) => ({
   title: makeSelectTitleForUri(props.uri)(state),
   thumbnail: makeSelectThumbnailForUri(props.uri)(state),
   cover: makeSelectCoverForUri(props.uri)(state),
-  channelIsMine: makeSelectClaimIsMine(props.uri)(state),
+  channelIsMine: selectClaimIsMineForUri(state, props.uri),
   page: selectCurrentChannelPage(state),
   claim: makeSelectClaimForUri(props.uri)(state),
   isSubscribed: makeSelectIsSubscribed(props.uri, true)(state),

--- a/ui/page/collection/index.js
+++ b/ui/page/collection/index.js
@@ -5,7 +5,7 @@ import CollectionPage from './view';
 import {
   makeSelectTitleForUri,
   makeSelectThumbnailForUri,
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   makeSelectClaimIsPending,
   makeSelectClaimForClaimId,
   makeSelectChannelForClaimUri,
@@ -40,7 +40,7 @@ const select = (state, props) => {
     isResolvingCollection: makeSelectIsResolvingCollectionForId(collectionId)(state),
     title: makeSelectTitleForUri(uri)(state),
     thumbnail: makeSelectThumbnailForUri(uri)(state),
-    isMyClaim: makeSelectClaimIsMine(uri)(state), // or collection is mine?
+    isMyClaim: selectClaimIsMineForUri(state, uri), // or collection is mine?
     isMyCollection: makeSelectCollectionIsMine(collectionId)(state),
     claimIsPending: makeSelectClaimIsPending(uri)(state),
     collectionHasEdits: Boolean(makeSelectEditedCollectionForId(collectionId)(state)),

--- a/ui/page/show/index.js
+++ b/ui/page/show/index.js
@@ -8,7 +8,7 @@ import {
   makeSelectIsUriResolving,
   makeSelectTotalPagesForChannel,
   makeSelectTitleForUri,
-  makeSelectClaimIsMine,
+  selectClaimIsMineForUri,
   makeSelectClaimIsPending,
   makeSelectClaimIsStreamPlaceholder,
 } from 'redux/selectors/claims';
@@ -77,7 +77,7 @@ const select = (state, props) => {
     totalPages: makeSelectTotalPagesForChannel(uri, PAGE_SIZE)(state),
     isSubscribed: makeSelectChannelInSubscriptions(uri)(state),
     title: makeSelectTitleForUri(uri)(state),
-    claimIsMine: makeSelectClaimIsMine(uri)(state),
+    claimIsMine: selectClaimIsMineForUri(state, uri),
     claimIsPending: makeSelectClaimIsPending(uri)(state),
     isLivestream: makeSelectClaimIsStreamPlaceholder(uri)(state),
     collection: makeSelectCollectionForId(collectionId)(state),

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -12,7 +12,7 @@ import * as SHARED_PREFERENCES from 'constants/shared_preferences';
 import { DOMAIN, SIMPLE_SITE } from 'config';
 import Lbry from 'lbry';
 import { doFetchChannelListMine, doFetchCollectionListMine, doCheckPendingClaims } from 'redux/actions/claims';
-import { makeSelectClaimForUri, makeSelectClaimIsMine, selectMyChannelClaims } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectClaimIsMineForUri, selectMyChannelClaims } from 'redux/selectors/claims';
 import { doFetchFileInfos } from 'redux/actions/file_info';
 import { doClearSupport, doBalanceSubscribe } from 'redux/actions/wallet';
 import { doClearPublish } from 'redux/actions/publish';
@@ -470,7 +470,7 @@ export function doAnalyticsView(uri, timeToStart) {
   return (dispatch, getState) => {
     const state = getState();
     const { txid, nout, claim_id: claimId } = makeSelectClaimForUri(uri)(state);
-    const claimIsMine = makeSelectClaimIsMine(uri)(state);
+    const claimIsMine = selectClaimIsMineForUri(state, uri);
     const outpoint = `${txid}:${nout}`;
 
     if (claimIsMine) {

--- a/ui/redux/actions/content.js
+++ b/ui/redux/actions/content.js
@@ -5,7 +5,7 @@ import * as MODALS from 'constants/modal_types';
 import { ipcRenderer } from 'electron';
 // @endif
 import { doOpenModal } from 'redux/actions/app';
-import { makeSelectClaimForUri, makeSelectClaimIsMine, makeSelectClaimWasPurchased } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectClaimIsMineForUri, makeSelectClaimWasPurchased } from 'redux/selectors/claims';
 import {
   makeSelectFileInfoForUri,
   selectFileInfosByOutpoint,
@@ -151,7 +151,7 @@ export function doPlayUri(
 ) {
   return (dispatch: Dispatch, getState: () => any) => {
     const state = getState();
-    const isMine = makeSelectClaimIsMine(uri)(state);
+    const isMine = selectClaimIsMineForUri(state, uri);
     const fileInfo = makeSelectFileInfoForUri(uri)(state);
     const uriIsStreamable = makeSelectUriIsStreamable(uri)(state);
     const downloadingByOutpoint = selectDownloadingByOutpoint(state);


### PR DESCRIPTION
## Issue
`normalizeUri` | `parseURI` is expensive and has been causing sluggish operations when called repeatedly or within a loop.

## Change
Since I'm not confident enough to remove the call entirely from makeSelectClaimIsMine (although I've yet to find a scenario that the uri is not already normalized), we'll try caching the calls instead.

## Results
- in a simple test of toggling between 2 category pages, we saved 20ms from `parseURI` calls alone.

- in a test of opening all categories one time, the memory usage remained similar. This makes sense since we removed a `makeSelect*` (which creates a selector for each call + not memoizing), and replaced that with a cached selector that's actually memoizing.