### PR TITLE
Adjust some initial states to optimize initial render

### DIFF
--- a/ui/page/livestream/view.jsx
+++ b/ui/page/livestream/view.jsx
@@ -19,7 +19,7 @@ type Props = {
 
 export default function LivestreamPage(props: Props) {
   const { uri, claim, doSetPlayingUri, isAuthenticated, doUserSetReferrer, channelClaim, chatDisabled } = props;
-  const [isLive, setIsLive] = React.useState(false);
+  const [isLive, setIsLive] = React.useState(true);
   const livestreamChannelId = channelClaim && channelClaim.signing_channel && channelClaim.signing_channel.claim_id;
   const [hasLivestreamClaim, setHasLivestreamClaim] = React.useState(false);
 

--- a/web/component/browserNotificationSettings/use-browser-notifications.js
+++ b/web/component/browserNotificationSettings/use-browser-notifications.js
@@ -11,7 +11,7 @@ export default () => {
   const [pushPermission, setPushPermission] = useState(window.Notification?.permission);
   const [subscribed, setSubscribed] = useState(false);
   const [pushEnabled, setPushEnabled] = useState(false);
-  const [pushSupported, setPushSupported] = useState(false);
+  const [pushSupported, setPushSupported] = useState(true);
   const [encounteredError, setEncounteredError] = useState(false);
 
   const [user] = useState(selectUser(store.getState()));


### PR DESCRIPTION
## Fixes

Adjust some initial states to optimize initial render. Further adjustment to livestream (if needed) can be made with upcoming changes.

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

On live stream you briefly see the "not streaming" message rendered on load.
On notification settings you briefly see the not supported hints rendered on load.

## What is the new behavior?

Both are not rendered by default.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
