### PR TITLE
Band-aid: wait a while before sending `notify`

### DIFF
--- a/web/setup/publish-v2.js
+++ b/web/setup/publish-v2.js
@@ -103,7 +103,7 @@ export function makeResumableUploadRequest(
           xhr.send(jsonPayload);
         }
 
-        makeNotifyRequest();
+        setTimeout(() => makeNotifyRequest(), 15000);
       },
     });
 


### PR DESCRIPTION
## Issue
The status = 0 is due to unresponsive backend right after the tus-upload. No root-cause found yet.

## Change
It may or may not help, but adding a delay to account for the unresponsive stage for now.
