### PR TITLE
Prevent unnecessary render of notifications banner

### DIFF
--- a/web/component/browserNotificationBanner/view.jsx
+++ b/web/component/browserNotificationBanner/view.jsx
@@ -8,10 +8,19 @@ import Button from 'component/button';
 import usePersistedState from 'effects/use-persisted-state';
 
 export const BrowserNotificationBanner = () => {
-  const { pushSupported, pushEnabled, pushPermission, pushToggle, pushErrorModal } = useBrowserNotifications();
+  const {
+    pushInitialized,
+    pushSupported,
+    pushEnabled,
+    pushPermission,
+    pushToggle,
+    pushErrorModal,
+  } = useBrowserNotifications();
   const [hasAcknowledgedPush, setHasAcknowledgedPush] = usePersistedState('push-nag', false);
 
-  if (!pushSupported || pushEnabled || pushPermission === 'denied' || hasAcknowledgedPush) return null;
+  if (!pushInitialized || !pushSupported || pushEnabled || pushPermission === 'denied' || hasAcknowledgedPush) {
+    return null;
+  }
 
   const handleClose = () => setHasAcknowledgedPush(true);
 

--- a/web/component/browserNotificationSettings/use-browser-notifications.js
+++ b/web/component/browserNotificationSettings/use-browser-notifications.js
@@ -13,13 +13,17 @@ export default () => {
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushSupported, setPushSupported] = useState(true);
   const [encounteredError, setEncounteredError] = useState(false);
+  const [pushInitialized, setPushInitialized] = useState(false);
 
   const [user] = useState(selectUser(store.getState()));
 
   useEffect(() => {
     setPushSupported(pushNotifications.supported);
     if (pushNotifications.supported) {
-      pushNotifications.subscribed(user.id).then((isSubscribed: boolean) => setSubscribed(isSubscribed));
+      pushNotifications.subscribed(user.id).then((isSubscribed: boolean) => {
+        setSubscribed(isSubscribed);
+        setPushInitialized(true);
+      });
     }
   }, [user]);
 
@@ -59,6 +63,7 @@ export default () => {
   };
 
   return {
+    pushInitialized,
     pushSupported,
     pushEnabled,
     pushPermission,


### PR DESCRIPTION
Add initialization status to push notification hook. Can be used to better control render strategy in cmpnts utilizing it.

## Fixes

Prevent unnecessary render of notifications banner on notifications page.

Issue Number: N/A

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

The notifications subscription banner can briefly render on page load because it doesn't know the user is subscribed fast enough.

## What is the new behavior?

Banner will not be shown if subscription status has not yet been determined.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
