### PR TITLE
Fix unable to clear muted list

### DIFF
--- a/ui/redux/reducers/blocked.js
+++ b/ui/redux/reducers/blocked.js
@@ -36,7 +36,7 @@ export default handleActions(
 
       return {
         ...state,
-        blockedChannels: sanitizedBlocked && sanitizedBlocked.length ? sanitizedBlocked : state.blockedChannels,
+        blockedChannels: sanitizedBlocked || state.blockedChannels,
       };
     },
   },


### PR DESCRIPTION
## Issue
When the muted list was being cleared from another app, the web version ended up restoring the previous muted list.

## Change
- As long as `blocked` is defined, return that since an empty array is a valid result.
- If undefined, something went wrong when calling the reducer, so retain the muted list. I believe this was the original intention of that line.


It could be that at one point, that reducer was expecting a delta. But now it expects the full list, so checking for `length` no longer make sense.