### PR TITLE
Hotfix livestream status

### DIFF
--- a/ui/page/livestream/view.jsx
+++ b/ui/page/livestream/view.jsx
@@ -55,7 +55,10 @@ export default function LivestreamPage(props: Props) {
   }, [livestreamChannelId, isLive]);
 
   React.useEffect(() => {
-    if (!hasLivestreamClaim || !livestreamChannelId) setIsLive(false);
+    if (!hasLivestreamClaim || !livestreamChannelId) {
+      setIsLive(false);
+      return;
+    }
     return watchLivestreamStatus(livestreamChannelId, (state) => setIsLive(state));
   }, [livestreamChannelId, setIsLive, hasLivestreamClaim]);
 

--- a/ui/page/livestream/view.jsx
+++ b/ui/page/livestream/view.jsx
@@ -55,7 +55,7 @@ export default function LivestreamPage(props: Props) {
   }, [livestreamChannelId, isLive]);
 
   React.useEffect(() => {
-    if (!hasLivestreamClaim || !livestreamChannelId) return;
+    if (!hasLivestreamClaim || !livestreamChannelId) setIsLive(false);
     return watchLivestreamStatus(livestreamChannelId, (state) => setIsLive(state));
   }, [livestreamChannelId, setIsLive, hasLivestreamClaim]);
 


### PR DESCRIPTION
## Fixes

Make sure we set livestream status to false if we aren't long polling.

Issue Number: N/A

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Livestream status defaults to true on livestream content page and isn't always correctly set to false.

## What is the new behavior?

Livestream status is correct on livestream content page.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
