### PR TITLE
`ClaimPreviewTile` state-map optimizations

### DIFF
--- a/extras/lbryinc/index.js
+++ b/extras/lbryinc/index.js
@@ -53,7 +53,7 @@ export { selectFilteredOutpoints, selectFilteredOutpointMap } from './redux/sele
 //   selectTrendingUris,
 //   selectFetchingTrendingUris,
 // } from './redux/selectors/homepage';
-export { selectViewCount, makeSelectViewCountForUri, makeSelectSubCountForUri } from './redux/selectors/stats';
+export { selectViewCount, selectViewCountForUri, selectSubCountForUri } from './redux/selectors/stats';
 export { selectBanStateForUri } from './redux/selectors/ban';
 export {
   selectHasSyncedWallet,

--- a/extras/lbryinc/redux/actions/cost_info.js
+++ b/extras/lbryinc/redux/actions/cost_info.js
@@ -1,12 +1,12 @@
 import * as ACTIONS from 'constants/action_types';
 import { Lbryio } from 'lbryinc';
-import { selectClaimsByUri } from 'redux/selectors/claims';
+import { selectClaimForUri } from 'redux/selectors/claims';
 
 // eslint-disable-next-line import/prefer-default-export
 export function doFetchCostInfoForUri(uri) {
   return (dispatch, getState) => {
     const state = getState();
-    const claim = selectClaimsByUri(state)[uri];
+    const claim = selectClaimForUri(state, uri);
 
     if (!claim) return;
 

--- a/extras/lbryinc/redux/selectors/stats.js
+++ b/extras/lbryinc/redux/selectors/stats.js
@@ -1,20 +1,20 @@
-import { createSelector } from 'reselect';
-import { makeSelectClaimForUri } from 'redux/selectors/claims';
+// @flow
+import { selectClaimIdForUri } from 'redux/selectors/claims';
 
-const selectState = state => state.stats || {};
-export const selectViewCount = createSelector(selectState, state => state.viewCountById);
-export const selectSubCount = createSelector(selectState, state => state.subCountById);
+type State = { claims: any, stats: any };
 
-export const makeSelectViewCountForUri = uri =>
-  createSelector(
-    makeSelectClaimForUri(uri),
-    selectViewCount,
-    (claim, viewCountById) => (claim ? viewCountById[claim.claim_id] || 0 : 0)
-  );
+const selectState = (state: State) => state.stats || {};
+export const selectViewCount = (state: State) => selectState(state).viewCountById;
+export const selectSubCount = (state: State) => selectState(state).subCountById;
 
-export const makeSelectSubCountForUri = uri =>
-  createSelector(
-    makeSelectClaimForUri(uri),
-    selectSubCount,
-    (claim, subCountById) => (claim ? subCountById[claim.claim_id] || 0 : 0)
-  );
+export const selectViewCountForUri = (state: State, uri: string) => {
+  const claimId = selectClaimIdForUri(state, uri);
+  const viewCountById = selectViewCount(state);
+  return claimId ? viewCountById[claimId] || 0 : 0;
+};
+
+export const selectSubCountForUri = (state: State, uri: string) => {
+  const claimId = selectClaimIdForUri(state, uri);
+  const subCountById = selectSubCount(state);
+  return claimId ? subCountById[claimId] || 0 : 0;
+};

--- a/ui/component/channelEdit/index.js
+++ b/ui/component/channelEdit/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import {
-  makeSelectTitleForUri,
+  selectTitleForUri,
   selectThumbnailForUri,
   makeSelectCoverForUri,
   makeSelectMetadataItemForUri,
@@ -21,7 +21,7 @@ import ChannelForm from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  title: makeSelectTitleForUri(props.uri)(state),
+  title: selectTitleForUri(state, props.uri),
   thumbnailUrl: selectThumbnailForUri(state, props.uri),
   coverUrl: makeSelectCoverForUri(props.uri)(state),
   description: makeSelectMetadataItemForUri(props.uri, 'description')(state),

--- a/ui/component/channelMentionSuggestion/index.js
+++ b/ui/component/channelMentionSuggestion/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectIsUriResolving } from 'redux/selectors/claims';
+import { selectClaimForUri, selectIsUriResolving } from 'redux/selectors/claims';
 import ChannelMentionSuggestion from './view';
 
 const select = (state, props) => ({
-  claim: makeSelectClaimForUri(props.uri)(state),
-  isResolvingUri: makeSelectIsUriResolving(props.uri)(state),
+  claim: selectClaimForUri(state, props.uri),
+  isResolvingUri: selectIsUriResolving(state, props.uri),
 });
 
 export default connect(select)(ChannelMentionSuggestion);

--- a/ui/component/channelMentionTopSuggestion/index.js
+++ b/ui/component/channelMentionTopSuggestion/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectIsUriResolving } from 'redux/selectors/claims';
+import { selectIsUriResolving } from 'redux/selectors/claims';
 import { doResolveUri } from 'redux/actions/claims';
 import { makeSelectWinningUriForQuery } from 'redux/selectors/search';
 import ChannelMentionTopSuggestion from './view';
@@ -8,7 +8,7 @@ const select = (state, props) => {
   const uriFromQuery = `lbry://${props.query}`;
   return {
     uriFromQuery,
-    isResolvingUri: makeSelectIsUriResolving(uriFromQuery)(state),
+    isResolvingUri: selectIsUriResolving(state, uriFromQuery),
     winningUri: makeSelectWinningUriForQuery(props.query)(state),
   };
 };

--- a/ui/component/channelThumbnail/index.js
+++ b/ui/component/channelThumbnail/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
-import { selectThumbnailForUri, selectClaimForUri, makeSelectIsUriResolving } from 'redux/selectors/claims';
+import { selectThumbnailForUri, selectClaimForUri, selectIsUriResolving } from 'redux/selectors/claims';
 import { doResolveUri } from 'redux/actions/claims';
 import ChannelThumbnail from './view';
 
 const select = (state, props) => ({
   thumbnail: selectThumbnailForUri(state, props.uri),
   claim: selectClaimForUri(state, props.uri),
-  isResolving: makeSelectIsUriResolving(props.uri)(state),
+  isResolving: selectIsUriResolving(state, props.uri),
 });
 
 export default connect(select, {

--- a/ui/component/channelTitle/index.js
+++ b/ui/component/channelTitle/index.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectTitleForUri } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectTitleForUri } from 'redux/selectors/claims';
 import ChannelTitle from './view';
 
 const select = (state, props) => ({
-  title: makeSelectTitleForUri(props.uri)(state),
+  title: selectTitleForUri(state, props.uri),
   claim: makeSelectClaimForUri(props.uri)(state),
 });
 

--- a/ui/component/claimLink/index.js
+++ b/ui/component/claimLink/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectIsUriResolving } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectIsUriResolving } from 'redux/selectors/claims';
 import { doResolveUri } from 'redux/actions/claims';
 import { doSetPlayingUri } from 'redux/actions/content';
 import { punctuationMarks } from 'util/remark-lbry';
@@ -25,7 +25,7 @@ const select = (state, props) => {
     uri,
     claim,
     fullUri: props.uri,
-    isResolvingUri: makeSelectIsUriResolving(uri)(state),
+    isResolvingUri: selectIsUriResolving(state, uri),
     blackListedOutpoints: selectBlackListedOutpoints(state),
     playingUri: selectPlayingUri(state),
   };

--- a/ui/component/claimPreviewSubtitle/index.js
+++ b/ui/component/claimPreviewSubtitle/index.js
@@ -1,14 +1,10 @@
 import * as PAGES from 'constants/pages';
 import { connect } from 'react-redux';
-import {
-  selectClaimForUri,
-  makeSelectClaimIsPending,
-  makeSelectClaimIsStreamPlaceholder,
-} from 'redux/selectors/claims';
+import { selectClaimForUri, makeSelectClaimIsPending, isStreamPlaceholderClaim } from 'redux/selectors/claims';
 import { doClearPublish, doPrepareEdit } from 'redux/actions/publish';
 import { push } from 'connected-react-router';
 import ClaimPreviewSubtitle from './view';
-import { doFetchSubCount, makeSelectSubCountForUri } from 'lbryinc';
+import { doFetchSubCount, selectSubCountForUri } from 'lbryinc';
 
 const select = (state, props) => {
   const claim = selectClaimForUri(state, props.uri);
@@ -17,8 +13,8 @@ const select = (state, props) => {
   return {
     claim,
     pending: makeSelectClaimIsPending(props.uri)(state),
-    isLivestream: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
-    subCount: isChannel ? makeSelectSubCountForUri(props.uri)(state) : 0,
+    isLivestream: isStreamPlaceholderClaim(claim),
+    subCount: isChannel ? selectSubCountForUri(state, props.uri) : 0,
   };
 };
 

--- a/ui/component/claimPreviewTile/index.js
+++ b/ui/component/claimPreviewTile/index.js
@@ -1,19 +1,18 @@
 import { connect } from 'react-redux';
 import {
   makeSelectClaimForUri,
-  makeSelectIsUriResolving,
+  selectIsUriResolving,
   getThumbnailFromClaim,
-  makeSelectTitleForUri,
-  makeSelectChannelForClaimUri,
-  makeSelectClaimIsNsfw,
-  makeSelectClaimIsStreamPlaceholder,
+  selectTitleForUri,
+  isStreamPlaceholderClaim,
   selectDateForUri,
 } from 'redux/selectors/claims';
 import { doFileGet } from 'redux/actions/file';
 import { doResolveUri } from 'redux/actions/claims';
-import { makeSelectViewCountForUri, selectBanStateForUri } from 'lbryinc';
-import { makeSelectIsActiveLivestream } from 'redux/selectors/livestream';
+import { selectViewCountForUri, selectBanStateForUri } from 'lbryinc';
+import { selectIsActiveLivestreamForUri } from 'redux/selectors/livestream';
 import { selectShowMatureContent } from 'redux/selectors/settings';
+import { isClaimNsfw } from 'util/claim';
 import ClaimPreviewTile from './view';
 import formatMediaDuration from 'util/formatMediaDuration';
 
@@ -21,21 +20,21 @@ const select = (state, props) => {
   const claim = props.uri && makeSelectClaimForUri(props.uri)(state);
   const media = claim && claim.value && (claim.value.video || claim.value.audio);
   const mediaDuration = media && media.duration && formatMediaDuration(media.duration, { screenReader: true });
+  const isLivestream = isStreamPlaceholderClaim(claim);
 
   return {
     claim,
     mediaDuration,
     date: props.uri && selectDateForUri(state, props.uri),
-    channel: props.uri && makeSelectChannelForClaimUri(props.uri)(state),
-    isResolvingUri: props.uri && makeSelectIsUriResolving(props.uri)(state),
+    isResolvingUri: props.uri && selectIsUriResolving(state, props.uri),
     thumbnail: getThumbnailFromClaim(claim),
-    title: props.uri && makeSelectTitleForUri(props.uri)(state),
+    title: props.uri && selectTitleForUri(state, props.uri),
     banState: selectBanStateForUri(state, props.uri),
     showMature: selectShowMatureContent(state),
-    isMature: makeSelectClaimIsNsfw(props.uri)(state),
-    isLivestream: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
-    isLivestreamActive: makeSelectIsActiveLivestream(props.uri)(state),
-    viewCount: makeSelectViewCountForUri(props.uri)(state),
+    isMature: claim ? isClaimNsfw(claim) : false,
+    isLivestream,
+    isLivestreamActive: isLivestream && selectIsActiveLivestreamForUri(state, props.uri),
+    viewCount: selectViewCountForUri(state, props.uri),
   };
 };
 

--- a/ui/component/claimPreviewTitle/index.js
+++ b/ui/component/claimPreviewTitle/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectTitleForUri } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectTitleForUri } from 'redux/selectors/claims';
 import ClaimPreviewTitle from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  title: makeSelectTitleForUri(props.uri)(state),
+  title: selectTitleForUri(state, props.uri),
 });
 
 export default connect(select)(ClaimPreviewTitle);

--- a/ui/component/claimType/index.js
+++ b/ui/component/claimType/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectClaimIsStreamPlaceholder } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectIsStreamPlaceholderForUri } from 'redux/selectors/claims';
 import FileType from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  isLivestream: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
+  isLivestream: selectIsStreamPlaceholderForUri(state, props.uri),
 });
 
 export default connect(select)(FileType);

--- a/ui/component/collectionEdit/index.js
+++ b/ui/component/collectionEdit/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import {
-  makeSelectTitleForUri,
+  selectTitleForUri,
   selectThumbnailForUri,
   makeSelectMetadataItemForUri,
   makeSelectAmountForUri,
@@ -25,7 +25,7 @@ import { doSetActiveChannel, doSetIncognito } from 'redux/actions/app';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  title: makeSelectTitleForUri(props.uri)(state),
+  title: selectTitleForUri(state, props.uri),
   thumbnailUrl: selectThumbnailForUri(state, props.uri),
   description: makeSelectMetadataItemForUri(props.uri, 'description')(state),
   tags: makeSelectMetadataItemForUri(props.uri, 'tags')(state),

--- a/ui/component/collectionPreviewOverlay/index.js
+++ b/ui/component/collectionPreviewOverlay/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectIsUriResolving, selectClaimIdForUri, makeSelectClaimForClaimId } from 'redux/selectors/claims';
+import { selectIsUriResolving, selectClaimIdForUri, makeSelectClaimForClaimId } from 'redux/selectors/claims';
 import {
   makeSelectUrlsForCollectionId,
   makeSelectNameForCollectionId,
@@ -22,7 +22,7 @@ const select = (state, props) => {
     collectionItemUrls: makeSelectUrlsForCollectionId(collectionId)(state), // ForId || ForUri
     pendingCollection: makeSelectPendingCollectionForId(collectionId)(state),
     claim,
-    isResolvingUri: collectionUri && makeSelectIsUriResolving(collectionUri)(state),
+    isResolvingUri: collectionUri && selectIsUriResolving(state, collectionUri),
   };
 };
 

--- a/ui/component/collectionPreviewTile/index.js
+++ b/ui/component/collectionPreviewTile/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import {
-  makeSelectIsUriResolving,
+  selectIsUriResolving,
   getThumbnailFromClaim,
-  makeSelectTitleForUri,
+  selectTitleForUri,
   makeSelectChannelForClaimUri,
-  makeSelectClaimIsNsfw,
+  selectClaimIsNsfwForUri,
   selectClaimIdForUri,
   makeSelectClaimForClaimId,
 } from 'redux/selectors/claims';
@@ -39,14 +39,14 @@ const select = (state, props) => {
     claim,
     isResolvingCollectionClaims: makeSelectIsResolvingCollectionForId(collectionId)(state),
     channelClaim: collectionUri && makeSelectChannelForClaimUri(collectionUri)(state),
-    isResolvingUri: collectionUri && makeSelectIsUriResolving(collectionUri)(state),
+    isResolvingUri: collectionUri && selectIsUriResolving(state, collectionUri),
     thumbnail: getThumbnailFromClaim(claim),
-    title: collectionUri && makeSelectTitleForUri(collectionUri)(state),
+    title: collectionUri && selectTitleForUri(state, collectionUri),
     blackListedOutpoints: selectBlackListedOutpoints(state),
     filteredOutpoints: selectFilteredOutpoints(state),
     blockedChannelUris: selectMutedChannels(state),
     showMature: selectShowMatureContent(state),
-    isMature: makeSelectClaimIsNsfw(collectionUri)(state),
+    isMature: selectClaimIsNsfwForUri(state, collectionUri),
   };
 };
 

--- a/ui/component/fileActions/index.js
+++ b/ui/component/fileActions/index.js
@@ -3,7 +3,7 @@ import {
   selectClaimIsMine,
   selectClaimForUri,
   selectHasChannels,
-  makeSelectClaimIsStreamPlaceholder,
+  selectIsStreamPlaceholderForUri,
   makeSelectTagInClaimOrChannelForUri,
 } from 'redux/selectors/claims';
 import { makeSelectStreamingUrlForUri, makeSelectFileInfoForUri } from 'redux/selectors/file_info';
@@ -27,7 +27,7 @@ const select = (state, props) => {
     renderMode: makeSelectFileRenderModeForUri(props.uri)(state),
     costInfo: makeSelectCostInfoForUri(props.uri)(state),
     hasChannels: selectHasChannels(state),
-    isLivestreamClaim: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
+    isLivestreamClaim: selectIsStreamPlaceholderForUri(state, props.uri),
     reactionsDisabled: makeSelectTagInClaimOrChannelForUri(props.uri, DISABLE_COMMENTS_TAG)(state),
     streamingUrl: makeSelectStreamingUrlForUri(props.uri)(state),
   };

--- a/ui/component/fileRenderFloating/index.js
+++ b/ui/component/fileRenderFloating/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectTitleForUri, makeSelectClaimIsNsfw, makeSelectClaimWasPurchased } from 'redux/selectors/claims';
+import { selectTitleForUri, selectClaimIsNsfwForUri, makeSelectClaimWasPurchased } from 'redux/selectors/claims';
 import { makeSelectFileInfoForUri, makeSelectStreamingUrlForUri } from 'redux/selectors/file_info';
 import {
   makeSelectNextUrlForCollectionAndUrl,
@@ -30,9 +30,9 @@ const select = (state, props) => {
     uri,
     primaryUri,
     playingUri,
-    title: makeSelectTitleForUri(uri)(state),
+    title: selectTitleForUri(state, uri),
     fileInfo: makeSelectFileInfoForUri(uri)(state),
-    mature: makeSelectClaimIsNsfw(uri)(state),
+    mature: selectClaimIsNsfwForUri(state, uri),
     isFloating: makeSelectIsPlayerFloating(props.location)(state),
     streamingUrl: makeSelectStreamingUrlForUri(uri)(state),
     floatingPlayerEnabled: makeSelectClientSetting(SETTINGS.FLOATING_PLAYER)(state),

--- a/ui/component/fileRenderInitiator/index.js
+++ b/ui/component/fileRenderInitiator/index.js
@@ -10,7 +10,7 @@ import { makeSelectClientSetting } from 'redux/selectors/settings';
 import { withRouter } from 'react-router';
 import {
   makeSelectIsPlaying,
-  makeSelectShouldObscurePreview,
+  selectShouldObscurePreviewForUri,
   makeSelectInsufficientCreditsForUri,
   makeSelectFileRenderModeForUri,
 } from 'redux/selectors/content';
@@ -25,7 +25,7 @@ const select = (state, props) => {
   return {
     claimThumbnail: selectThumbnailForUri(state, props.uri),
     fileInfo: makeSelectFileInfoForUri(props.uri)(state),
-    obscurePreview: makeSelectShouldObscurePreview(props.uri)(state),
+    obscurePreview: selectShouldObscurePreviewForUri(state, props.uri),
     isPlaying: makeSelectIsPlaying(props.uri)(state),
     insufficientCredits: makeSelectInsufficientCreditsForUri(props.uri)(state),
     autoplay: makeSelectClientSetting(SETTINGS.AUTOPLAY_MEDIA)(state),

--- a/ui/component/fileTitle/index.js
+++ b/ui/component/fileTitle/index.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux';
-import { makeSelectTitleForUri } from 'redux/selectors/claims';
+import { selectTitleForUri } from 'redux/selectors/claims';
 import FileTitleSection from './view';
 
 const select = (state, props) => ({
-  title: makeSelectTitleForUri(props.uri)(state),
+  title: selectTitleForUri(state, props.uri),
 });
 
 export default connect(select)(FileTitleSection);

--- a/ui/component/fileTitleSection/index.js
+++ b/ui/component/fileTitleSection/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
-import { doFetchSubCount, makeSelectSubCountForUri } from 'lbryinc';
-import { makeSelectTitleForUri, makeSelectClaimForUri } from 'redux/selectors/claims';
+import { doFetchSubCount, selectSubCountForUri } from 'lbryinc';
+import { selectTitleForUri, makeSelectClaimForUri } from 'redux/selectors/claims';
 import { makeSelectInsufficientCreditsForUri } from 'redux/selectors/content';
 import { makeSelectViewersForId } from 'redux/selectors/livestream';
 import FileTitleSection from './view';
@@ -10,12 +10,12 @@ const select = (state, props) => {
   const viewers = claim && makeSelectViewersForId(claim.claim_id)(state);
   const channelClaimId = claim && claim.signing_channel ? claim.signing_channel.claim_id : undefined;
   const channelUri = claim && claim.signing_channel ? claim.signing_channel.canonical_url : undefined;
-  const subCount = channelUri && makeSelectSubCountForUri(channelUri)(state);
+  const subCount = channelUri && selectSubCountForUri(state, channelUri);
 
   return {
     viewers,
     isInsufficientCredits: makeSelectInsufficientCreditsForUri(props.uri)(state),
-    title: makeSelectTitleForUri(props.uri)(state),
+    title: selectTitleForUri(state, props.uri),
     channelClaimId,
     subCount,
   };

--- a/ui/component/fileType/index.js
+++ b/ui/component/fileType/index.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux';
 import { makeSelectMediaTypeForUri } from 'redux/selectors/file_info';
-import { makeSelectClaimIsStreamPlaceholder } from 'redux/selectors/claims';
+import { selectIsStreamPlaceholderForUri } from 'redux/selectors/claims';
 import FileType from './view';
 
 const select = (state, props) => ({
   mediaType: makeSelectMediaTypeForUri(props.uri)(state),
-  isLivestream: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
+  isLivestream: selectIsStreamPlaceholderForUri(state, props.uri),
 });
 
 export default connect(select)(FileType);

--- a/ui/component/fileViewCount/index.js
+++ b/ui/component/fileViewCount/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
 import { makeSelectClaimForUri } from 'redux/selectors/claims';
-import { doFetchViewCount, makeSelectViewCountForUri } from 'lbryinc';
+import { doFetchViewCount, selectViewCountForUri } from 'lbryinc';
 import { doAnalyticsView } from 'redux/actions/app';
 import FileViewCount from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  viewCount: makeSelectViewCountForUri(props.uri)(state),
+  viewCount: selectViewCountForUri(state, props.uri),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/fileViewCountInline/index.js
+++ b/ui/component/fileViewCountInline/index.js
@@ -1,13 +1,13 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri } from 'redux/selectors/claims';
-import { makeSelectViewCountForUri } from 'lbryinc';
+import { selectClaimForUri } from 'redux/selectors/claims';
+import { selectViewCountForUri } from 'lbryinc';
 import { selectLanguage } from 'redux/selectors/settings';
 import FileViewCountInline from './view';
 
 const select = (state, props) => {
   return {
-    claim: makeSelectClaimForUri(props.uri)(state),
-    viewCount: makeSelectViewCountForUri(props.uri)(state),
+    claim: selectClaimForUri(state, props.uri),
+    viewCount: selectViewCountForUri(state, props.uri),
     lang: selectLanguage(state),
   };
 };

--- a/ui/component/fileViewerEmbeddedTitle/index.js
+++ b/ui/component/fileViewerEmbeddedTitle/index.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux';
 import fileViewerEmbeddedTitle from './view';
-import { makeSelectTagInClaimOrChannelForUri, makeSelectTitleForUri } from 'redux/selectors/claims';
+import { makeSelectTagInClaimOrChannelForUri, selectTitleForUri } from 'redux/selectors/claims';
 import { PREFERENCE_EMBED } from 'constants/tags';
 
 export default connect((state, props) => {
   return {
-    title: makeSelectTitleForUri(props.uri)(state),
+    title: selectTitleForUri(state, props.uri),
     preferEmbed: makeSelectTagInClaimOrChannelForUri(props.uri, PREFERENCE_EMBED)(state),
   };
 })(fileViewerEmbeddedTitle);

--- a/ui/component/previewLink/index.js
+++ b/ui/component/previewLink/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import {
   selectClaimIsMine,
-  makeSelectTitleForUri,
+  selectTitleForUri,
   getThumbnailFromClaim,
   selectClaimForUri,
-  makeSelectIsUriResolving,
+  selectIsUriResolving,
   makeSelectMetadataItemForUri,
 } from 'redux/selectors/claims';
 import { doResolveUri } from 'redux/actions/claims';
@@ -17,11 +17,11 @@ const select = (state, props) => {
   return {
     uri: props.uri,
     claim,
-    title: makeSelectTitleForUri(props.uri)(state),
+    title: selectTitleForUri(state, props.uri),
     thumbnail: getThumbnailFromClaim(claim),
     description: makeSelectMetadataItemForUri(props.uri, 'description')(state),
     channelIsMine: selectClaimIsMine(state, claim),
-    isResolvingUri: makeSelectIsUriResolving(props.uri)(state),
+    isResolvingUri: selectIsUriResolving(state, props.uri),
     blackListedOutpoints: selectBlackListedOutpoints(state),
   };
 };

--- a/ui/component/publishFile/index.js
+++ b/ui/component/publishFile/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { selectBalance } from 'redux/selectors/wallet';
 import { selectIsStillEditing, makeSelectPublishFormValue } from 'redux/selectors/publish';
 import { doUpdatePublishForm, doClearPublish } from 'redux/actions/publish';
-import { makeSelectClaimIsStreamPlaceholder } from 'redux/selectors/claims';
+import { selectIsStreamPlaceholderForUri } from 'redux/selectors/claims';
 import { doToast } from 'redux/actions/notifications';
 import { selectFfmpegStatus } from 'redux/selectors/settings';
 import PublishPage from './view';
@@ -20,7 +20,7 @@ const select = (state, props) => ({
   size: makeSelectPublishFormValue('fileSize')(state),
   duration: makeSelectPublishFormValue('fileDur')(state),
   isVid: makeSelectPublishFormValue('fileVid')(state),
-  isLivestreamClaim: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
+  isLivestreamClaim: selectIsStreamPlaceholderForUri(state, props.uri),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/publishForm/index.js
+++ b/ui/component/publishForm/index.js
@@ -15,7 +15,7 @@ import {
   selectIsResolvingPublishUris,
   selectMyClaimForUri,
 } from 'redux/selectors/publish';
-import { makeSelectClaimIsStreamPlaceholder } from 'redux/selectors/claims';
+import { selectIsStreamPlaceholderForUri } from 'redux/selectors/claims';
 import * as RENDER_MODES from 'constants/file_render_modes';
 import * as SETTINGS from 'constants/settings';
 import { doClaimInitialRewards } from 'redux/actions/rewards';
@@ -45,7 +45,7 @@ const select = (state) => {
     user: selectUser(state),
     // The winning claim for a short lbry uri
     amountNeededForTakeover: selectTakeOverAmount(state),
-    isLivestreamClaim: makeSelectClaimIsStreamPlaceholder(permanentUrl)(state),
+    isLivestreamClaim: selectIsStreamPlaceholderForUri(state, permanentUrl),
     isPostClaim,
     permanentUrl,
     // My previously published claims under this short lbry uri

--- a/ui/component/recommendedContent/index.js
+++ b/ui/component/recommendedContent/index.js
@@ -1,14 +1,14 @@
 import { connect } from 'react-redux';
 import { makeSelectClaimForUri } from 'redux/selectors/claims';
 import { doFetchRecommendedContent } from 'redux/actions/search';
-import { makeSelectRecommendedContentForUri, selectIsSearching } from 'redux/selectors/search';
+import { selectRecommendedContentForUri, selectIsSearching } from 'redux/selectors/search';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import RecommendedContent from './view';
 
 const select = (state, props) => {
   const claim = makeSelectClaimForUri(props.uri)(state);
   const { claim_id: claimId } = claim;
-  const recommendedContentUris = makeSelectRecommendedContentForUri(props.uri)(state);
+  const recommendedContentUris = selectRecommendedContentForUri(state, props.uri);
   const nextRecommendedUri = recommendedContentUris && recommendedContentUris[0];
 
   return {

--- a/ui/component/repostCreate/index.js
+++ b/ui/component/repostCreate/index.js
@@ -2,12 +2,12 @@ import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
 import {
   makeSelectClaimForUri,
-  makeSelectTitleForUri,
+  selectTitleForUri,
   selectRepostError,
   selectRepostLoading,
   selectMyClaimsWithoutChannels,
   makeSelectEffectiveAmountForUri,
-  makeSelectIsUriResolving,
+  selectIsUriResolving,
   selectFetchingMyChannels,
 } from 'redux/selectors/claims';
 
@@ -29,13 +29,13 @@ const select = (state, props) => ({
   enteredContentClaim: makeSelectClaimForUri(props.contentUri)(state),
   enteredRepostClaim: makeSelectClaimForUri(props.repostUri, false)(state),
   enteredRepostAmount: makeSelectEffectiveAmountForUri(props.repostUri)(state),
-  title: makeSelectTitleForUri(props.uri)(state),
+  title: selectTitleForUri(state, props.uri),
   balance: selectBalance(state),
   error: selectRepostError(state),
   reposting: selectRepostLoading(state),
   myClaims: selectMyClaimsWithoutChannels(state),
-  isResolvingPassedRepost: props.name && makeSelectIsUriResolving(`lbry://${props.name}`)(state),
-  isResolvingEnteredRepost: props.repostUri && makeSelectIsUriResolving(`lbry://${props.repostUri}`)(state),
+  isResolvingPassedRepost: props.name && selectIsUriResolving(state, `lbry://${props.name}`),
+  isResolvingEnteredRepost: props.repostUri && selectIsUriResolving(state, `lbry://${props.repostUri}`),
   activeChannelClaim: selectActiveChannelClaim(state),
   fetchingMyChannels: selectFetchingMyChannels(state),
   incognito: selectIncognito(state),

--- a/ui/component/router/index.js
+++ b/ui/component/router/index.js
@@ -4,7 +4,7 @@ import { selectHasNavigated, selectScrollStartingPosition, selectWelcomeVersion 
 import { selectHomepageData } from 'redux/selectors/settings';
 import Router from './view';
 import { normalizeURI } from 'util/lbryURI';
-import { makeSelectTitleForUri } from 'redux/selectors/claims';
+import { selectTitleForUri } from 'redux/selectors/claims';
 import { doSetHasNavigated } from 'redux/actions/app';
 import { doUserSetReferrer } from 'redux/actions/user';
 import { selectHasUnclaimedRefereeReward } from 'redux/selectors/rewards';
@@ -28,7 +28,7 @@ const select = (state) => {
 
   return {
     uri,
-    title: makeSelectTitleForUri(uri)(state),
+    title: selectTitleForUri(state, uri),
     currentScroll: selectScrollStartingPosition(state),
     isAuthenticated: selectUserVerifiedEmail(state),
     welcomeVersion: selectWelcomeVersion(state),

--- a/ui/component/searchTopClaim/index.js
+++ b/ui/component/searchTopClaim/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { doClearPublish, doPrepareEdit } from 'redux/actions/publish';
 import { doResolveUris } from 'redux/actions/claims';
 import { selectPendingIds, makeSelectClaimForUri } from 'redux/selectors/claims';
-import { makeSelectWinningUriForQuery, makeSelectIsResolvingWinningUri } from 'redux/selectors/search';
+import { makeSelectWinningUriForQuery, selectIsResolvingWinningUri } from 'redux/selectors/search';
 import SearchTopClaim from './view';
 import { push } from 'connected-react-router';
 import * as PAGES from 'constants/pages';
@@ -13,7 +13,7 @@ const select = (state, props) => {
   return {
     winningUri,
     winningClaim: winningUri ? makeSelectClaimForUri(winningUri)(state) : undefined,
-    isResolvingWinningUri: props.query ? makeSelectIsResolvingWinningUri(props.query)(state) : false,
+    isResolvingWinningUri: props.query ? selectIsResolvingWinningUri(state, props.query) : false,
     pendingIds: selectPendingIds(state),
   };
 };

--- a/ui/component/socialShare/index.js
+++ b/ui/component/socialShare/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectTitleForUri } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectTitleForUri } from 'redux/selectors/claims';
 import SocialShare from './view';
 import { selectUserInviteReferralCode, selectUser } from 'redux/selectors/user';
 import { makeSelectContentPositionForUri } from 'redux/selectors/content';
@@ -8,7 +8,7 @@ const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
   referralCode: selectUserInviteReferralCode(state),
   user: selectUser(state),
-  title: makeSelectTitleForUri(props.uri)(state),
+  title: selectTitleForUri(state, props.uri),
   position: makeSelectContentPositionForUri(props.uri)(state),
 });
 

--- a/ui/component/uriIndicator/index.js
+++ b/ui/component/uriIndicator/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
 import { normalizeURI } from 'util/lbryURI';
 import { doResolveUri } from 'redux/actions/claims';
-import { makeSelectIsUriResolving, makeSelectClaimForUri } from 'redux/selectors/claims';
+import { selectIsUriResolving, makeSelectClaimForUri } from 'redux/selectors/claims';
 import UriIndicator from './view';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
-  isResolvingUri: makeSelectIsUriResolving(props.uri)(state),
+  isResolvingUri: selectIsUriResolving(state, props.uri),
   uri: normalizeURI(props.uri),
 });
 

--- a/ui/component/viewers/videoViewer/index.js
+++ b/ui/component/viewers/videoViewer/index.js
@@ -16,7 +16,7 @@ import {
 import { selectVolume, selectMute } from 'redux/selectors/app';
 import { savePosition, clearPosition, doPlayUri, doSetPlayingUri } from 'redux/actions/content';
 import { makeSelectContentPositionForUri, makeSelectIsPlayerFloating, selectPlayingUri } from 'redux/selectors/content';
-import { makeSelectRecommendedContentForUri } from 'redux/selectors/search';
+import { selectRecommendedContentForUri } from 'redux/selectors/search';
 import VideoViewer from './view';
 import { withRouter } from 'react-router';
 import { doClaimEligiblePurchaseRewards } from 'redux/actions/rewards';
@@ -44,7 +44,7 @@ const select = (state, props) => {
     nextRecommendedUri = makeSelectNextUrlForCollectionAndUrl(collectionId, uri)(state);
     previousListUri = makeSelectPreviousUrlForCollectionAndUrl(collectionId, uri)(state);
   } else {
-    const recommendedContent = makeSelectRecommendedContentForUri(uri)(state);
+    const recommendedContent = selectRecommendedContentForUri(state, uri);
     nextRecommendedUri = recommendedContent && recommendedContent[0];
   }
 

--- a/ui/component/walletSendTip/index.js
+++ b/ui/component/walletSendTip/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import {
-  makeSelectTitleForUri,
+  selectTitleForUri,
   makeSelectClaimForUri,
   selectClaimIsMineForUri,
   selectFetchingMyChannels,
@@ -24,7 +24,7 @@ const select = (state, props) => ({
   instantTipEnabled: makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_ENABLED)(state),
   instantTipMax: makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_MAX)(state),
   isPending: selectIsSendingSupport(state),
-  title: makeSelectTitleForUri(props.uri)(state),
+  title: selectTitleForUri(state, props.uri),
 });
 
 export default withRouter(connect(select, { doHideModal, doSendTip, doSendCashTip })(WalletSendTip));

--- a/ui/component/wunderbarSuggestion/index.js
+++ b/ui/component/wunderbarSuggestion/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri, makeSelectIsUriResolving } from 'redux/selectors/claims';
+import { selectClaimForUri, selectIsUriResolving } from 'redux/selectors/claims';
 import WunderbarSuggestion from './view';
 
 const select = (state, props) => ({
-  claim: makeSelectClaimForUri(props.uri)(state),
-  isResolvingUri: makeSelectIsUriResolving(props.uri)(state),
+  claim: selectClaimForUri(state, props.uri),
+  isResolvingUri: selectIsUriResolving(state, props.uri),
 });
 
 export default connect(select)(WunderbarSuggestion);

--- a/ui/component/wunderbarTopSuggestion/index.js
+++ b/ui/component/wunderbarTopSuggestion/index.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import {
   makeSelectClaimForUri,
-  makeSelectIsUriResolving,
+  selectIsUriResolving,
   makeSelectTagInClaimOrChannelForUri,
 } from 'redux/selectors/claims';
 import { doResolveUris } from 'redux/actions/claims';
@@ -23,7 +23,7 @@ const select = (state, props) => {
     }
   } catch (e) {}
 
-  const resolvingUris = uris.some((uri) => makeSelectIsUriResolving(uri)(state));
+  const resolvingUris = uris.some((uri) => selectIsUriResolving(state, uri));
   const winningUri = makeSelectWinningUriForQuery(props.query)(state);
   const winningClaim = winningUri ? makeSelectClaimForUri(winningUri)(state) : undefined;
   const preferEmbed = makeSelectTagInClaimOrChannelForUri(winningUri, PREFERENCE_EMBED)(state);

--- a/ui/constants/claim.js
+++ b/ui/constants/claim.js
@@ -1,5 +1,4 @@
 // @flow
-import { MATURE_TAGS } from 'constants/tags';
 export const MINIMUM_PUBLISH_BID = 0.0001;
 export const ESTIMATED_FEE = 0.048; // .001 + .001 | .048 + .048 = .1
 
@@ -39,68 +38,3 @@ export const FORCE_CONTENT_TYPE_COMIC = [
   'application/x-cbz',
   'application/x-cb7',
 ];
-
-const matureTagMap = MATURE_TAGS.reduce((acc, tag) => ({ ...acc, [tag]: true }), {});
-
-export const isClaimNsfw = (claim: Claim): boolean => {
-  if (!claim) {
-    throw new Error('No claim passed to isClaimNsfw()');
-  }
-
-  if (!claim.value) {
-    return false;
-  }
-
-  const tags = claim.value.tags || [];
-  for (let i = 0; i < tags.length; i += 1) {
-    const tag = tags[i].toLowerCase();
-    if (matureTagMap[tag]) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
-export function createNormalizedClaimSearchKey(options: { page: number, release_time?: string }) {
-  // Ignore page because we don't care what the last page searched was, we want everything
-  // Ignore release_time because that will change depending on when you call claim_search ex: release_time: ">12344567"
-  const { page: optionToIgnoreForQuery, release_time: anotherToIgnore, ...rest } = options;
-  const query = JSON.stringify(rest);
-  return query;
-}
-
-export function concatClaims(claimList: Array<Claim> = [], concatClaimList: Array<any> = []): Array<Claim> {
-  if (!claimList || claimList.length === 0) {
-    if (!concatClaimList) {
-      return [];
-    }
-    return concatClaimList.slice();
-  }
-
-  const claims = claimList.slice();
-  concatClaimList.forEach((claim) => {
-    if (!claims.some((item) => item.claim_id === claim.claim_id)) {
-      claims.push(claim);
-    }
-  });
-
-  return claims;
-}
-
-export function filterClaims(claims: Array<Claim>, query: ?string): Array<Claim> {
-  if (query) {
-    const queryMatchRegExp = new RegExp(query, 'i');
-    return claims.filter((claim) => {
-      const { value } = claim;
-
-      return (
-        (value.title && value.title.match(queryMatchRegExp)) ||
-        (claim.signing_channel && claim.signing_channel.name.match(queryMatchRegExp)) ||
-        (claim.name && claim.name.match(queryMatchRegExp))
-      );
-    });
-  }
-
-  return claims;
-}

--- a/ui/modal/modalPublishPreview/index.js
+++ b/ui/modal/modalPublishPreview/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
 import ModalPublishPreview from './view';
 import { makeSelectPublishFormValue, selectPublishFormValues, selectIsStillEditing } from 'redux/selectors/publish';
-import { selectMyChannelClaims, makeSelectClaimIsStreamPlaceholder } from 'redux/selectors/claims';
+import { selectMyChannelClaims, selectIsStreamPlaceholderForUri } from 'redux/selectors/claims';
 import * as SETTINGS from 'constants/settings';
 import { selectFfmpegStatus, makeSelectClientSetting } from 'redux/selectors/settings';
 import { doPublishDesktop } from 'redux/actions/publish';
@@ -21,7 +21,7 @@ const select = (state, props) => {
     isStillEditing: selectIsStillEditing(state),
     ffmpegStatus: selectFfmpegStatus(state),
     enablePublishPreview: makeSelectClientSetting(SETTINGS.ENABLE_PUBLISH_PREVIEW)(state),
-    isLivestreamClaim: makeSelectClaimIsStreamPlaceholder(editingUri)(state),
+    isLivestreamClaim: selectIsStreamPlaceholderForUri(state, editingUri),
   };
 };
 

--- a/ui/modal/modalRemoveFile/index.js
+++ b/ui/modal/modalRemoveFile/index.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { doDeleteFileAndMaybeGoBack } from 'redux/actions/file';
 import {
-  makeSelectTitleForUri,
+  selectTitleForUri,
   makeSelectClaimForUri,
   makeSelectIsAbandoningClaimForUri,
   selectClaimIsMineForUri,
@@ -12,7 +12,7 @@ import ModalRemoveFile from './view';
 
 const select = (state, props) => ({
   claimIsMine: selectClaimIsMineForUri(state, props.uri),
-  title: makeSelectTitleForUri(props.uri)(state),
+  title: selectTitleForUri(state, props.uri),
   claim: makeSelectClaimForUri(props.uri)(state),
   isAbandoning: makeSelectIsAbandoningClaimForUri(props.uri)(state),
 });

--- a/ui/page/channel/index.js
+++ b/ui/page/channel/index.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import {
   selectClaimIsMine,
-  makeSelectTitleForUri,
+  selectTitleForUri,
   getThumbnailFromClaim,
   makeSelectCoverForUri,
   selectCurrentChannelPage,
@@ -9,7 +9,7 @@ import {
   makeSelectClaimIsPending,
 } from 'redux/selectors/claims';
 import { selectMyUnpublishedCollections } from 'redux/selectors/collections';
-import { selectBlackListedOutpoints, doFetchSubCount, makeSelectSubCountForUri } from 'lbryinc';
+import { selectBlackListedOutpoints, doFetchSubCount, selectSubCountForUri } from 'lbryinc';
 import { selectYoutubeChannels } from 'redux/selectors/user';
 import { selectIsSubscribedForUri } from 'redux/selectors/subscriptions';
 import { selectModerationBlockList } from 'redux/selectors/comments';
@@ -21,7 +21,7 @@ const select = (state, props) => {
   const claim = selectClaimForUri(state, props.uri);
 
   return {
-    title: makeSelectTitleForUri(props.uri)(state),
+    title: selectTitleForUri(state, props.uri),
     thumbnail: getThumbnailFromClaim(claim),
     cover: makeSelectCoverForUri(props.uri)(state),
     channelIsMine: selectClaimIsMine(state, claim),
@@ -29,7 +29,7 @@ const select = (state, props) => {
     claim,
     isSubscribed: selectIsSubscribedForUri(state, props.uri),
     blackListedOutpoints: selectBlackListedOutpoints(state),
-    subCount: makeSelectSubCountForUri(props.uri)(state),
+    subCount: selectSubCountForUri(state, props.uri),
     pending: makeSelectClaimIsPending(props.uri)(state),
     youtubeChannels: selectYoutubeChannels(state),
     blockedChannels: selectModerationBlockList(state),

--- a/ui/page/collection/index.js
+++ b/ui/page/collection/index.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import CollectionPage from './view';
 import {
-  makeSelectTitleForUri,
+  selectTitleForUri,
   getThumbnailFromClaim,
   selectClaimIsMine,
   makeSelectClaimIsPending,
@@ -38,7 +38,7 @@ const select = (state, props) => {
     collectionUrls: makeSelectUrlsForCollectionId(collectionId)(state),
     collectionCount: makeSelectCountForCollectionId(collectionId)(state),
     isResolvingCollection: makeSelectIsResolvingCollectionForId(collectionId)(state),
-    title: makeSelectTitleForUri(uri)(state),
+    title: selectTitleForUri(state, uri),
     thumbnail: getThumbnailFromClaim(claim),
     isMyClaim: selectClaimIsMine(state, claim), // or collection is mine?
     isMyCollection: makeSelectCollectionIsMine(collectionId)(state),

--- a/ui/page/embedWrapper/index.js
+++ b/ui/page/embedWrapper/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import EmbedWrapperPage from './view';
-import { makeSelectClaimForUri, makeSelectIsUriResolving } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectIsUriResolving } from 'redux/selectors/claims';
 import { makeSelectStreamingUrlForUri } from 'redux/selectors/file_info';
 import { doResolveUri } from 'redux/actions/claims';
 import { buildURI } from 'util/lbryURI';
@@ -17,7 +17,7 @@ const select = (state, props) => {
     claim: makeSelectClaimForUri(uri)(state),
     costInfo: makeSelectCostInfoForUri(uri)(state),
     streamingUrl: makeSelectStreamingUrlForUri(uri)(state),
-    isResolvingUri: makeSelectIsUriResolving(uri)(state),
+    isResolvingUri: selectIsUriResolving(state, uri),
     blackListedOutpoints: selectBlackListedOutpoints(state),
   };
 };

--- a/ui/page/file/index.js
+++ b/ui/page/file/index.js
@@ -2,9 +2,9 @@ import { connect } from 'react-redux';
 import { doSetContentHistoryItem, doSetPrimaryUri, clearPosition } from 'redux/actions/content';
 import { withRouter } from 'react-router-dom';
 import {
-  makeSelectClaimIsNsfw,
+  selectClaimIsNsfwForUri,
   makeSelectTagInClaimOrChannelForUri,
-  makeSelectClaimIsStreamPlaceholder,
+  selectIsStreamPlaceholderForUri,
 } from 'redux/selectors/claims';
 import { makeSelectFileInfoForUri } from 'redux/selectors/file_info';
 import { doFetchFileInfo } from 'redux/actions/file_info';
@@ -27,12 +27,12 @@ const select = (state, props) => {
     linkedCommentId: urlParams.get('lc'),
     costInfo: makeSelectCostInfoForUri(props.uri)(state),
     obscureNsfw: !selectShowMatureContent(state),
-    isMature: makeSelectClaimIsNsfw(props.uri)(state),
+    isMature: selectClaimIsNsfwForUri(state, props.uri),
     fileInfo: makeSelectFileInfoForUri(props.uri)(state),
     renderMode: makeSelectFileRenderModeForUri(props.uri)(state),
     videoTheaterMode: makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)(state),
     commentsDisabled: makeSelectTagInClaimOrChannelForUri(props.uri, DISABLE_COMMENTS_TAG)(state),
-    isLivestream: makeSelectClaimIsStreamPlaceholder(props.uri)(state),
+    isLivestream: selectIsStreamPlaceholderForUri(state, props.uri),
     collection: makeSelectCollectionForId(collectionId)(state),
     collectionId,
     position: makeSelectContentPositionForUri(props.uri)(state),

--- a/ui/page/show/index.js
+++ b/ui/page/show/index.js
@@ -5,12 +5,12 @@ import { withRouter } from 'react-router';
 import { PAGE_SIZE } from 'constants/claim';
 import {
   makeSelectClaimForUri,
-  makeSelectIsUriResolving,
+  selectIsUriResolving,
   makeSelectTotalPagesForChannel,
-  makeSelectTitleForUri,
+  selectTitleForUri,
   selectClaimIsMine,
   makeSelectClaimIsPending,
-  makeSelectClaimIsStreamPlaceholder,
+  selectIsStreamPlaceholderForUri,
 } from 'redux/selectors/claims';
 import {
   makeSelectCollectionForId,
@@ -72,14 +72,14 @@ const select = (state, props) => {
   return {
     uri,
     claim,
-    isResolvingUri: makeSelectIsUriResolving(uri)(state),
+    isResolvingUri: selectIsUriResolving(state, uri),
     blackListedOutpoints: selectBlackListedOutpoints(state),
     totalPages: makeSelectTotalPagesForChannel(uri, PAGE_SIZE)(state),
     isSubscribed: makeSelectChannelInSubscriptions(uri)(state),
-    title: makeSelectTitleForUri(uri)(state),
+    title: selectTitleForUri(state, uri),
     claimIsMine: selectClaimIsMine(state, claim),
     claimIsPending: makeSelectClaimIsPending(uri)(state),
-    isLivestream: makeSelectClaimIsStreamPlaceholder(uri)(state),
+    isLivestream: selectIsStreamPlaceholderForUri(state, uri),
     collection: makeSelectCollectionForId(collectionId)(state),
     collectionId: collectionId,
     collectionUrls: makeSelectUrlsForCollectionId(collectionId)(state),

--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -1,7 +1,7 @@
 // @flow
 import * as ACTIONS from 'constants/action_types';
 import { selectShowMatureContent } from 'redux/selectors/settings';
-import { makeSelectClaimForUri, makeSelectClaimIsNsfw } from 'redux/selectors/claims';
+import { selectClaimForUri, selectClaimIsNsfwForUri } from 'redux/selectors/claims';
 import { doResolveUris } from 'redux/actions/claims';
 import { buildURI, isURIValid } from 'util/lbryURI';
 import { batchActions } from 'util/batch-actions';
@@ -12,7 +12,7 @@ import { getRecommendationSearchOptions } from 'util/search';
 import { SEARCH_SERVER_API } from 'config';
 
 type Dispatch = (action: any) => any;
-type GetState = () => { search: SearchState };
+type GetState = () => { claims: any, search: SearchState };
 
 type SearchOptions = {
   size?: number,
@@ -131,9 +131,9 @@ export const doUpdateSearchOptions = (newOptions: SearchOptions, additionalOptio
 
 export const doFetchRecommendedContent = (uri: string) => (dispatch: Dispatch, getState: GetState) => {
   const state = getState();
-  const claim = makeSelectClaimForUri(uri)(state);
+  const claim = selectClaimForUri(state, uri);
   const matureEnabled = selectShowMatureContent(state);
-  const claimIsMature = makeSelectClaimIsNsfw(uri)(state);
+  const claimIsMature = selectClaimIsNsfwForUri(state, uri);
 
   if (claim && claim.value && claim.claim_id) {
     const options: SearchOptions = getRecommendationSearchOptions(matureEnabled, claimIsMature, claim.claim_id);

--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 import {
   makeSelectClaimForUri,
   selectClaimsByUri,
-  makeSelectClaimIsNsfw,
+  selectClaimIsNsfwForUri,
   makeSelectClaimIsMine,
   makeSelectContentTypeForUri,
 } from 'redux/selectors/claims';
@@ -85,10 +85,11 @@ export const selectRecentHistory = createSelector(selectHistory, (history) => {
   return history.slice(0, RECENT_HISTORY_AMOUNT);
 });
 
-export const makeSelectShouldObscurePreview = (uri: string) =>
-  createSelector(selectShowMatureContent, makeSelectClaimIsNsfw(uri), (showMatureContent, isClaimMature) => {
-    return isClaimMature && !showMatureContent;
-  });
+export const selectShouldObscurePreviewForUri = (state: State, uri: string) => {
+  const showMatureContent = selectShowMatureContent(state);
+  const isClaimMature = selectClaimIsNsfwForUri(state, uri);
+  return isClaimMature && !showMatureContent;
+};
 
 // should probably be in lbry-redux, yarn link was fighting me
 export const makeSelectFileExtensionForUri = (uri: string) =>

--- a/ui/redux/selectors/search.js
+++ b/ui/redux/selectors/search.js
@@ -6,20 +6,21 @@ import {
   selectClaimsByUri,
   makeSelectClaimForUri,
   makeSelectClaimForClaimId,
-  makeSelectClaimIsNsfw,
+  selectClaimIsNsfwForUri,
   makeSelectPendingClaimForUri,
-  makeSelectIsUriResolving,
+  selectIsUriResolving,
 } from 'redux/selectors/claims';
 import { parseURI } from 'util/lbryURI';
 import { isClaimNsfw } from 'util/claim';
 import { createSelector } from 'reselect';
+import { createCachedSelector } from 're-reselect';
 import { createNormalizedSearchKey, getRecommendationSearchOptions } from 'util/search';
 import { selectMutedChannels } from 'redux/selectors/blocked';
 import { selectHistory } from 'redux/selectors/content';
 import { selectAllCostInfoByUri } from 'lbryinc';
 import { SIMPLE_SITE } from 'config';
 
-type State = { search: SearchState };
+type State = { claims: any, search: SearchState };
 
 export const selectState = (state: State): SearchState => state.search;
 
@@ -51,98 +52,98 @@ export const makeSelectHasReachedMaxResultsLength = (query: string): ((state: St
     return hasReachedMaxResultsLength[query];
   });
 
-export const makeSelectRecommendedContentForUri = (uri: string) =>
-  createSelector(
-    selectHistory,
-    selectClaimsByUri,
-    selectShowMatureContent,
-    selectMutedChannels,
-    selectAllCostInfoByUri,
-    selectSearchResultByQuery,
-    makeSelectClaimIsNsfw(uri),
-    (history, claimsByUri, matureEnabled, blockedChannels, costInfoByUri, searchUrisByQuery, isMature) => {
-      const claim = claimsByUri[uri];
+export const selectRecommendedContentForUri = createCachedSelector(
+  (state, uri) => uri,
+  selectHistory,
+  selectClaimsByUri,
+  selectShowMatureContent,
+  selectMutedChannels,
+  selectAllCostInfoByUri,
+  selectSearchResultByQuery,
+  selectClaimIsNsfwForUri, // (state, uri)
+  (uri, history, claimsByUri, matureEnabled, blockedChannels, costInfoByUri, searchUrisByQuery, isMature) => {
+    const claim = claimsByUri[uri];
 
-      if (!claim) return;
+    if (!claim) return;
 
-      let recommendedContent;
-      // always grab the claimId - this value won't change for filtering
-      const currentClaimId = claim.claim_id;
+    let recommendedContent;
+    // always grab the claimId - this value won't change for filtering
+    const currentClaimId = claim.claim_id;
 
-      const { title } = claim.value;
+    const { title } = claim.value;
 
-      if (!title) return;
+    if (!title) return;
 
-      const options: {
-        size: number,
-        nsfw?: boolean,
-        isBackgroundSearch?: boolean,
-      } = { size: 20, nsfw: matureEnabled, isBackgroundSearch: true };
+    const options: {
+      size: number,
+      nsfw?: boolean,
+      isBackgroundSearch?: boolean,
+    } = { size: 20, nsfw: matureEnabled, isBackgroundSearch: true };
 
-      if (SIMPLE_SITE) {
-        options[SEARCH_OPTIONS.CLAIM_TYPE] = SEARCH_OPTIONS.INCLUDE_FILES;
-        options[SEARCH_OPTIONS.MEDIA_VIDEO] = true;
-        options[SEARCH_OPTIONS.PRICE_FILTER_FREE] = true;
-      }
-      if (matureEnabled || (!matureEnabled && !isMature)) {
-        options[SEARCH_OPTIONS.RELATED_TO] = claim.claim_id;
-      }
-
-      const searchQuery = getSearchQueryString(title.replace(/\//, ' '), options);
-      const normalizedSearchQuery = createNormalizedSearchKey(searchQuery);
-
-      let searchResult = searchUrisByQuery[normalizedSearchQuery];
-
-      if (searchResult) {
-        // Filter from recommended: The same claim and blocked channels
-        recommendedContent = searchResult['uris'].filter((searchUri) => {
-          const searchClaim = claimsByUri[searchUri];
-
-          if (!searchClaim) return;
-
-          const signingChannel = searchClaim && searchClaim.signing_channel;
-          const channelUri = signingChannel && signingChannel.canonical_url;
-          const blockedMatch = blockedChannels.some((blockedUri) => blockedUri.includes(channelUri));
-
-          let isEqualUri;
-          try {
-            const { claimId: searchId } = parseURI(searchUri);
-            isEqualUri = searchId === currentClaimId;
-          } catch (e) {}
-
-          return !isEqualUri && !blockedMatch;
-        });
-
-        // Claim to play next: playable and free claims not played before in history
-        const nextUriToPlay = recommendedContent.filter((nextRecommendedUri) => {
-          const costInfo = costInfoByUri[nextRecommendedUri] && costInfoByUri[nextRecommendedUri].cost;
-          const recommendedClaim = claimsByUri[nextRecommendedUri];
-          const isVideo = recommendedClaim && recommendedClaim.value && recommendedClaim.value.stream_type === 'video';
-          const isAudio = recommendedClaim && recommendedClaim.value && recommendedClaim.value.stream_type === 'audio';
-
-          let historyMatch = false;
-          try {
-            const { claimId: nextRecommendedId } = parseURI(nextRecommendedUri);
-
-            historyMatch = history.some(
-              (historyItem) =>
-                (claimsByUri[historyItem.uri] && claimsByUri[historyItem.uri].claim_id) === nextRecommendedId
-            );
-          } catch (e) {}
-
-          return !historyMatch && costInfo === 0 && (isVideo || isAudio);
-        })[0];
-
-        const index = recommendedContent.indexOf(nextUriToPlay);
-        if (index > 0) {
-          const a = recommendedContent[0];
-          recommendedContent[0] = nextUriToPlay;
-          recommendedContent[index] = a;
-        }
-      }
-      return recommendedContent;
+    if (SIMPLE_SITE) {
+      options[SEARCH_OPTIONS.CLAIM_TYPE] = SEARCH_OPTIONS.INCLUDE_FILES;
+      options[SEARCH_OPTIONS.MEDIA_VIDEO] = true;
+      options[SEARCH_OPTIONS.PRICE_FILTER_FREE] = true;
     }
-  );
+    if (matureEnabled || (!matureEnabled && !isMature)) {
+      options[SEARCH_OPTIONS.RELATED_TO] = claim.claim_id;
+    }
+
+    const searchQuery = getSearchQueryString(title.replace(/\//, ' '), options);
+    const normalizedSearchQuery = createNormalizedSearchKey(searchQuery);
+
+    let searchResult = searchUrisByQuery[normalizedSearchQuery];
+
+    if (searchResult) {
+      // Filter from recommended: The same claim and blocked channels
+      recommendedContent = searchResult['uris'].filter((searchUri) => {
+        const searchClaim = claimsByUri[searchUri];
+
+        if (!searchClaim) return;
+
+        const signingChannel = searchClaim && searchClaim.signing_channel;
+        const channelUri = signingChannel && signingChannel.canonical_url;
+        const blockedMatch = blockedChannels.some((blockedUri) => blockedUri.includes(channelUri));
+
+        let isEqualUri;
+        try {
+          const { claimId: searchId } = parseURI(searchUri);
+          isEqualUri = searchId === currentClaimId;
+        } catch (e) {}
+
+        return !isEqualUri && !blockedMatch;
+      });
+
+      // Claim to play next: playable and free claims not played before in history
+      const nextUriToPlay = recommendedContent.filter((nextRecommendedUri) => {
+        const costInfo = costInfoByUri[nextRecommendedUri] && costInfoByUri[nextRecommendedUri].cost;
+        const recommendedClaim = claimsByUri[nextRecommendedUri];
+        const isVideo = recommendedClaim && recommendedClaim.value && recommendedClaim.value.stream_type === 'video';
+        const isAudio = recommendedClaim && recommendedClaim.value && recommendedClaim.value.stream_type === 'audio';
+
+        let historyMatch = false;
+        try {
+          const { claimId: nextRecommendedId } = parseURI(nextRecommendedUri);
+
+          historyMatch = history.some(
+            (historyItem) =>
+              (claimsByUri[historyItem.uri] && claimsByUri[historyItem.uri].claim_id) === nextRecommendedId
+          );
+        } catch (e) {}
+
+        return !historyMatch && costInfo === 0 && (isVideo || isAudio);
+      })[0];
+
+      const index = recommendedContent.indexOf(nextUriToPlay);
+      if (index > 0) {
+        const a = recommendedContent[0];
+        recommendedContent[0] = nextUriToPlay;
+        recommendedContent[index] = a;
+      }
+    }
+    return recommendedContent;
+  }
+)((state, uri) => String(uri));
 
 export const makeSelectRecommendedRecsysIdForClaimId = (claimId: string) =>
   createSelector(
@@ -234,7 +235,7 @@ export const makeSelectWinningUriForQuery = (query: string) => {
   );
 };
 
-export const makeSelectIsResolvingWinningUri = (query: string = '') => {
+export const selectIsResolvingWinningUri = (state: State, query: string = '') => {
   const uriFromQuery = `lbry://${query}`;
   let channelUriFromQuery;
   try {
@@ -244,13 +245,9 @@ export const makeSelectIsResolvingWinningUri = (query: string = '') => {
     }
   } catch (e) {}
 
-  return createSelector(
-    makeSelectIsUriResolving(uriFromQuery),
-    channelUriFromQuery ? makeSelectIsUriResolving(channelUriFromQuery) : () => {},
-    (claim1IsResolving, claim2IsResolving) => {
-      return claim1IsResolving || claim2IsResolving;
-    }
-  );
+  const claim1IsResolving = selectIsUriResolving(state, uriFromQuery);
+  const claim2IsResolving = channelUriFromQuery ? selectIsUriResolving(state, channelUriFromQuery) : false;
+  return claim1IsResolving || claim2IsResolving;
 };
 
 export const makeSelectUrlForClaimId = (claimId: string) =>

--- a/ui/redux/selectors/settings.js
+++ b/ui/redux/selectors/settings.js
@@ -15,13 +15,19 @@ export const selectFindingFFmpeg = (state) => selectState(state).findingFFmpeg |
 export const selectClientSettings = (state) => selectState(state).clientSettings || {};
 export const selectLoadedLanguages = (state) => selectState(state).loadedLanguages || {};
 
+export const selectClientSetting = (state, setting) => {
+  const clientSettings = selectClientSettings(state);
+  return clientSettings ? clientSettings[setting] : undefined;
+};
+
+// TODO - kill this
 export const makeSelectClientSetting = (setting) =>
   createSelector(selectClientSettings, (settings) => (settings ? settings[setting] : undefined));
 
 // refactor me
-export const selectShowMatureContent = !ENABLE_MATURE
-  ? createSelector(() => false)
-  : makeSelectClientSetting(SETTINGS.SHOW_MATURE);
+export const selectShowMatureContent = (state) => {
+  return !ENABLE_MATURE ? false : selectClientSetting(state, SETTINGS.SHOW_MATURE);
+};
 
 // and me
 export const selectShowRepostedContent = makeSelectClientSetting(SETTINGS.HIDE_REPOSTS);

--- a/web/component/ads/index.js
+++ b/web/component/ads/index.js
@@ -1,11 +1,12 @@
 import { connect } from 'react-redux';
 import { selectTheme } from 'redux/selectors/settings';
-import { makeSelectClaimForUri, makeSelectClaimIsNsfw } from 'redux/selectors/claims';
+import { makeSelectClaimForUri, selectClaimIsNsfwForUri } from 'redux/selectors/claims';
 import Ads from './view';
+
 const select = (state, props) => ({
   theme: selectTheme(state),
   claim: makeSelectClaimForUri(props.uri)(state),
-  isMature: makeSelectClaimIsNsfw(props.uri)(state),
+  isMature: selectClaimIsNsfwForUri(state, props.uri),
 });
 
 export default connect(select)(Ads);


### PR DESCRIPTION
## Issue
Lots of time is spent mapping the state to props for this component (since there are lots of tiles).

## Changes
Using this component as a starting point, went through the selectors and made the usual cleanup/fixes:
- Move away from the wrong `makeSelect*` model, which creates a new selector on every call instead of actually re-using the cached version.
- Do proper caching for multi-param selectors using `re-reselect`.
- Don't cache simple functions or direct access to states.

## Results
Here's a small sample of time saved when scrolling the homepage.  The first `select` in the list refers to `ClaimPreviewTile`, and the total time dropped from 250ms to 50ms, and the total mapping time for all components dropped 50% (580ms --> 220ms), since the selectors are shared by many components.

<img src="https://user-images.githubusercontent.com/64950861/141937920-1906cc03-907c-44b7-9d70-11faa611540d.png" width="400">      -      <img src="https://user-images.githubusercontent.com/64950861/141937763-220b29ac-849b-4519-9dbc-ac45a7cbf6e5.png" width="400">













