### PR TITLE
Fix annoying hierarchy error with Yrbl

### DIFF
--- a/ui/component/yrbl/index.jsx
+++ b/ui/component/yrbl/index.jsx
@@ -41,7 +41,7 @@ export default class extends React.PureComponent<Props> {
           {(title || subtitle) && (
             <div className="yrbl__content">
               <h2 className="section__title">{title}</h2>
-              <p className="section__subtitle">{subtitle}</p>
+              <div className="section__subtitle">{subtitle}</div>
             </div>
           )}
           {actions}


### PR DESCRIPTION
`<div>` cannot be a descendend of `<p>`, and `{subtitle}`s sometimes need to have `<div>`s.

Just switch from `<p>` to `<div>`, and let the client decide when the actual text paragraphs are.
