### PR TITLE
Cache the processing of ChannelMentionSuggestions

### DIFF
--- a/ui/component/channelMentionSuggestions/index.js
+++ b/ui/component/channelMentionSuggestions/index.js
@@ -3,38 +3,23 @@ import { MAX_LIVESTREAM_COMMENTS } from 'constants/livestream';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import { selectSubscriptionUris } from 'redux/selectors/subscriptions';
 import { withRouter } from 'react-router';
-import { makeSelectClaimForUri } from 'redux/selectors/claims';
+import { selectCanonicalUrlForUri } from 'redux/selectors/claims';
 import { doResolveUris } from 'redux/actions/claims';
-import { selectTopLevelCommentsForUri } from 'redux/selectors/comments';
+import { selectChannelMentionData } from 'redux/selectors/livestream';
 import ChannelMentionSuggestions from './view';
 
 const select = (state, props) => {
-  const subscriptionUris = selectSubscriptionUris(state);
-  const topLevelComments = selectTopLevelCommentsForUri(
-    state,
-    props.uri,
-    props.isLivestream ? MAX_LIVESTREAM_COMMENTS : -1
-  );
-
-  const commentorUris = [];
-  // Avoid repeated commentors
-  topLevelComments.map(({ channel_url }) => !commentorUris.includes(channel_url) && commentorUris.push(channel_url));
-
-  const getUnresolved = (uris) =>
-    uris.map((uri) => !makeSelectClaimForUri(uri)(state) && uri).filter((uri) => uri !== false);
-  const getCanonical = (uris) =>
-    uris
-      .map((uri) => makeSelectClaimForUri(uri)(state) && makeSelectClaimForUri(uri)(state).canonical_url)
-      .filter((uri) => Boolean(uri));
+  const maxComments = props.isLivestream ? MAX_LIVESTREAM_COMMENTS : -1;
+  const data = selectChannelMentionData(state, props.uri, maxComments);
 
   return {
-    commentorUris,
-    subscriptionUris,
-    unresolvedCommentors: getUnresolved(commentorUris),
-    unresolvedSubscriptions: getUnresolved(subscriptionUris),
-    canonicalCreator: getCanonical([props.creatorUri])[0],
-    canonicalCommentors: getCanonical(commentorUris),
-    canonicalSubscriptions: getCanonical(subscriptionUris),
+    commentorUris: data.commentorUris,
+    subscriptionUris: selectSubscriptionUris(state),
+    unresolvedCommentors: data.unresolvedCommentors,
+    unresolvedSubscriptions: data.unresolvedSubscriptions,
+    canonicalCreator: selectCanonicalUrlForUri(state, props.creatorUri),
+    canonicalCommentors: data.canonicalCommentors,
+    canonicalSubscriptions: data.canonicalSubscriptions,
     showMature: selectShowMatureContent(state),
   };
 };

--- a/ui/redux/selectors/livestream.js
+++ b/ui/redux/selectors/livestream.js
@@ -1,7 +1,9 @@
 // @flow
 import { createSelector } from 'reselect';
 import { createCachedSelector } from 're-reselect';
-import { selectMyClaims, selectPendingClaims } from 'redux/selectors/claims';
+import { selectMyClaims, selectPendingClaims, selectClaimIdsByUri, selectClaimsById } from 'redux/selectors/claims';
+import { selectTopLevelCommentsForUri } from 'redux/selectors/comments';
+import { selectSubscriptionUris } from 'redux/selectors/subscriptions';
 
 type State = { livestream: any };
 
@@ -61,3 +63,67 @@ export const selectIsActiveLivestreamForUri = createCachedSelector(
     return activeLivestreamValues.some((v) => v.latestClaimUri === uri);
   }
 )((state, uri) => String(uri));
+
+// ****************************************************************************
+// Temporary
+// ****************************************************************************
+
+// Until ChannelMentions is redesigned, this serves as a cached and leaner
+// version of the original code.
+export const selectChannelMentionData = createCachedSelector(
+  selectClaimIdsByUri,
+  selectClaimsById,
+  selectTopLevelCommentsForUri,
+  selectSubscriptionUris,
+  (claimIdsByUri, claimsById, topLevelComments, subscriptionUris) => {
+    const commentorUris = [];
+    const unresolvedCommentors = [];
+    const unresolvedSubscriptions = [];
+    const canonicalCommentors = [];
+    const canonicalSubscriptions = [];
+
+    topLevelComments.forEach((comment) => {
+      const uri = comment.channel_url;
+
+      if (!commentorUris.includes(uri)) {
+        // Update: commentorUris
+        commentorUris.push(uri);
+
+        // Update: unresolvedCommentors
+        const claimId = claimIdsByUri[uri];
+        if (claimId === undefined) {
+          unresolvedCommentors.push(uri);
+        }
+
+        // Update: canonicalCommentors
+        const claim = claimsById[claimId];
+        if (claim && claim.canonical_url) {
+          canonicalCommentors.push(claim.canonical_url);
+        }
+      }
+    });
+
+    subscriptionUris.forEach((uri) => {
+      // Update: unresolvedSubscriptions
+      const claimId = claimIdsByUri[uri];
+      if (claimId === undefined) {
+        unresolvedSubscriptions.push(uri);
+      }
+
+      // Update: canonicalSubscriptions
+      const claim = claimsById[claimId];
+      if (claim && claim.canonical_url) {
+        canonicalSubscriptions.push(claim.canonical_url);
+      }
+    });
+
+    return {
+      topLevelComments,
+      commentorUris,
+      unresolvedCommentors,
+      canonicalCommentors,
+      unresolvedSubscriptions,
+      canonicalSubscriptions,
+    };
+  }
+)((state, uri, maxCount) => `${String(uri)}:${maxCount}`);


### PR DESCRIPTION
## Issue
`ChannelMentionSuggestions` is one of the bottlenecks of livestream page.

The component probably needs a re-design ....
- Don't perpetually mount -- only mount when activated by the user through "@". This would avoid the heavy processing entirely.
- Need better way of resolving uris (too many arrays, too many loops).
- Tom also mentioned that we should not be resolving every commenter as we encounter them in a livestream. This is currently the case, probably because the component is always mounted. 
- Currently, the heavy loop also runs every time you type something in `CommentCreate`. This doesn't feel normal.

## Changes
Until the re-design occurs, attempt to cache the heavy processing. Also, trimmed down the amount of loops.

## Results
Before:  
Every time something trivial updates in redux (e.g. viewer count, sync loop), the processing runs and tops the list in the profiler:
![2021-11-17--20-30](https://user-images.githubusercontent.com/64950861/142201284-f8e88e01-19c5-412a-b20d-e59291ca8695.png)

After:
![image](https://user-images.githubusercontent.com/64950861/142203087-5aa3ee3a-4b75-44e2-97f9-bca7c1e2e8a4.png)

----

@saltrafael, can you give this a review to ensure things are still 1:1 and no worse side-effects?
We can also drop this PR if you have ideas to fix the issues mentioned above (but I think it would require lots of rework and testing).