### PR TITLE
Fix blacklisted claims appearing in tiles

### DIFF
--- a/extras/lbryinc/redux/selectors/ban.js
+++ b/extras/lbryinc/redux/selectors/ban.js
@@ -9,61 +9,33 @@ import { selectClaimForUri } from 'redux/selectors/claims';
 import { selectMutedChannels } from 'redux/selectors/blocked';
 import { selectModerationBlockList } from 'redux/selectors/comments';
 import { selectBlackListedOutpoints, selectFilteredOutpoints } from 'lbryinc';
+import { getChannelFromClaim } from 'util/claim';
 import { isURIEqual } from 'util/lbryURI';
 
-const selectClaimExistsForUri = (state, uri) => {
-  return Boolean(selectClaimForUri(state, uri));
-};
-
-const selectTxidForUri = (state, uri) => {
-  const claim = selectClaimForUri(state, uri);
-  const signingChannel = claim && claim.signing_channel;
-  return signingChannel ? signingChannel.txid : claim ? claim.txid : undefined;
-};
-
-const selectNoutForUri = (state, uri) => {
-  const claim = selectClaimForUri(state, uri);
-  const signingChannel = claim && claim.signing_channel;
-  return signingChannel ? signingChannel.nout : claim ? claim.nout : undefined;
-};
-
-const selectPermanentUrlForUri = (state, uri) => {
-  const claim = selectClaimForUri(state, uri);
-  const signingChannel = claim && claim.signing_channel;
-  return signingChannel ? signingChannel.permanent_url : claim ? claim.permanent_url : undefined;
-};
-
 export const selectBanStateForUri = createCachedSelector(
-  // Break apart 'selectClaimForUri' into 4 cheaper selectors that return
-  // primitives for values that we care about. The Claim object itself is easily
-  // invalidated due to constantly-changing fields like 'confirmation'.
-  selectClaimExistsForUri,
-  selectTxidForUri,
-  selectNoutForUri,
-  selectPermanentUrlForUri,
+  selectClaimForUri,
   selectBlackListedOutpoints,
   selectFilteredOutpoints,
   selectMutedChannels,
   selectModerationBlockList,
-  (
-    claimExists,
-    txid,
-    nout,
-    permanentUrl,
-    blackListedOutpoints,
-    filteredOutpoints,
-    mutedChannelUris,
-    personalBlocklist
-  ) => {
+  (claim, blackListedOutpoints, filteredOutpoints, mutedChannelUris, personalBlocklist) => {
     const banState = {};
 
-    if (!claimExists) {
+    if (!claim) {
       return banState;
     }
 
+    const channelClaim = getChannelFromClaim(claim);
+
     // This will be replaced once blocking is done at the wallet server level.
     if (blackListedOutpoints) {
-      if (blackListedOutpoints.some((outpoint) => outpoint.txid === txid && outpoint.nout === nout)) {
+      if (
+        blackListedOutpoints.some(
+          (outpoint) =>
+            (channelClaim && outpoint.txid === channelClaim.txid && outpoint.nout === channelClaim.nout) ||
+            (outpoint.txid === claim.txid && outpoint.nout === claim.nout)
+        )
+      ) {
         banState['blacklisted'] = true;
       }
     }
@@ -71,22 +43,28 @@ export const selectBanStateForUri = createCachedSelector(
     // We're checking to see if the stream outpoint or signing channel outpoint
     // is in the filter list.
     if (filteredOutpoints) {
-      if (filteredOutpoints.some((outpoint) => outpoint.txid === txid && outpoint.nout === nout)) {
+      if (
+        filteredOutpoints.some(
+          (outpoint) =>
+            (channelClaim && outpoint.txid === channelClaim.txid && outpoint.nout === channelClaim.nout) ||
+            (outpoint.txid === claim.txid && outpoint.nout === claim.nout)
+        )
+      ) {
         banState['filtered'] = true;
       }
     }
 
     // block stream claims
     // block channel claims if we can't control for them in claim search
-    if (mutedChannelUris.length) {
-      if (mutedChannelUris.some((blockedUri) => isURIEqual(blockedUri, permanentUrl))) {
+    if (mutedChannelUris.length && channelClaim) {
+      if (mutedChannelUris.some((blockedUri) => isURIEqual(blockedUri, channelClaim.permanent_url))) {
         banState['muted'] = true;
       }
     }
 
     // Commentron blocklist
-    if (personalBlocklist.length) {
-      if (personalBlocklist.some((blockedUri) => isURIEqual(blockedUri, permanentUrl))) {
+    if (personalBlocklist.length && channelClaim) {
+      if (personalBlocklist.some((blockedUri) => isURIEqual(blockedUri, channelClaim.permanent_url))) {
         banState['blocked'] = true;
       }
     }


### PR DESCRIPTION
## Mistake
Tried to simplify the logic between checking Signing Channel vs Content claim, and ended up always checking against Channel. This is ok for commentron blocklists, but not for blacklists where the txid is per claim.

## Changes
- Restored original logic.
- While at it, restored the usage of `selectClaimForUri` (i.e. no need to split into 4 selectors anymore), since we've updated the reducer to prevent invalidation from things like `confirmations` and `is_my_output`.
