### PR TITLE
Get active viewers even when not live (we want waiting count)

### DIFF
--- a/ui/component/fileViewCount/index.js
+++ b/ui/component/fileViewCount/index.js
@@ -10,7 +10,7 @@ const select = (state, props) => {
   return {
     claimId,
     viewCount: selectViewCountForUri(state, props.uri),
-    activeViewers: props.livestream && props.isLive && claimId ? selectViewersForId(state, claimId) : undefined,
+    activeViewers: props.livestream && claimId ? selectViewersForId(state, claimId) : undefined,
   };
 };
 


### PR DESCRIPTION
## Fixes

Get active viewers even when not live (we want waiting count)

Issue Number: N/A

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

We only select active viewers when live.

## What is the new behavior?

Always select active viewers.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
