### PR TITLE
ClaimLink: skip blacklist check

### DIFF
--- a/ui/component/claimLink/index.js
+++ b/ui/component/claimLink/index.js
@@ -3,7 +3,6 @@ import { makeSelectClaimForUri, selectIsUriResolving } from 'redux/selectors/cla
 import { doResolveUri } from 'redux/actions/claims';
 import { doSetPlayingUri } from 'redux/actions/content';
 import { punctuationMarks } from 'util/remark-lbry';
-import { selectBlackListedOutpoints } from 'lbryinc';
 import { selectPlayingUri } from 'redux/selectors/content';
 import ClaimLink from './view';
 
@@ -26,7 +25,6 @@ const select = (state, props) => {
     claim,
     fullUri: props.uri,
     isResolvingUri: selectIsUriResolving(state, uri),
-    blackListedOutpoints: selectBlackListedOutpoints(state),
     playingUri: selectPlayingUri(state),
   };
 };

--- a/ui/component/claimLink/view.jsx
+++ b/ui/component/claimLink/view.jsx
@@ -15,10 +15,6 @@ type Props = {
   description: ?string,
   isResolvingUri: boolean,
   doResolveUri: (string) => void,
-  blackListedOutpoints: Array<{
-    txid: string,
-    nout: number,
-  }>,
   playingUri: ?PlayingUri,
   parentCommentId?: string,
   isMarkdownPost?: boolean,
@@ -43,21 +39,6 @@ class ClaimLink extends React.Component<Props> {
     this.resolve(this.props);
   }
 
-  isClaimBlackListed() {
-    const { claim, blackListedOutpoints } = this.props;
-    const signingChannel = claim && claim.signing_channel;
-    if (claim && blackListedOutpoints) {
-      let blackListed = false;
-
-      blackListed = blackListedOutpoints.some(
-        (outpoint) =>
-          (signingChannel && outpoint.txid === signingChannel.txid && outpoint.nout === signingChannel.nout) ||
-          (outpoint.txid === claim.txid && outpoint.nout === claim.nout)
-      );
-      return blackListed;
-    }
-  }
-
   resolve = (props: Props) => {
     const { isResolvingUri, doResolveUri, claim, uri } = props;
 
@@ -79,14 +60,13 @@ class ClaimLink extends React.Component<Props> {
       allowPreview,
     } = this.props;
     const isUnresolved = (!isResolvingUri && !claim) || !claim;
-    const isBlacklisted = this.isClaimBlackListed();
     const isPlayingInline =
       playingUri &&
       playingUri.uri === uri &&
       ((playingUri.source === 'comment' && parentCommentId === playingUri.commentId) ||
         playingUri.source === 'markdown');
 
-    if (isBlacklisted || isUnresolved) {
+    if (isUnresolved) {
       return <span>{children}</span>;
     }
 


### PR DESCRIPTION
## Issue
- It was checking the blacklist on every render.
- Finding opportunities to improve performance.

## Changes
Since the final destination will be a dead end anyways, skip the blacklist-check so that livestreams can render a bit faster when there lots of mentions.

The only downside is that a claim preview for a blacklisted item would now appear (vs. being a text previously)

![image](https://user-images.githubusercontent.com/64950861/142592151-13e39372-b5bb-4b07-8d77-6f606a3f1740.png)
