### PR TITLE
Notifications: skip resolve during boot

### DIFF
--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -545,7 +545,7 @@ export function doSignIn() {
 
     dispatch(doGetAndPopulatePreferences());
     dispatch(doNotificationSocketConnect(true));
-    dispatch(doNotificationList());
+    dispatch(doNotificationList(null, false));
     dispatch(doCheckPendingClaims());
     dispatch(doBalanceSubscribe());
     dispatch(doFetchChannelListMine());


### PR DESCRIPTION
## Issue
- Large resolve count on bootup.

## Changes
- Skip the resolve call on sign-in (we just want the notification count). The same call will happen when you click the notification bell, so it's not too late to resolve at that time.
- Added `true` to `doResolveUris` to return cached results, otherwise it will keep resolving the same channels every time we enter Notifications Page.
