### PR TITLE
SyncFatalError: show nag instead of hard-crashing.

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2220,5 +2220,8 @@
   "Enter the full channel name or URL to search.\n\nExamples:\n - @channel\n - @channel#3\n - https://odysee.com/@Odysee:8\n - lbry://@Odysee#8": "Enter the full channel name or URL to search.\n\nExamples:\n - @channel\n - @channel#3\n - https://odysee.com/@Odysee:8\n - lbry://@Odysee#8",
   "Choose %asset%": "Choose %asset%",
   "Showing %filtered% results of %total%": "Showing %filtered% results of %total%",
+  "Failed to synchronize settings. Wait a while before retrying.": "Failed to synchronize settings. Wait a while before retrying.",
+  "You are offline. Check your internet connection.": "You are offline. Check your internet connection.",
+  "A new version of Odysee is available.": "A new version of Odysee is available.",
   "--end--": "--end--"
 }

--- a/web/effects/use-degraded-performance.js
+++ b/web/effects/use-degraded-performance.js
@@ -5,6 +5,14 @@ import { X_LBRY_AUTH_TOKEN } from 'constants/token';
 
 import fetchWithTimeout from 'util/fetch';
 
+const STATUS_GENERAL_STATE = {
+  // internal/status/status.go#L44
+  OK: 'ok',
+  NOT_READY: 'not_ready',
+  OFFLINE: 'offline',
+  FAILING: 'failing',
+};
+
 const STATUS_TIMEOUT_LIMIT = 10000;
 export const STATUS_OK = 'ok';
 export const STATUS_DEGRADED = 'degraded';
@@ -33,7 +41,9 @@ export function useDegradedPerformance(onDegradedPerformanceCallback, user) {
       fetchWithTimeout(STATUS_TIMEOUT_LIMIT, fetch(STATUS_ENDPOINT, getParams(user)))
         .then((response) => response.json())
         .then((status) => {
-          if (status.general_state !== STATUS_OK) {
+          if (status.general_state === STATUS_GENERAL_STATE.OFFLINE) {
+            onDegradedPerformanceCallback(STATUS_DOWN);
+          } else if (status.general_state !== STATUS_GENERAL_STATE.OK) {
             onDegradedPerformanceCallback(STATUS_FAILING);
           }
         })


### PR DESCRIPTION
## Issue
When sync fails, we crash the app.

## Ticket
Maybe handles [#39 Better handle both internal and web backend interruptions / downtime](https://github.com/OdyseeTeam/odysee-frontend/issues/39) too?

## Approach
I'm tackling this from the standpoint that (1) sync errors are not that fatal -- we'll just lose a few recent changes (2) network disconnection is the common cause.

## Changes
1. Downgrade the crash to a nag.
2. Detect if it's just a simple network disconnection, and tell the user.
3. If it's not network disconnection, tell the user that settings are now potentially unsynchronized. Then, add a button to retry to sync.

## Test
Try @ `kp`
Besides disconnecting the network, I don't really know how to simulate an actual sync error -- I just tweaked the code locally.

## Screenshots
![image](https://user-images.githubusercontent.com/64950861/142603241-72f1db80-8c2b-4ff7-b1a4-cb26cb4a5e19.png)

![image](https://user-images.githubusercontent.com/64950861/142603310-81bfe229-2b24-4bb4-9921-291811a21e02.png)

## Known tradeoffs
I'm not listening to `navigation.onLine` to keep things lite.  The sync loop on Tab Focus should happen often enough for the nag to check its visibility status.