### PR TITLE
TUS: Detect and disallow concurrent uploads

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1303,6 +1303,7 @@
   "Retrying...": "Retrying...",
   "Uploading...": "Uploading...",
   "Creating...": "Creating...",
+  "Stopped. Duplicate session detected.": "Stopped. Duplicate session detected.",
   "Use a URL": "Use a URL",
   "Edit Cover Image": "Edit Cover Image",
   "Cover Image": "Cover Image",

--- a/ui/component/webUploadList/internal/web-upload-item.jsx
+++ b/ui/component/webUploadList/internal/web-upload-item.jsx
@@ -66,6 +66,8 @@ export default function WebUploadItem(props: Props) {
             return __('Retrying...');
           case 'error':
             return __('Failed.');
+          case 'conflict':
+            return __('Stopped. Duplicate session detected.');
           default:
             return status;
         }
@@ -130,7 +132,7 @@ export default function WebUploadItem(props: Props) {
         <div className="claim-upload__progress--label">lbry://{params.name}</div>
         <div className={'claim-upload__progress--outer card--inline'}>
           <div className={'claim-upload__progress--inner'} style={{ width: `${progress}%` }}>
-            {resolveProgressStr()}
+            <span className="claim-upload__progress--inner-text">{resolveProgressStr()}</span>
           </div>
         </div>
       </>

--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -375,6 +375,15 @@
 .claim-upload__progress--inner {
   background: var(--color-primary-alt);
   padding: var(--spacing-xxs);
+  height: 2.4rem;
+}
+
+.claim-upload__progress--inner-text {
+  position: absolute;
+  width: 80%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 //

--- a/web/setup/publish-v2.js
+++ b/web/setup/publish-v2.js
@@ -48,8 +48,18 @@ export function makeResumableUploadRequest(
       id: new Date().getTime(),
     });
 
+    const urlOptions = {};
+    if (params.uploadUrl) {
+      // Resuming from previous upload. TUS clears the resume fingerprint on any
+      // 4xx error, so we need to use the fixed URL mode instead.
+      urlOptions.uploadUrl = params.uploadUrl;
+    } else {
+      // New upload, so use `endpoint`.
+      urlOptions.endpoint = RESUMABLE_ENDPOINT;
+    }
+
     const uploader = new tus.Upload(file, {
-      endpoint: RESUMABLE_ENDPOINT,
+      ...urlOptions,
       chunkSize: UPLOAD_CHUNK_SIZE_BYTE,
       retryDelays: [0, 5000, 10000, 15000],
       parallelUploads: 1,


### PR DESCRIPTION
## Ticket
#276 improve upload error handling 

## Issues
- `tus-js-client` clears the upload fingerprint on any 4xx error, which makes it not resumable and ended up creating a new session instead.  So, when a user tries to resume the same session/file from 2 different tabs concurrently, one of the tabs eventually hits `423` and starts a new upload session, hence the double SDK calls.

## Change
- Detect and disallow concurrent uploads.
- Use the client's "vimeo mode" (direct URL mode) to bypass that odd behavior of creating a new session on failure.
    - Fortunately, there is this direct URL mode, otherwise we would need to fork. We (Randy and I) still think it's odd for the client to do that -- it should let the user decide if they want to give up or not.