### PR TITLE
Un-authenticated `resolve`

### DIFF
--- a/ui/component/commentMenuList/view.jsx
+++ b/ui/component/commentMenuList/view.jsx
@@ -42,6 +42,7 @@ function CommentMenuList(props: Props) {
   const {
     uri,
     claim,
+    claimIsMine,
     authorUri,
     commentIsMine,
     commentId,
@@ -104,7 +105,7 @@ function CommentMenuList(props: Props) {
 
   function getBlockOptionElem() {
     const isPersonalBlockTheOnlyOption = !activeChannelIsModerator && !activeChannelIsAdmin;
-    const isTimeoutBlockAvailable = (claim && claim.is_my_output) || activeChannelIsModerator;
+    const isTimeoutBlockAvailable = claimIsMine || activeChannelIsModerator;
     const personalPermanentBlockOnly = isPersonalBlockTheOnlyOption && !isTimeoutBlockAvailable;
 
     function getSubtitle() {

--- a/ui/constants/token.js
+++ b/ui/constants/token.js
@@ -1,1 +1,5 @@
 export const X_LBRY_AUTH_TOKEN = 'X-Lbry-Auth-Token';
+
+// Additional parameter for apiCall() to skip sending the auth token.
+// NO_AUTH will be stripped from the parameter object before sending out.
+export const NO_AUTH = 'no_auth';

--- a/ui/lbry.js
+++ b/ui/lbry.js
@@ -1,4 +1,6 @@
 // @flow
+import { NO_AUTH, X_LBRY_AUTH_TOKEN } from 'constants/token';
+
 require('proxy-polyfill');
 
 const CHECK_DAEMON_STARTED_TRY_NUMBER = 200;
@@ -192,10 +194,18 @@ function checkAndParse(response) {
 }
 
 export function apiCall(method: string, params: ?{}, resolve: Function, reject: Function) {
+  let apiRequestHeaders = Lbry.apiRequestHeaders;
+
+  if (params && params[NO_AUTH]) {
+    apiRequestHeaders = Object.assign({}, Lbry.apiRequestHeaders);
+    delete apiRequestHeaders[X_LBRY_AUTH_TOKEN];
+    delete params[NO_AUTH];
+  }
+
   const counter = new Date().getTime();
   const options = {
     method: 'POST',
-    headers: Lbry.apiRequestHeaders,
+    headers: apiRequestHeaders,
     body: JSON.stringify({
       jsonrpc: '2.0',
       method,

--- a/ui/modal/modalBlockChannel/index.js
+++ b/ui/modal/modalBlockChannel/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { makeSelectClaimForUri } from 'redux/selectors/claims';
+import { selectClaimForUri, selectClaimIsMine } from 'redux/selectors/claims';
 import { doHideModal } from 'redux/actions/app';
 import { doCommentModBlock, doCommentModBlockAsAdmin, doCommentModBlockAsModerator } from 'redux/actions/comments';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
@@ -7,11 +7,15 @@ import { selectModerationDelegatorsById } from 'redux/selectors/comments';
 
 import ModalBlockChannel from './view';
 
-const select = (state, props) => ({
-  activeChannelClaim: selectActiveChannelClaim(state),
-  contentClaim: makeSelectClaimForUri(props.contentUri)(state),
-  moderationDelegatorsById: selectModerationDelegatorsById(state),
-});
+const select = (state, props) => {
+  const contentClaim = selectClaimForUri(state, props.contentUri);
+  return {
+    activeChannelClaim: selectActiveChannelClaim(state),
+    contentClaim,
+    contentClaimIsMine: selectClaimIsMine(state, contentClaim),
+    moderationDelegatorsById: selectModerationDelegatorsById(state),
+  };
+};
 
 const perform = {
   doHideModal,

--- a/ui/modal/modalBlockChannel/view.jsx
+++ b/ui/modal/modalBlockChannel/view.jsx
@@ -31,6 +31,7 @@ type Props = {
   // --- redux ---
   activeChannelClaim: ?ChannelClaim,
   contentClaim: ?Claim,
+  contentClaimIsMine: ?boolean,
   moderationDelegatorsById: { [string]: { global: boolean, delegators: { name: string, claimId: string } } },
   doHideModal: () => void,
   doCommentModBlock: (commenterUri: string, offendingCommentId: ?string, timeoutSec: ?number) => void,
@@ -55,6 +56,7 @@ export default function ModalBlockChannel(props: Props) {
     offendingCommentId,
     activeChannelClaim,
     contentClaim,
+    contentClaimIsMine,
     moderationDelegatorsById,
     doHideModal,
     doCommentModBlock,
@@ -78,7 +80,7 @@ export default function ModalBlockChannel(props: Props) {
   const [timeoutSec, setTimeoutSec] = React.useState(-1);
 
   const isPersonalTheOnlyTab = !activeChannelIsModerator && !activeChannelIsAdmin;
-  const isTimeoutAvail = (contentClaim && contentClaim.is_my_output) || activeChannelIsModerator;
+  const isTimeoutAvail = contentClaimIsMine || activeChannelIsModerator;
   const blockButtonDisabled = blockType === BLOCK.TIMEOUT && timeoutSec < 1;
 
   // **************************************************************************

--- a/ui/page/show/index.js
+++ b/ui/page/show/index.js
@@ -88,7 +88,8 @@ const select = (state, props) => {
 };
 
 const perform = (dispatch) => ({
-  resolveUri: (uri) => dispatch(doResolveUri(uri)),
+  resolveUri: (uri, returnCached, resolveRepost, options) =>
+    dispatch(doResolveUri(uri, returnCached, resolveRepost, options)),
   beginPublish: (name) => {
     dispatch(doClearPublish());
     dispatch(doPrepareEdit({ name }));

--- a/ui/page/show/view.jsx
+++ b/ui/page/show/view.jsx
@@ -23,7 +23,7 @@ const isDev = process.env.NODE_ENV !== 'production';
 
 type Props = {
   isResolvingUri: boolean,
-  resolveUri: (string) => void,
+  resolveUri: (string, boolean, boolean, any) => void,
   isSubscribed: boolean,
   uri: string,
   claim: StreamClaim,
@@ -107,7 +107,12 @@ function ShowPage(props: Props) {
       (resolveUri && !isResolvingUri && uri && haventFetchedYet) ||
       (claimExists && !claimIsPending && (!canonicalUrl || isMine === undefined))
     ) {
-      resolveUri(uri);
+      resolveUri(
+        uri,
+        false,
+        true,
+        isMine === undefined ? { include_is_my_output: true, include_purchase_receipt: true } : {}
+      );
     }
   }, [resolveUri, isResolvingUri, canonicalUrl, uri, claimExists, haventFetchedYet, isMine, claimIsPending, search]);
 

--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -27,7 +27,8 @@ let checkPendingInterval;
 export function doResolveUris(
   uris: Array<string>,
   returnCachedClaims: boolean = false,
-  resolveReposts: boolean = true
+  resolveReposts: boolean = true,
+  additionalOptions: any = {}
 ) {
   return (dispatch: Dispatch, getState: GetState) => {
     const normalizedUris = uris.map(normalizeURI);
@@ -47,13 +48,6 @@ export function doResolveUris(
       return;
     }
 
-    const options: { include_is_my_output?: boolean, include_purchase_receipt: boolean } = {
-      include_purchase_receipt: true,
-    };
-
-    if (urisToResolve.length === 1) {
-      options.include_is_my_output = true;
-    }
     dispatch({
       type: ACTIONS.RESOLVE_URIS_STARTED,
       data: { uris: normalizedUris },
@@ -70,7 +64,7 @@ export function doResolveUris(
 
     const collectionIds: Array<string> = [];
 
-    return Lbry.resolve({ urls: urisToResolve, ...options }).then(async (result: ResolveResponse) => {
+    return Lbry.resolve({ urls: urisToResolve, ...additionalOptions }).then(async (result: ResolveResponse) => {
       let repostedResults = {};
       const repostsToResolve = [];
       const fallbackResolveInfo = {
@@ -127,7 +121,7 @@ export function doResolveUris(
           type: ACTIONS.RESOLVE_URIS_STARTED,
           data: { uris: repostsToResolve, debug: 'reposts' },
         });
-        repostedResults = await Lbry.resolve({ urls: repostsToResolve, ...options });
+        repostedResults = await Lbry.resolve({ urls: repostsToResolve, ...additionalOptions });
       }
       processResult(repostedResults, resolveInfo);
 
@@ -145,8 +139,13 @@ export function doResolveUris(
   };
 }
 
-export function doResolveUri(uri: string) {
-  return doResolveUris([uri]);
+export function doResolveUri(
+  uri: string,
+  returnCachedClaims: boolean = false,
+  resolveReposts: boolean = true,
+  additionalOptions: any = {}
+) {
+  return doResolveUris([uri], returnCachedClaims, resolveReposts, additionalOptions);
 }
 
 export function doFetchClaimListMine(
@@ -660,10 +659,7 @@ export function doClaimSearch(
       return false;
     };
 
-    return await Lbry.claim_search({
-      ...options,
-      include_purchase_receipt: true,
-    }).then(success, failure);
+    return await Lbry.claim_search(options).then(success, failure);
   };
 }
 

--- a/ui/redux/selectors/comments.js
+++ b/ui/redux/selectors/comments.js
@@ -4,7 +4,12 @@ import { createCachedSelector } from 're-reselect';
 import { selectMutedChannels } from 'redux/selectors/blocked';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import { selectBlacklistedOutpointMap, selectFilteredOutpointMap } from 'lbryinc';
-import { selectClaimsById, selectMyClaimIdsRaw, selectClaimIdForUri } from 'redux/selectors/claims';
+import {
+  selectClaimsById,
+  selectMyClaimIdsRaw,
+  selectMyChannelClaimIds,
+  selectClaimIdForUri,
+} from 'redux/selectors/claims';
 import { isClaimNsfw } from 'util/claim';
 
 type State = { claims: any, comments: CommentsState };
@@ -181,6 +186,7 @@ export const selectCommentIdsForUri = (state: State, uri: string) => {
 const filterCommentsDepOnList = {
   claimsById: selectClaimsById,
   myClaimIds: selectMyClaimIdsRaw,
+  myChannelClaimIds: selectMyChannelClaimIds,
   mutedChannels: selectMutedChannels,
   personalBlockList: selectModerationBlockList,
   blacklistedMap: selectBlacklistedOutpointMap,
@@ -264,6 +270,7 @@ const filterComments = (comments: Array<Comment>, claimId?: string, filterInputs
   const {
     claimsById,
     myClaimIds,
+    myChannelClaimIds,
     mutedChannels,
     personalBlockList,
     blacklistedMap,
@@ -282,8 +289,12 @@ const filterComments = (comments: Array<Comment>, claimId?: string, filterInputs
 
         // Return comment if `channelClaim` doesn't exist so the component knows to resolve the author
         if (channelClaim) {
-          if (myClaimIds && myClaimIds.size > 0) {
-            const claimIsMine = channelClaim.is_my_output || myClaimIds.includes(channelClaim.claim_id);
+          if ((myClaimIds && myClaimIds.size > 0) || (myChannelClaimIds && myChannelClaimIds.length > 0)) {
+            const claimIsMine =
+              channelClaim.is_my_output ||
+              myChannelClaimIds.includes(channelClaim.claim_id) ||
+              myClaimIds.includes(channelClaim.claim_id);
+            // TODO: I believe 'myClaimIds' does not include channels, so it seems wasteful to include it here?   ^
             if (claimIsMine) {
               return true;
             }


### PR DESCRIPTION
@tzarebczan, I still have some scenarios to test, but I think I've tested enough for us to try in parallel.  Need to help to verify the API call (even though the change is just to omit the auth header).

----

## Issue
Part of [#306 Optimize backend calls (try to use non-auth and batching where possible) ](https://github.com/OdyseeTeam/odysee-frontend/issues/306)

## Changes
 - `apiCall`: allow clients to add `no_auth` in the existing `param` to signal that we don't want to send the headers (it is doing that by default).  The function will strip off `no_auth` before sending the actual payload.
 - `doResolveUris`: default to no-auth as `page/show` is the only place that actually needs it to be populated.
 - In other non-critical areas like Claim Context Menu, use the signing channel to check if the claim is ours.

## Next
Do the same thing for `claim_search`.