### PR TITLE
Kill makeSelectClientSetting

### DIFF
--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -5,7 +5,7 @@ import { parseURI } from 'util/lbryURI';
 import * as SETTINGS from 'constants/settings';
 import { makeSelectClaimForUri } from 'redux/selectors/claims';
 import { selectPlayingUri, selectPrimaryUri } from 'redux/selectors/content';
-import { makeSelectClientSetting, selectDaemonSettings } from 'redux/selectors/settings';
+import { selectClientSetting, selectDaemonSettings } from 'redux/selectors/settings';
 import { history } from 'ui/store';
 
 const recsysEndpoint = 'https://clickstream.odysee.com/log/video/view';
@@ -229,7 +229,7 @@ const recsys = {
       const claim = makeSelectClaimForUri(actualPlayingUri)(state);
       const playingClaimId = claim ? claim.claim_id : null;
       // const primaryUri = selectPrimaryUri(state);
-      const floatingPlayer = makeSelectClientSetting(SETTINGS.FLOATING_PLAYER)(state);
+      const floatingPlayer = selectClientSetting(state, SETTINGS.FLOATING_PLAYER);
       // When leaving page, if floating player is enabled, play will continue.
       Object.keys(recsys.entries).forEach((claimId) => {
         const shouldSkip = recsys.entries[claimId].parentUuid && !recsys.entries[claimId].recClaimIds;

--- a/ui/component/app/index.js
+++ b/ui/component/app/index.js
@@ -8,12 +8,7 @@ import { doFetchChannelListMine, doFetchCollectionListMine, doResolveUris } from
 import { selectMyChannelUrls } from 'redux/selectors/claims';
 import * as SETTINGS from 'constants/settings';
 import { selectSubscriptions } from 'redux/selectors/subscriptions';
-import {
-  makeSelectClientSetting,
-  selectLanguage,
-  selectLoadedLanguages,
-  selectThemePath,
-} from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage, selectLoadedLanguages, selectThemePath } from 'redux/selectors/settings';
 import {
   selectIsUpgradeAvailable,
   selectAutoUpdateDownloaded,
@@ -33,7 +28,7 @@ const select = (state) => ({
   accessToken: selectAccessToken(state),
   theme: selectThemePath(state),
   language: selectLanguage(state),
-  syncEnabled: makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state),
+  syncEnabled: selectClientSetting(state, SETTINGS.ENABLE_SYNC),
   languages: selectLoadedLanguages(state),
   autoUpdateDownloaded: selectAutoUpdateDownloaded(state),
   isUpgradeAvailable: selectIsUpgradeAvailable(state),

--- a/ui/component/channelContent/index.js
+++ b/ui/component/channelContent/index.js
@@ -12,7 +12,7 @@ import * as SETTINGS from 'constants/settings';
 import { makeSelectChannelIsMuted } from 'redux/selectors/blocked';
 import { withRouter } from 'react-router';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
-import { makeSelectClientSetting, selectShowMatureContent } from 'redux/selectors/settings';
+import { selectClientSetting, selectShowMatureContent } from 'redux/selectors/settings';
 
 import ChannelContent from './view';
 
@@ -31,7 +31,7 @@ const select = (state, props) => {
     claim,
     isAuthenticated: selectUserVerifiedEmail(state),
     showMature: selectShowMatureContent(state),
-    tileLayout: makeSelectClientSetting(SETTINGS.TILE_LAYOUT)(state),
+    tileLayout: selectClientSetting(state, SETTINGS.TILE_LAYOUT),
   };
 };
 

--- a/ui/component/claimList/index.js
+++ b/ui/component/claimList/index.js
@@ -2,10 +2,10 @@ import { connect } from 'react-redux';
 import ClaimList from './view';
 import * as SETTINGS from 'constants/settings';
 
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 
 const select = (state) => ({
-  searchInLanguage: makeSelectClientSetting(SETTINGS.SEARCH_IN_LANGUAGE)(state),
+  searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
 });
 
 export default connect(select)(ClaimList);

--- a/ui/component/claimListDiscover/index.js
+++ b/ui/component/claimListDiscover/index.js
@@ -10,7 +10,7 @@ import * as SETTINGS from 'constants/settings';
 import { selectFollowedTags } from 'redux/selectors/tags';
 import { selectMutedChannels } from 'redux/selectors/blocked';
 import { doToggleTagFollowDesktop } from 'redux/actions/tags';
-import { makeSelectClientSetting, selectShowMatureContent, selectLanguage } from 'redux/selectors/settings';
+import { selectClientSetting, selectShowMatureContent, selectLanguage } from 'redux/selectors/settings';
 import { selectModerationBlockList } from 'redux/selectors/comments';
 import ClaimListDiscover from './view';
 import { doFetchViewCount } from 'lbryinc';
@@ -22,11 +22,11 @@ const select = (state) => ({
   claimsByUri: selectClaimsByUri(state),
   loading: selectFetchingClaimSearch(state),
   showNsfw: selectShowMatureContent(state),
-  hideReposts: makeSelectClientSetting(SETTINGS.HIDE_REPOSTS)(state),
+  hideReposts: selectClientSetting(state, SETTINGS.HIDE_REPOSTS),
   languageSetting: selectLanguage(state),
   mutedUris: selectMutedChannels(state),
   blockedUris: selectModerationBlockList(state),
-  searchInLanguage: makeSelectClientSetting(SETTINGS.SEARCH_IN_LANGUAGE)(state),
+  searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
 });
 
 const perform = {

--- a/ui/component/claimListHeader/index.js
+++ b/ui/component/claimListHeader/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { selectFetchingClaimSearch } from 'redux/selectors/claims';
 import { selectFollowedTags } from 'redux/selectors/tags';
 import { doToggleTagFollowDesktop } from 'redux/actions/tags';
-import { makeSelectClientSetting, selectShowMatureContent, selectLanguage } from 'redux/selectors/settings';
+import { selectClientSetting, selectShowMatureContent, selectLanguage } from 'redux/selectors/settings';
 import { doSetClientSetting } from 'redux/actions/settings';
 import * as SETTINGS from 'constants/settings';
 import ClaimListHeader from './view';
@@ -11,7 +11,7 @@ const select = (state) => ({
   followedTags: selectFollowedTags(state),
   loading: selectFetchingClaimSearch(state),
   showNsfw: selectShowMatureContent(state),
-  searchInLanguage: makeSelectClientSetting(SETTINGS.SEARCH_IN_LANGUAGE)(state),
+  searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
   languageSetting: selectLanguage(state),
 });
 

--- a/ui/component/claimTilesDiscover/index.js
+++ b/ui/component/claimTilesDiscover/index.js
@@ -6,7 +6,7 @@ import * as SETTINGS from 'constants/settings';
 import { MATURE_TAGS } from 'constants/tags';
 import { doFetchViewCount } from 'lbryinc';
 import { doToggleTagFollowDesktop } from 'redux/actions/tags';
-import { makeSelectClientSetting, selectShowMatureContent } from 'redux/selectors/settings';
+import { selectClientSetting, selectShowMatureContent } from 'redux/selectors/settings';
 import { selectMutedAndBlockedChannelIds } from 'redux/selectors/blocked';
 import { ENABLE_NO_SOURCE_CLAIMS, SIMPLE_SITE } from 'config';
 import * as CS from 'constants/claim_search';
@@ -15,7 +15,7 @@ import ClaimListDiscover from './view';
 
 const select = (state, props) => {
   const showNsfw = selectShowMatureContent(state);
-  const hideReposts = makeSelectClientSetting(SETTINGS.HIDE_REPOSTS)(state);
+  const hideReposts = selectClientSetting(state, SETTINGS.HIDE_REPOSTS);
   const mutedAndBlockedChannelIds = selectMutedAndBlockedChannelIds(state);
 
   return {

--- a/ui/component/dateTime/index.js
+++ b/ui/component/dateTime/index.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux';
 import { selectDateForUri } from 'redux/selectors/claims';
 import * as SETTINGS from 'constants/settings';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import DateTime from './view';
 
 const select = (state, props) => ({
   date: props.date || selectDateForUri(state, props.uri),
-  clock24h: makeSelectClientSetting(SETTINGS.CLOCK_24H)(state),
+  clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
 });
 export default connect(select)(DateTime);

--- a/ui/component/emailCollection/index.js
+++ b/ui/component/emailCollection/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
 import { doSetClientSetting } from 'redux/actions/settings';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { selectEmailToVerify, selectUser } from 'redux/selectors/user';
 import FirstRunEmailCollection from './view';
 import * as SETTINGS from 'constants/settings';
 
 const select = (state) => ({
-  emailCollectionAcknowledged: makeSelectClientSetting(SETTINGS.EMAIL_COLLECTION_ACKNOWLEDGED)(state),
+  emailCollectionAcknowledged: selectClientSetting(state, SETTINGS.EMAIL_COLLECTION_ACKNOWLEDGED),
   email: selectEmailToVerify(state),
   user: selectUser(state),
 });

--- a/ui/component/embedPlayButton/index.js
+++ b/ui/component/embedPlayButton/index.js
@@ -5,7 +5,7 @@ import * as SETTINGS from 'constants/settings';
 import { doFetchCostInfoForUri, selectCostInfoForUri } from 'lbryinc';
 import { doPlayUri, doSetPlayingUri } from 'redux/actions/content';
 import { doAnaltyicsPurchaseEvent } from 'redux/actions/app';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
 
 import ChannelThumbnail from './view';
@@ -13,7 +13,7 @@ import ChannelThumbnail from './view';
 const select = (state, props) => ({
   thumbnail: selectThumbnailForUri(state, props.uri),
   claim: makeSelectClaimForUri(props.uri)(state),
-  floatingPlayerEnabled: makeSelectClientSetting(SETTINGS.FLOATING_PLAYER)(state),
+  floatingPlayerEnabled: selectClientSetting(state, SETTINGS.FLOATING_PLAYER),
   costInfo: selectCostInfoForUri(state, props.uri),
   renderMode: makeSelectFileRenderModeForUri(props.uri)(state),
 });

--- a/ui/component/fileRender/index.js
+++ b/ui/component/fileRender/index.js
@@ -2,14 +2,14 @@ import { connect } from 'react-redux';
 import { makeSelectDownloadPathForUri, makeSelectStreamingUrlForUri } from 'redux/selectors/file_info';
 import { makeSelectClaimForUri, selectThumbnailForUri, makeSelectContentTypeForUri } from 'redux/selectors/claims';
 import * as SETTINGS from 'constants/settings';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { makeSelectFileRenderModeForUri, makeSelectFileExtensionForUri } from 'redux/selectors/content';
 import FileRender from './view';
 
 const select = (state, props) => {
-  const autoplay = props.embedded ? false : makeSelectClientSetting(SETTINGS.AUTOPLAY_MEDIA)(state);
+  const autoplay = props.embedded ? false : selectClientSetting(state, SETTINGS.AUTOPLAY_MEDIA);
   return {
-    currentTheme: makeSelectClientSetting(SETTINGS.THEME)(state),
+    currentTheme: selectClientSetting(state, SETTINGS.THEME),
     claim: makeSelectClaimForUri(props.uri)(state),
     thumbnail: selectThumbnailForUri(state, props.uri),
     contentType: makeSelectContentTypeForUri(props.uri)(state),

--- a/ui/component/fileRenderFloating/index.js
+++ b/ui/component/fileRenderFloating/index.js
@@ -12,7 +12,7 @@ import {
   selectPlayingUri,
   makeSelectFileRenderModeForUri,
 } from 'redux/selectors/content';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { selectCostInfoForUri } from 'lbryinc';
 import { doPlayUri, doSetPlayingUri } from 'redux/actions/content';
 import { doFetchRecommendedContent } from 'redux/actions/search';
@@ -35,9 +35,9 @@ const select = (state, props) => {
     mature: selectClaimIsNsfwForUri(state, uri),
     isFloating: makeSelectIsPlayerFloating(props.location)(state),
     streamingUrl: makeSelectStreamingUrlForUri(uri)(state),
-    floatingPlayerEnabled: makeSelectClientSetting(SETTINGS.FLOATING_PLAYER)(state),
+    floatingPlayerEnabled: selectClientSetting(state, SETTINGS.FLOATING_PLAYER),
     renderMode: makeSelectFileRenderModeForUri(uri)(state),
-    videoTheaterMode: makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)(state),
+    videoTheaterMode: selectClientSetting(state, SETTINGS.VIDEO_THEATER_MODE),
     costInfo: selectCostInfoForUri(state, uri),
     claimWasPurchased: makeSelectClaimWasPurchased(uri)(state),
     nextListUri: collectionId && makeSelectNextUrlForCollectionAndUrl(collectionId, uri)(state),

--- a/ui/component/fileRenderInitiator/index.js
+++ b/ui/component/fileRenderInitiator/index.js
@@ -6,7 +6,7 @@ import * as SETTINGS from 'constants/settings';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
 import { selectCostInfoForUri } from 'lbryinc';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { withRouter } from 'react-router';
 import {
   makeSelectIsPlaying,
@@ -28,7 +28,7 @@ const select = (state, props) => {
     obscurePreview: selectShouldObscurePreviewForUri(state, props.uri),
     isPlaying: makeSelectIsPlaying(props.uri)(state),
     insufficientCredits: selectInsufficientCreditsForUri(state, props.uri),
-    autoplay: makeSelectClientSetting(SETTINGS.AUTOPLAY_MEDIA)(state),
+    autoplay: selectClientSetting(state, SETTINGS.AUTOPLAY_MEDIA),
     costInfo: selectCostInfoForUri(state, props.uri),
     renderMode: makeSelectFileRenderModeForUri(props.uri)(state),
     claim: makeSelectClaimForUri(props.uri)(state),

--- a/ui/component/header/index.js
+++ b/ui/component/header/index.js
@@ -8,7 +8,7 @@ import { selectUserVerifiedEmail, selectUserEmail, selectEmailToVerify, selectUs
 import { doClearEmailEntry, doClearPasswordEntry } from 'redux/actions/user';
 import { doSetClientSetting } from 'redux/actions/settings';
 import { doSignOut, doOpenModal } from 'redux/actions/app';
-import { makeSelectClientSetting, selectLanguage } from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage } from 'redux/selectors/settings';
 import { selectHasNavigated, selectActiveChannelClaim, selectActiveChannelStakedLevel } from 'redux/selectors/app';
 import Header from './view';
 
@@ -17,9 +17,9 @@ const select = (state) => ({
   balance: selectBalance(state),
   roundedSpendableBalance: formatCredits(selectBalance(state), 2, true),
   roundedBalance: formatCredits(selectTotalBalance(state), 2, true),
-  currentTheme: makeSelectClientSetting(SETTINGS.THEME)(state),
-  automaticDarkModeEnabled: makeSelectClientSetting(SETTINGS.AUTOMATIC_DARK_MODE_ENABLED)(state),
-  hideBalance: makeSelectClientSetting(SETTINGS.HIDE_BALANCE)(state),
+  currentTheme: selectClientSetting(state, SETTINGS.THEME),
+  automaticDarkModeEnabled: selectClientSetting(state, SETTINGS.AUTOMATIC_DARK_MODE_ENABLED),
+  hideBalance: selectClientSetting(state, SETTINGS.HIDE_BALANCE),
   authenticated: selectUserVerifiedEmail(state),
   email: selectUserEmail(state),
   syncError: selectGetSyncErrorMessage(state),

--- a/ui/component/logo/index.js
+++ b/ui/component/logo/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
 import Logo from './view';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import * as SETTINGS from 'constants/settings';
 
 const select = (state, props) => ({
-  currentTheme: makeSelectClientSetting(SETTINGS.THEME)(state),
+  currentTheme: selectClientSetting(state, SETTINGS.THEME),
 });
 
 export default connect(select)(Logo);

--- a/ui/component/nagContinueFirstRun/index.js
+++ b/ui/component/nagContinueFirstRun/index.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import NagContinueFirstRun from './view';
 
 const select = (state) => ({
-  followingAcknowledged: makeSelectClientSetting(SETTINGS.FOLLOWING_ACKNOWLEDGED)(state),
-  firstRunStarted: makeSelectClientSetting(SETTINGS.FIRST_RUN_STARTED)(state),
+  followingAcknowledged: selectClientSetting(state, SETTINGS.FOLLOWING_ACKNOWLEDGED),
+  firstRunStarted: selectClientSetting(state, SETTINGS.FIRST_RUN_STARTED),
 });
 
 export default connect(select)(NagContinueFirstRun);

--- a/ui/component/page/index.js
+++ b/ui/component/page/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import * as SETTINGS from 'constants/settings';
 import Page from './view';
 
 const select = (state, props) => ({
-  videoTheaterMode: makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)(state),
+  videoTheaterMode: selectClientSetting(state, SETTINGS.VIDEO_THEATER_MODE),
 });
 
 export default connect(select)(Page);

--- a/ui/component/publishForm/index.js
+++ b/ui/component/publishForm/index.js
@@ -30,7 +30,7 @@ import {
   selectIncognito,
   selectActiveChannelStakedLevel,
 } from 'redux/selectors/app';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
 import { selectUser } from 'redux/selectors/user';
 import PublishForm from './view';
@@ -59,7 +59,7 @@ const select = (state) => {
     isResolvingUri: selectIsResolvingPublishUris(state),
     totalRewardValue: selectUnclaimedRewardValue(state),
     modal: selectModal(state),
-    enablePublishPreview: makeSelectClientSetting(SETTINGS.ENABLE_PUBLISH_PREVIEW)(state),
+    enablePublishPreview: selectClientSetting(state, SETTINGS.ENABLE_PUBLISH_PREVIEW),
     activeChannelClaim: selectActiveChannelClaim(state),
     incognito: selectIncognito(state),
     activeChannelStakedLevel: selectActiveChannelStakedLevel(state),

--- a/ui/component/settingAppearance/index.js
+++ b/ui/component/settingAppearance/index.js
@@ -1,15 +1,15 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doSetClientSetting } from 'redux/actions/settings';
-import { selectLanguage, makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectLanguage, selectClientSetting } from 'redux/selectors/settings';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import SettingAppearance from './view';
 
 const select = (state) => ({
-  clock24h: makeSelectClientSetting(SETTINGS.CLOCK_24H)(state),
-  searchInLanguage: makeSelectClientSetting(SETTINGS.SEARCH_IN_LANGUAGE)(state),
+  clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
+  searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
   isAuthenticated: selectUserVerifiedEmail(state),
-  hideBalance: makeSelectClientSetting(SETTINGS.HIDE_BALANCE)(state),
+  hideBalance: selectClientSetting(state, SETTINGS.HIDE_BALANCE),
   language: selectLanguage(state),
 });
 

--- a/ui/component/settingAutoLaunch/index.js
+++ b/ui/component/settingAutoLaunch/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doSetAutoLaunch } from 'redux/actions/settings';
-import { makeSelectClientSetting, selectLanguage } from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage } from 'redux/selectors/settings';
 import { doToast } from 'redux/actions/notifications';
 import SettingAutoLaunch from './view';
 
 const select = (state) => ({
-  autoLaunch: makeSelectClientSetting(SETTINGS.AUTO_LAUNCH)(state),
+  autoLaunch: selectClientSetting(state, SETTINGS.AUTO_LAUNCH),
   language: selectLanguage(state),
 });
 

--- a/ui/component/settingClosingBehavior/index.js
+++ b/ui/component/settingClosingBehavior/index.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doSetAppToTrayWhenClosed } from 'redux/actions/settings';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import SettingClosingBehavior from './view';
 
 const select = (state) => ({
-  toTrayWhenClosed: makeSelectClientSetting(SETTINGS.TO_TRAY_WHEN_CLOSED)(state),
+  toTrayWhenClosed: selectClientSetting(state, SETTINGS.TO_TRAY_WHEN_CLOSED),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/settingCommentsServer/index.js
+++ b/ui/component/settingCommentsServer/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doSetClientSetting } from 'redux/actions/settings';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import SettingCommentsServer from './view';
 
 const select = (state) => ({
-  customServerEnabled: makeSelectClientSetting(SETTINGS.CUSTOM_COMMENTS_SERVER_ENABLED)(state),
-  customServerUrl: makeSelectClientSetting(SETTINGS.CUSTOM_COMMENTS_SERVER_URL)(state),
+  customServerEnabled: selectClientSetting(state, SETTINGS.CUSTOM_COMMENTS_SERVER_ENABLED),
+  customServerUrl: selectClientSetting(state, SETTINGS.CUSTOM_COMMENTS_SERVER_URL),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/settingContent/index.js
+++ b/ui/component/settingContent/index.js
@@ -4,22 +4,22 @@ import * as SETTINGS from 'constants/settings';
 import { doOpenModal } from 'redux/actions/app';
 import { doSetPlayingUri } from 'redux/actions/content';
 import { doSetClientSetting } from 'redux/actions/settings';
-import { selectShowMatureContent, selectLanguage, makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectShowMatureContent, selectLanguage, selectClientSetting } from 'redux/selectors/settings';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 
 import SettingContent from './view';
 
 const select = (state) => ({
   isAuthenticated: selectUserVerifiedEmail(state),
-  floatingPlayer: makeSelectClientSetting(SETTINGS.FLOATING_PLAYER)(state),
-  autoplayMedia: makeSelectClientSetting(SETTINGS.AUTOPLAY_MEDIA)(state),
-  autoplayNext: makeSelectClientSetting(SETTINGS.AUTOPLAY_NEXT)(state),
-  hideReposts: makeSelectClientSetting(SETTINGS.HIDE_REPOSTS)(state),
+  floatingPlayer: selectClientSetting(state, SETTINGS.FLOATING_PLAYER),
+  autoplayMedia: selectClientSetting(state, SETTINGS.AUTOPLAY_MEDIA),
+  autoplayNext: selectClientSetting(state, SETTINGS.AUTOPLAY_NEXT),
+  hideReposts: selectClientSetting(state, SETTINGS.HIDE_REPOSTS),
   showNsfw: selectShowMatureContent(state),
   myChannelUrls: selectMyChannelUrls(state),
-  instantPurchaseEnabled: makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_ENABLED)(state),
-  instantPurchaseMax: makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_MAX)(state),
-  enablePublishPreview: makeSelectClientSetting(SETTINGS.ENABLE_PUBLISH_PREVIEW)(state),
+  instantPurchaseEnabled: selectClientSetting(state, SETTINGS.INSTANT_PURCHASE_ENABLED),
+  instantPurchaseMax: selectClientSetting(state, SETTINGS.INSTANT_PURCHASE_MAX),
+  enablePublishPreview: selectClientSetting(state, SETTINGS.ENABLE_PUBLISH_PREVIEW),
   language: selectLanguage(state),
 });
 

--- a/ui/component/settingUnauthenticated/index.js
+++ b/ui/component/settingUnauthenticated/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doSetClientSetting } from 'redux/actions/settings';
-import { selectLanguage, makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectLanguage, selectClientSetting } from 'redux/selectors/settings';
 
 import SettingUnauthenticated from './view';
 
 const select = (state) => ({
-  searchInLanguage: makeSelectClientSetting(SETTINGS.SEARCH_IN_LANGUAGE)(state),
+  searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
   language: selectLanguage(state),
 });
 

--- a/ui/component/syncEnableFlow/index.js
+++ b/ui/component/syncEnableFlow/index.js
@@ -8,13 +8,13 @@ import {
   selectHashChanged,
 } from 'redux/selectors/sync';
 import { doCheckSync, doGetSync } from 'redux/actions/sync';
-import { makeSelectClientSetting, selectLanguage } from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage } from 'redux/selectors/settings';
 import { doSetWalletSyncPreference } from 'redux/actions/settings';
 import SyncToggle from './view';
 import { doGetAndPopulatePreferences } from 'redux/actions/app';
 
 const select = (state) => ({
-  syncEnabled: makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state),
+  syncEnabled: selectClientSetting(state, SETTINGS.ENABLE_SYNC),
   hasSyncedWallet: selectHasSyncedWallet(state),
   hasSyncChanged: selectHashChanged(state),
   verifiedEmail: selectUserVerifiedEmail(state),

--- a/ui/component/syncToggle/index.js
+++ b/ui/component/syncToggle/index.js
@@ -2,13 +2,13 @@ import * as SETTINGS from 'constants/settings';
 import { connect } from 'react-redux';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { selectGetSyncErrorMessage } from 'redux/selectors/sync';
-import { makeSelectClientSetting, selectLanguage } from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage } from 'redux/selectors/settings';
 import { doSetWalletSyncPreference } from 'redux/actions/settings';
 import { doOpenModal } from 'redux/actions/app';
 import SyncToggle from './view';
 
 const select = (state) => ({
-  syncEnabled: makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state),
+  syncEnabled: selectClientSetting(state, SETTINGS.ENABLE_SYNC),
   verifiedEmail: selectUserVerifiedEmail(state),
   getSyncError: selectGetSyncErrorMessage(state),
   language: selectLanguage(state),

--- a/ui/component/themeSelector/index.js
+++ b/ui/component/themeSelector/index.js
@@ -1,15 +1,15 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doSetClientSetting, doSetDarkTime } from 'redux/actions/settings';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import ThemeSelector from './view';
 
 const select = (state) => ({
-  currentTheme: makeSelectClientSetting(SETTINGS.THEME)(state),
-  themes: makeSelectClientSetting(SETTINGS.THEMES)(state),
-  automaticDarkModeEnabled: makeSelectClientSetting(SETTINGS.AUTOMATIC_DARK_MODE_ENABLED)(state),
-  darkModeTimes: makeSelectClientSetting(SETTINGS.DARK_MODE_TIMES)(state),
-  clock24h: makeSelectClientSetting(SETTINGS.CLOCK_24H)(state),
+  currentTheme: selectClientSetting(state, SETTINGS.THEME),
+  themes: selectClientSetting(state, SETTINGS.THEMES),
+  automaticDarkModeEnabled: selectClientSetting(state, SETTINGS.AUTOMATIC_DARK_MODE_ENABLED),
+  darkModeTimes: selectClientSetting(state, SETTINGS.DARK_MODE_TIMES),
+  clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/userEmailNew/index.js
+++ b/ui/component/userEmailNew/index.js
@@ -9,13 +9,13 @@ import {
 import * as SETTINGS from 'constants/settings';
 import * as DAEMON_SETTINGS from 'constants/daemon_settings';
 import { doSetWalletSyncPreference, doSetDaemonSetting } from 'redux/actions/settings';
-import { selectDaemonSettings, makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectDaemonSettings, selectClientSetting } from 'redux/selectors/settings';
 import UserEmailNew from './view';
 
 const select = (state) => ({
   isPending: selectEmailNewIsPending(state),
   errorMessage: selectEmailNewErrorMessage(state),
-  syncEnabled: makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state),
+  syncEnabled: selectClientSetting(state, SETTINGS.ENABLE_SYNC),
   daemonSettings: selectDaemonSettings(state),
   emailExists: selectEmailAlreadyExists(state),
   user: selectUser(state),

--- a/ui/component/userSignUp/index.js
+++ b/ui/component/userSignUp/index.js
@@ -15,7 +15,7 @@ import {
 import { selectMyChannelClaims, selectFetchingMyChannels, selectCreatingChannel } from 'redux/selectors/claims';
 import { selectBalance } from 'redux/selectors/wallet';
 import * as SETTINGS from 'constants/settings';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { selectInterestedInYoutubeSync } from 'redux/selectors/app';
 import { doToggleInterestedInYoutubeSync } from 'redux/actions/app';
 import UserSignIn from './view';
@@ -33,10 +33,10 @@ const select = (state) => ({
   fetchingChannels: selectFetchingMyChannels(state),
   youtubeChannels: selectYoutubeChannels(state),
   userFetchPending: selectUserIsPending(state),
-  syncEnabled: makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state),
-  followingAcknowledged: makeSelectClientSetting(SETTINGS.FOLLOWING_ACKNOWLEDGED)(state),
-  tagsAcknowledged: makeSelectClientSetting(SETTINGS.TAGS_ACKNOWLEDGED)(state),
-  rewardsAcknowledged: makeSelectClientSetting(SETTINGS.REWARDS_ACKNOWLEDGED)(state),
+  syncEnabled: selectClientSetting(state, SETTINGS.ENABLE_SYNC),
+  followingAcknowledged: selectClientSetting(state, SETTINGS.FOLLOWING_ACKNOWLEDGED),
+  tagsAcknowledged: selectClientSetting(state, SETTINGS.TAGS_ACKNOWLEDGED),
+  rewardsAcknowledged: selectClientSetting(state, SETTINGS.REWARDS_ACKNOWLEDGED),
   syncingWallet: selectGetSyncIsPending(state),
   hasSynced: Boolean(selectSyncHash(state)),
   creatingChannel: selectCreatingChannel(state),

--- a/ui/component/viewers/videoViewer/index.js
+++ b/ui/component/viewers/videoViewer/index.js
@@ -20,7 +20,7 @@ import { selectRecommendedContentForUri } from 'redux/selectors/search';
 import VideoViewer from './view';
 import { withRouter } from 'react-router';
 import { doClaimEligiblePurchaseRewards } from 'redux/actions/rewards';
-import { selectDaemonSettings, makeSelectClientSetting, selectHomepageData } from 'redux/selectors/settings';
+import { selectDaemonSettings, selectClientSetting, selectHomepageData } from 'redux/selectors/settings';
 import { toggleVideoTheaterMode, toggleAutoplayNext, doSetClientSetting } from 'redux/actions/settings';
 import { selectUserVerifiedEmail, selectUser } from 'redux/selectors/user';
 
@@ -57,17 +57,17 @@ const select = (state, props) => {
     previousListUri,
     isMarkdownOrComment,
     autoplayIfEmbedded: Boolean(autoplay),
-    autoplayNext: makeSelectClientSetting(SETTINGS.AUTOPLAY_NEXT)(state),
+    autoplayNext: selectClientSetting(state, SETTINGS.AUTOPLAY_NEXT),
     volume: selectVolume(state),
     muted: selectMute(state),
-    videoPlaybackRate: makeSelectClientSetting(SETTINGS.VIDEO_PLAYBACK_RATE)(state),
+    videoPlaybackRate: selectClientSetting(state, SETTINGS.VIDEO_PLAYBACK_RATE),
     thumbnail: selectThumbnailForUri(state, uri),
     claim: makeSelectClaimForUri(uri)(state),
     homepageData: selectHomepageData(state),
     authenticated: selectUserVerifiedEmail(state),
     shareTelemetry: IS_WEB || selectDaemonSettings(state).share_usage_data,
     isFloating: makeSelectIsPlayerFloating(props.location)(state),
-    videoTheaterMode: makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)(state),
+    videoTheaterMode: selectClientSetting(state, SETTINGS.VIDEO_THEATER_MODE),
   };
 };
 

--- a/ui/component/walletSendTip/index.js
+++ b/ui/component/walletSendTip/index.js
@@ -7,7 +7,7 @@ import {
 } from 'redux/selectors/claims';
 import { doHideModal } from 'redux/actions/app';
 import { doSendTip, doSendCashTip } from 'redux/actions/wallet';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { selectActiveChannelClaim, selectIncognito } from 'redux/selectors/app';
 import { selectBalance, selectIsSendingSupport } from 'redux/selectors/wallet';
 import { withRouter } from 'react-router';
@@ -21,8 +21,8 @@ const select = (state, props) => ({
   claimIsMine: selectClaimIsMineForUri(state, props.uri),
   fetchingChannels: selectFetchingMyChannels(state),
   incognito: selectIncognito(state),
-  instantTipEnabled: makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_ENABLED)(state),
-  instantTipMax: makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_MAX)(state),
+  instantTipEnabled: selectClientSetting(state, SETTINGS.INSTANT_PURCHASE_ENABLED),
+  instantTipMax: selectClientSetting(state, SETTINGS.INSTANT_PURCHASE_MAX),
   isPending: selectIsSendingSupport(state),
   title: selectTitleForUri(state, props.uri),
 });

--- a/ui/modal/modalPublishPreview/index.js
+++ b/ui/modal/modalPublishPreview/index.js
@@ -4,7 +4,7 @@ import ModalPublishPreview from './view';
 import { makeSelectPublishFormValue, selectPublishFormValues, selectIsStillEditing } from 'redux/selectors/publish';
 import { selectMyChannelClaims, selectIsStreamPlaceholderForUri } from 'redux/selectors/claims';
 import * as SETTINGS from 'constants/settings';
-import { selectFfmpegStatus, makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectFfmpegStatus, selectClientSetting } from 'redux/selectors/settings';
 import { doPublishDesktop } from 'redux/actions/publish';
 import { doSetClientSetting } from 'redux/actions/settings';
 
@@ -20,7 +20,7 @@ const select = (state, props) => {
     remoteFile: makeSelectPublishFormValue('remoteFileUrl')(state),
     isStillEditing: selectIsStillEditing(state),
     ffmpegStatus: selectFfmpegStatus(state),
-    enablePublishPreview: makeSelectClientSetting(SETTINGS.ENABLE_PUBLISH_PREVIEW)(state),
+    enablePublishPreview: selectClientSetting(state, SETTINGS.ENABLE_PUBLISH_PREVIEW),
     isLivestreamClaim: selectIsStreamPlaceholderForUri(state, editingUri),
   };
 };

--- a/ui/page/channelsFollowing/index.js
+++ b/ui/page/channelsFollowing/index.js
@@ -3,13 +3,13 @@ import * as SETTINGS from 'constants/settings';
 import { doFetchActiveLivestreams } from 'redux/actions/livestream';
 import { selectActiveLivestreams } from 'redux/selectors/livestream';
 import { selectSubscriptions } from 'redux/selectors/subscriptions';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 
 import ChannelsFollowingPage from './view';
 
 const select = (state) => ({
   subscribedChannels: selectSubscriptions(state),
-  tileLayout: makeSelectClientSetting(SETTINGS.TILE_LAYOUT)(state),
+  tileLayout: selectClientSetting(state, SETTINGS.TILE_LAYOUT),
   activeLivestreams: selectActiveLivestreams(state),
 });
 

--- a/ui/page/discover/index.js
+++ b/ui/page/discover/index.js
@@ -8,7 +8,7 @@ import { selectActiveLivestreams } from 'redux/selectors/livestream';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { selectFollowedTags } from 'redux/selectors/tags';
 import { doToggleTagFollowDesktop } from 'redux/actions/tags';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import Tags from './view';
 
 const select = (state, props) => {
@@ -21,7 +21,7 @@ const select = (state, props) => {
     repostedUri: repostedUri,
     repostedClaim: repostedUri ? makeSelectClaimForUri(repostedUri)(state) : null,
     isAuthenticated: selectUserVerifiedEmail(state),
-    tileLayout: makeSelectClientSetting(SETTINGS.TILE_LAYOUT)(state),
+    tileLayout: selectClientSetting(state, SETTINGS.TILE_LAYOUT),
     activeLivestreams: selectActiveLivestreams(state),
   };
 };

--- a/ui/page/file/index.js
+++ b/ui/page/file/index.js
@@ -12,7 +12,7 @@ import { makeSelectCollectionForId } from 'redux/selectors/collections';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
 import * as SETTINGS from 'constants/settings';
 import { selectCostInfoForUri, doFetchCostInfoForUri } from 'lbryinc';
-import { selectShowMatureContent, makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectShowMatureContent, selectClientSetting } from 'redux/selectors/settings';
 import { makeSelectFileRenderModeForUri, makeSelectContentPositionForUri } from 'redux/selectors/content';
 import { DISABLE_COMMENTS_TAG } from 'constants/tags';
 
@@ -30,7 +30,7 @@ const select = (state, props) => {
     isMature: selectClaimIsNsfwForUri(state, props.uri),
     fileInfo: makeSelectFileInfoForUri(props.uri)(state),
     renderMode: makeSelectFileRenderModeForUri(props.uri)(state),
-    videoTheaterMode: makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)(state),
+    videoTheaterMode: selectClientSetting(state, SETTINGS.VIDEO_THEATER_MODE),
     commentsDisabled: makeSelectTagInClaimOrChannelForUri(props.uri, DISABLE_COMMENTS_TAG)(state),
     isLivestream: selectIsStreamPlaceholderForUri(state, props.uri),
     collection: makeSelectCollectionForId(collectionId)(state),

--- a/ui/page/invite/index.js
+++ b/ui/page/invite/index.js
@@ -6,14 +6,14 @@ import {
   selectUserVerifiedEmail,
 } from 'redux/selectors/user';
 import { doFetchInviteStatus } from 'redux/actions/user';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { doSetClientSetting } from 'redux/actions/settings';
 import InvitePage from './view';
 
 const select = (state) => ({
   isFailed: selectUserInviteStatusFailed(state),
   isPending: selectUserInviteStatusIsPending(state),
-  inviteAcknowledged: makeSelectClientSetting(state)(SETTINGS.INVITE_ACKNOWLEDGED),
+  inviteAcknowledged: selectClientSetting(state, SETTINGS.INVITE_ACKNOWLEDGED),
   authenticated: selectUserVerifiedEmail(state),
 });
 

--- a/ui/page/tagsFollowing/index.js
+++ b/ui/page/tagsFollowing/index.js
@@ -3,14 +3,14 @@ import { selectFollowedTags } from 'redux/selectors/tags';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { selectSubscriptions } from 'redux/selectors/subscriptions';
 import DiscoverPage from './view';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import * as SETTINGS from 'constants/settings';
 
 const select = (state) => ({
   followedTags: selectFollowedTags(state),
   subscribedChannels: selectSubscriptions(state),
   email: selectUserVerifiedEmail(state),
-  tileLayout: makeSelectClientSetting(SETTINGS.TILE_LAYOUT)(state),
+  tileLayout: selectClientSetting(state, SETTINGS.TILE_LAYOUT),
 });
 
 const perform = {};

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -41,7 +41,7 @@ import {
   selectModal,
   selectAllowAnalytics,
 } from 'redux/selectors/app';
-import { selectDaemonSettings, makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectDaemonSettings, selectClientSetting } from 'redux/selectors/settings';
 import { selectUser, selectUserVerifiedEmail } from 'redux/selectors/user';
 import { doSyncLoop, doSetPrefsReady, doPreferenceGet, doPopulateSharedUserState } from 'redux/actions/sync';
 import { doAuthenticate } from 'redux/actions/user';
@@ -613,7 +613,7 @@ export function doGetAndPopulatePreferences() {
 
   return (dispatch, getState) => {
     const state = getState();
-    const syncEnabled = makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state);
+    const syncEnabled = selectClientSetting(state, SETTINGS.ENABLE_SYNC);
     const hasVerifiedEmail = state.user && state.user.user && state.user.user.has_verified_email;
     let preferenceKey;
     // @if TARGET='app'

--- a/ui/redux/actions/content.js
+++ b/ui/redux/actions/content.js
@@ -18,7 +18,7 @@ import { doPurchaseUri } from 'redux/actions/file';
 import Lbry from 'lbry';
 import * as SETTINGS from 'constants/settings';
 import { selectCostInfoForUri, Lbryio } from 'lbryinc';
-import { makeSelectClientSetting, selectosNotificationsEnabled, selectDaemonSettings } from 'redux/selectors/settings';
+import { selectClientSetting, selectosNotificationsEnabled, selectDaemonSettings } from 'redux/selectors/settings';
 
 const DOWNLOAD_POLL_INTERVAL = 1000;
 
@@ -167,8 +167,8 @@ export function doPlayUri(
     const costInfo = selectCostInfoForUri(state, uri);
     const cost = (costInfo && Number(costInfo.cost)) || 0;
     const saveFile = !IS_WEB && (!uriIsStreamable ? true : daemonSettings.save_files || saveFileOverride || cost > 0);
-    const instantPurchaseEnabled = makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_ENABLED)(state);
-    const instantPurchaseMax = makeSelectClientSetting(SETTINGS.INSTANT_PURCHASE_MAX)(state);
+    const instantPurchaseEnabled = selectClientSetting(state, SETTINGS.INSTANT_PURCHASE_ENABLED);
+    const instantPurchaseMax = selectClientSetting(state, SETTINGS.INSTANT_PURCHASE_MAX);
 
     function beginGetFile() {
       dispatch(doPurchaseUriWrapper(uri, cost, saveFile, cb));

--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -8,7 +8,7 @@ import { doToast } from 'redux/actions/notifications';
 import analytics from 'analytics';
 import SUPPORTED_LANGUAGES from 'constants/supported_languages';
 import { launcher } from 'util/autoLaunch';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { doSyncLoop, doSyncUnsubscribe, doSetSyncLock } from 'redux/actions/sync';
 import { doAlertWaitingForSync, doGetAndPopulatePreferences } from 'redux/actions/app';
 import { selectPrefsReady } from 'redux/selectors/sync';
@@ -243,7 +243,7 @@ export function doPushSettingsToPrefs() {
 export function doEnterSettingsPage() {
   return async (dispatch, getState) => {
     const state = getState();
-    const syncEnabled = makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state);
+    const syncEnabled = selectClientSetting(state, SETTINGS.ENABLE_SYNC);
     const hasVerifiedEmail = state.user && state.user.user && state.user.user.has_verified_email;
     if (IS_WEB && !hasVerifiedEmail) {
       return;
@@ -366,7 +366,7 @@ export function doSetLanguage(language) {
 export function doSetAutoLaunch(value) {
   return (dispatch, getState) => {
     const state = getState();
-    const autoLaunch = makeSelectClientSetting(SETTINGS.AUTO_LAUNCH)(state);
+    const autoLaunch = selectClientSetting(state, SETTINGS.AUTO_LAUNCH);
 
     if (IS_MAC || process.env.NODE_ENV !== 'production') {
       return;
@@ -423,7 +423,7 @@ export function doSetAppToTrayWhenClosed(value) {
 export function toggleVideoTheaterMode() {
   return (dispatch, getState) => {
     const state = getState();
-    const videoTheaterMode = makeSelectClientSetting(SETTINGS.VIDEO_THEATER_MODE)(state);
+    const videoTheaterMode = selectClientSetting(state, SETTINGS.VIDEO_THEATER_MODE);
 
     dispatch(doSetClientSetting(SETTINGS.VIDEO_THEATER_MODE, !videoTheaterMode));
   };
@@ -433,7 +433,7 @@ export function toggleAutoplayNext() {
   return (dispatch, getState) => {
     const state = getState();
     const ready = selectPrefsReady(state);
-    const autoplayNext = makeSelectClientSetting(SETTINGS.AUTOPLAY_NEXT)(state);
+    const autoplayNext = selectClientSetting(state, SETTINGS.AUTOPLAY_NEXT);
 
     dispatch(doSetClientSetting(SETTINGS.AUTOPLAY_NEXT, !autoplayNext, ready));
 

--- a/ui/redux/actions/sync.js
+++ b/ui/redux/actions/sync.js
@@ -10,7 +10,7 @@ import {
   selectSetSyncIsPending,
   selectSyncIsLocked,
 } from 'redux/selectors/sync';
-import { makeSelectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 import { getSavedPassword, getAuthToken } from 'util/saved-passwords';
 import { doAnalyticsTagSync, doHandleSyncComplete } from 'redux/actions/app';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
@@ -101,7 +101,7 @@ export const doGetSyncDesktop = (cb?: (any, any) => void, password?: string) => 
   getState: GetState
 ) => {
   const state = getState();
-  const syncEnabled = makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state);
+  const syncEnabled = selectClientSetting(state, SETTINGS.ENABLE_SYNC);
   const getSyncPending = selectGetSyncIsPending(state);
   const setSyncPending = selectSetSyncIsPending(state);
   const syncLocked = selectSyncIsLocked(state);
@@ -120,14 +120,14 @@ export function doSyncLoop(noInterval?: boolean) {
     if (!noInterval && syncTimer) clearInterval(syncTimer);
     const state = getState();
     const hasVerifiedEmail = selectUserVerifiedEmail(state);
-    const syncEnabled = makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state);
+    const syncEnabled = selectClientSetting(state, SETTINGS.ENABLE_SYNC);
     const syncLocked = selectSyncIsLocked(state);
     if (hasVerifiedEmail && syncEnabled && !syncLocked) {
       dispatch(doGetSyncDesktop((error, hasNewData) => dispatch(doHandleSyncComplete(error, hasNewData))));
       if (!noInterval) {
         syncTimer = setInterval(() => {
           const state = getState();
-          const syncEnabled = makeSelectClientSetting(SETTINGS.ENABLE_SYNC)(state);
+          const syncEnabled = selectClientSetting(state, SETTINGS.ENABLE_SYNC);
           if (syncEnabled) {
             dispatch(doGetSyncDesktop((error, hasNewData) => dispatch(doHandleSyncComplete(error, hasNewData))));
             dispatch(doAnalyticsTagSync());

--- a/ui/redux/selectors/settings.js
+++ b/ui/redux/selectors/settings.js
@@ -20,20 +20,14 @@ export const selectClientSetting = (state, setting) => {
   return clientSettings ? clientSettings[setting] : undefined;
 };
 
-// TODO - kill this
-export const makeSelectClientSetting = (setting) =>
-  createSelector(selectClientSettings, (settings) => (settings ? settings[setting] : undefined));
-
 // refactor me
 export const selectShowMatureContent = (state) => {
   return !ENABLE_MATURE ? false : selectClientSetting(state, SETTINGS.SHOW_MATURE);
 };
 
-// and me
-export const selectShowRepostedContent = makeSelectClientSetting(SETTINGS.HIDE_REPOSTS);
-
-export const selectTheme = makeSelectClientSetting(SETTINGS.THEME);
-export const selectAutomaticDarkModeEnabled = makeSelectClientSetting(SETTINGS.AUTOMATIC_DARK_MODE_ENABLED);
+export const selectTheme = (state) => selectClientSetting(state, SETTINGS.THEME);
+export const selectAutomaticDarkModeEnabled = (state) =>
+  selectClientSetting(state, SETTINGS.AUTOMATIC_DARK_MODE_ENABLED);
 export const selectIsNight = (state) => selectState(state).isNight;
 export const selectSavedWalletServers = (state) => selectState(state).customWalletServers;
 export const selectSharedPreferences = (state) => selectState(state).sharedPreferences;
@@ -58,13 +52,15 @@ export const selectThemePath = createSelector(
   }
 );
 
-export const selectHomepageCode = createSelector(makeSelectClientSetting(SETTINGS.HOMEPAGE), (setting) => {
-  return homepages[setting] ? setting : getDefaultHomepageKey();
-});
+export const selectHomepageCode = (state) => {
+  const hp = selectClientSetting(state, SETTINGS.HOMEPAGE);
+  return homepages[hp] ? hp : getDefaultHomepageKey();
+};
 
-export const selectLanguage = createSelector(makeSelectClientSetting(SETTINGS.LANGUAGE), (setting) => {
-  return setting || getDefaultLanguage();
-});
+export const selectLanguage = (state) => {
+  const lang = selectClientSetting(state, SETTINGS.LANGUAGE);
+  return lang || getDefaultLanguage();
+};
 
 export const selectHomepageData = createSelector(
   // using homepage setting,
@@ -76,4 +72,4 @@ export const selectHomepageData = createSelector(
   }
 );
 
-export const selectosNotificationsEnabled = makeSelectClientSetting(SETTINGS.OS_NOTIFICATIONS_ENABLED);
+export const selectosNotificationsEnabled = (state) => selectClientSetting(state, SETTINGS.OS_NOTIFICATIONS_ENABLED);


### PR DESCRIPTION
## Why
- No memo required (no transformation).
- `makeSelect*` is an incorrect pattern that doesn't memoize correctly.

## Changes
- Replaced makeSelectClientSetting with selectClientSetting.
- Remove unused selectShowRepostedContent.
