### PR TITLE
Re-enable reposts on homepages

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -248,6 +248,7 @@ function ClaimListDiscover(props: Props) {
     has_source?: boolean,
     has_no_source?: boolean,
     limit_claims_per_channel?: number,
+    remove_duplicates?: boolean,
   } = {
     page_size: dynamicPageSize,
     page,
@@ -259,6 +260,7 @@ function ClaimListDiscover(props: Props) {
     not_channel_ids: isChannel ? undefined : mutedAndBlockedChannelIds,
     not_tags: !showNsfw ? MATURE_TAGS : [],
     order_by: resolveOrderByOption(orderParam, sortByParam),
+    remove_duplicates: isChannel ? undefined : true,
   };
 
   if (ENABLE_NO_SOURCE_CLAIMS && hasNoSource) {

--- a/ui/component/claimTilesDiscover/index.js
+++ b/ui/component/claimTilesDiscover/index.js
@@ -85,6 +85,7 @@ function resolveSearchOptions(props) {
     not_channel_ids: mutedAndBlockedChannelIds,
     order_by: orderBy || ['trending_group', 'trending_mixed'],
     stream_types: streamTypesParam,
+    remove_duplicates: true,
   };
 
   if (ENABLE_NO_SOURCE_CLAIMS && hasNoSource) {

--- a/ui/component/settingContent/view.jsx
+++ b/ui/component/settingContent/view.jsx
@@ -93,22 +93,23 @@ export default function SettingContent(props: Props) {
               />
             </SettingsRow>
 
+            <SettingsRow title={__('Hide reposts')} subtitle={__(HELP.HIDE_REPOSTS)}>
+              <FormField
+                type="checkbox"
+                name="hide_reposts"
+                checked={hideReposts}
+                onChange={(e) => {
+                  if (isAuthenticated) {
+                    let param = e.target.checked ? { add: 'noreposts' } : { remove: 'noreposts' };
+                    Lbryio.call('user_tag', 'edit', param);
+                  }
+                  setClientSetting(SETTINGS.HIDE_REPOSTS, !hideReposts);
+                }}
+              />
+            </SettingsRow>
+
             {!SIMPLE_SITE && (
               <>
-                <SettingsRow title={__('Hide reposts')} subtitle={__(HELP.HIDE_REPOSTS)}>
-                  <FormField
-                    type="checkbox"
-                    name="hide_reposts"
-                    onChange={(e) => {
-                      if (isAuthenticated) {
-                        let param = e.target.checked ? { add: 'noreposts' } : { remove: 'noreposts' };
-                        Lbryio.call('user_tag', 'edit', param);
-                      }
-                      setClientSetting(SETTINGS.HIDE_REPOSTS, !hideReposts);
-                    }}
-                  />
-                </SettingsRow>
-
                 {/*
               <SettingsRow title={__('Show anonymous content')} subtitle={__('Anonymous content is published without a channel.')} >
                 <FormField

--- a/ui/redux/reducers/settings.js
+++ b/ui/redux/reducers/settings.js
@@ -4,7 +4,7 @@ import * as SHARED_PREFERENCES from 'constants/shared_preferences';
 import moment from 'moment';
 import { getSubsetFromKeysArray } from 'util/sync-settings';
 import { getDefaultLanguage } from 'util/default-languages';
-import { UNSYNCED_SETTINGS, SIMPLE_SITE } from 'config';
+import { UNSYNCED_SETTINGS } from 'config';
 import Comments from 'comments';
 
 const { CLIENT_SYNC_KEYS } = SHARED_PREFERENCES;
@@ -73,7 +73,7 @@ const defaultState = {
     [SETTINGS.AUTOPLAY_MEDIA]: true,
     [SETTINGS.FLOATING_PLAYER]: true,
     [SETTINGS.AUTO_DOWNLOAD]: true,
-    [SETTINGS.HIDE_REPOSTS]: SIMPLE_SITE,
+    [SETTINGS.HIDE_REPOSTS]: false,
 
     // OS
     [SETTINGS.AUTO_LAUNCH]: true,

--- a/ui/util/buildHomepage.js
+++ b/ui/util/buildHomepage.js
@@ -111,7 +111,7 @@ export const getHomepageRowForCat = (cat: HomepageCat) => {
     title: cat.label,
     pinnedUrls: cat.pinnedUrls,
     options: {
-      claimType: cat.claimType || 'stream',
+      claimType: cat.claimType || ['stream', 'repost'],
       channelIds: cat.channelIds,
       orderBy: orderValue,
       pageSize: cat.pageSize || undefined,


### PR DESCRIPTION
Note: when I first tried it, I was still seeing duplicates with `--remove_duplicates`.  After lunch, things started to work.  I confirm that my params remained the same before and after lunch.  Perhaps my hub switched .... i.e. some hubs are not old?

## Issue
Closes [#37 Examine re-enabling reposts on odysee homepage](https://github.com/OdyseeTeam/odysee-frontend/issues/37)

## Changes
- Added `--remove_duplicates` to Tile and List `claim_searches`.
- Brought back the "Hide reposts" setting.