### PR TITLE
Workaround for SecurePrivacy issues with VPNs

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -346,6 +346,7 @@ function App(props: Props) {
     if (gdprRequired === 'true') {
       // $FlowFixMe
       document.head.appendChild(script);
+      // $FlowFixMe
       document.head.appendChild(cmpScript);
     }
 
@@ -360,6 +361,7 @@ function App(props: Props) {
           localStorage.setItem('gdprRequired', 'true');
           // $FlowFixMe
           document.head.appendChild(script);
+          // $FlowFixMe
           document.head.appendChild(cmpScript);
         // note we don't need gdpr, save to session
         } else if (gdprRequiredBasedOnLocation ===  false) {
@@ -371,6 +373,7 @@ function App(props: Props) {
     return () => {
       // $FlowFixMe
       document.head.removeChild(script);
+      // $FlowFixMe
       document.head.appendChild(cmpScript);
     };
   }, []);

--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -336,12 +336,17 @@ function App(props: Props) {
     // might use this for future checking to prevent doubleloading
     script.id = 'securePrivacy';
 
+    const cmpScript = document.createElement('script');
+    cmpScript.src = 'https://app.secureprivacy.ai/secureprivacy-plugin/web-plugin/cmp/cmp-v2.js';
+    cmpScript.async = true;
+
     const getLocaleEndpoint = 'https://api.odysee.com/locale/get';
     const gdprRequired = localStorage.getItem('gdprRequired');
     // gdpr is known to be required, add script
     if (gdprRequired === 'true') {
       // $FlowFixMe
       document.head.appendChild(script);
+      document.head.appendChild(cmpScript);
     }
 
     // haven't done a gdpr check, do it now
@@ -355,6 +360,7 @@ function App(props: Props) {
           localStorage.setItem('gdprRequired', 'true');
           // $FlowFixMe
           document.head.appendChild(script);
+          document.head.appendChild(cmpScript);
         // note we don't need gdpr, save to session
         } else if (gdprRequiredBasedOnLocation ===  false) {
           localStorage.setItem('gdprRequired', 'false');
@@ -365,6 +371,7 @@ function App(props: Props) {
     return () => {
       // $FlowFixMe
       document.head.removeChild(script);
+      document.head.appendChild(cmpScript);
     };
   }, []);
 


### PR DESCRIPTION
If SecurePrivacy loads some scripts but not others, it can cause issues

This workaround ensures that __tcfapi function is available and will not cause issues with the banner