### PR TITLE
Fix livestream tiles appearing in Tag Search

### DIFF
--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -75,9 +75,10 @@ function DiscoverPage(props: Props) {
 
   const initialLivestreamTileLimit = getPageSize(DEFAULT_LIVESTREAM_TILE_LIMIT);
 
-  const [showViewMoreLivestreams, setShowViewMoreLivestreams] = React.useState(!dynamicRouteProps);
-  const livestreamUris = getLivestreamUris(activeLivestreams, channelIds);
-  const useDualList = showViewMoreLivestreams && livestreamUris.length > initialLivestreamTileLimit;
+  const showLivestreams = window.location.pathname === `/$/${PAGES.WILD_WEST}`;
+  const [showViewMoreLivestreams, setShowViewMoreLivestreams] = React.useState(showLivestreams);
+  const livestreamUris = showLivestreams && getLivestreamUris(activeLivestreams, channelIds);
+  const useDualList = showViewMoreLivestreams && livestreamUris && livestreamUris.length > initialLivestreamTileLimit;
 
   function getElemMeta() {
     return !dynamicRouteProps ? (
@@ -167,7 +168,7 @@ function DiscoverPage(props: Props) {
       {useDualList && (
         <>
           <ClaimListDiscover
-            uris={livestreamUris.slice(0, initialLivestreamTileLimit)}
+            uris={livestreamUris && livestreamUris.slice(0, initialLivestreamTileLimit)}
             headerLabel={headerLabel}
             header={repostedUri ? <span /> : undefined}
             tileLayout={repostedUri ? false : tileLayout}


### PR DESCRIPTION
## Ticket
Closes [#155 All live streams show on tag explore/discovery page + content type filters don't work there](https://github.com/OdyseeTeam/odysee-frontend/issues/155)

`!dynamicRouteProps` wasn't good enough to determine if it's Wild West. Use direct path instead.
