### PR TITLE
Fix livestream tiles reloading placeholders then scrolled

### DIFF
--- a/ui/component/claimListDiscover/index.js
+++ b/ui/component/claimListDiscover/index.js
@@ -15,12 +15,12 @@ import { selectModerationBlockList } from 'redux/selectors/comments';
 import ClaimListDiscover from './view';
 import { doFetchViewCount } from 'lbryinc';
 
-const select = (state) => ({
+const select = (state, props) => ({
   followedTags: selectFollowedTags(state),
   claimSearchByQuery: selectClaimSearchByQuery(state),
   claimSearchByQueryLastPageReached: selectClaimSearchByQueryLastPageReached(state),
   claimsByUri: selectClaimsByUri(state),
-  loading: selectFetchingClaimSearch(state),
+  loading: props.loading !== undefined ? props.loading : selectFetchingClaimSearch(state),
   showNsfw: selectShowMatureContent(state),
   hideReposts: selectClientSetting(state, SETTINGS.HIDE_REPOSTS),
   languageSetting: selectLanguage(state),

--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -175,6 +175,7 @@ function DiscoverPage(props: Props) {
             hideAdvancedFilter
             hideFilters
             infiniteScroll={false}
+            loading={false}
             showNoSourceClaims={ENABLE_NO_SOURCE_CLAIMS}
             meta={getElemMeta()}
           />


### PR DESCRIPTION
## Issue
Closes #9: Wild west + scroll down tries to reload livestreams
