### PR TITLE
GA: entered livestream

### DIFF
--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -383,6 +383,8 @@ const analytics: Analytics = {
           return 'loaded_markdown';
         case RENDER_MODES.IMAGE:
           return 'loaded_image';
+        case 'livestream':
+          return 'loaded_livestream';
         default:
           return 'loaded_misc';
       }
@@ -480,7 +482,7 @@ function sendPromMetric(name: string, value?: number) {
     let url = new URL(SDK_API_PATH + '/metric/ui');
     const params = { name: name, value: value ? value.toString() : '' };
     url.search = new URLSearchParams(params).toString();
-    return fetch(url, { method: 'post' }).catch(function(error) {});
+    return fetch(url, { method: 'post' }).catch(function (error) {});
   }
 }
 

--- a/ui/page/livestream/view.jsx
+++ b/ui/page/livestream/view.jsx
@@ -24,6 +24,11 @@ export default function LivestreamPage(props: Props) {
   const livestreamChannelId = channelClaim && channelClaim.signing_channel && channelClaim.signing_channel.claim_id;
 
   React.useEffect(() => {
+    // TODO: This should not be needed one we unify the livestream player (?)
+    analytics.playerLoadedEvent('livestream', false);
+  }, []);
+
+  React.useEffect(() => {
     if (!livestreamChannelId) {
       setIsLive(false);
       return;


### PR DESCRIPTION
## Issue
#85: "user joined livestream"

## Approach
Add `loaded_livestream` into the existing `player :: action` event, so we can compare it against `loaded_video | loaded_image | loaded_markdown | loaded_audio`.
