### PR TITLE
Cache api pre-flight calls for 24 hours

### DIFF
--- a/extras/lbry-first/lbry-first.js
+++ b/extras/lbry-first/lbry-first.js
@@ -14,7 +14,10 @@ const LbryFirst: LbryFirstTypes = {
   isConnected: false,
   connectPromise: null,
   lbryFirstConnectionString: 'http://localhost:1337/rpc',
-  apiRequestHeaders: { 'Content-Type': 'application/json' },
+  apiRequestHeaders: {
+    'Content-Type': 'application/json',
+    'Access-Control-Max-Age': 86400,
+  },
 
   // Allow overriding lbryFirst connection string (e.g. to `/api/proxy` for lbryweb)
   setLbryFirstConnectionString: (value: string) => {
@@ -25,9 +28,8 @@ const LbryFirst: LbryFirstTypes = {
     LbryFirst.apiRequestHeaders = Object.assign(LbryFirst.apiRequestHeaders, { [key]: value });
   },
 
-  unsetApiHeader: key => {
-    Object.keys(LbryFirst.apiRequestHeaders).includes(key) &&
-      delete LbryFirst.apiRequestHeaders['key'];
+  unsetApiHeader: (key) => {
+    Object.keys(LbryFirst.apiRequestHeaders).includes(key) && delete LbryFirst.apiRequestHeaders['key'];
   },
   // Allow overriding Lbry methods
   overrides: {},
@@ -114,7 +116,7 @@ function checkAndParse(response) {
   if (response.status >= 200 && response.status < 300) {
     return response.json();
   }
-  return response.json().then(json => {
+  return response.json().then((json) => {
     let error;
     if (json.error) {
       const errorMessage = typeof json.error === 'object' ? json.error.message : json.error;
@@ -142,7 +144,7 @@ export function apiCall(method: string, params: ?{}, resolve: Function, reject: 
 
   return fetch(LbryFirst.lbryFirstConnectionString, options)
     .then(checkAndParse)
-    .then(response => {
+    .then((response) => {
       const error = response.error || (response.result && response.result.error);
 
       if (error) {
@@ -158,7 +160,7 @@ function lbryFirstCallWithResult(name: string, params: ?{} = {}) {
     apiCall(
       name,
       params,
-      result => {
+      (result) => {
         resolve(result);
       },
       reject

--- a/ui/lbry.js
+++ b/ui/lbry.js
@@ -15,7 +15,10 @@ const Lbry = {
   daemonConnectionString: 'http://localhost:5279',
   alternateConnectionString: '',
   methodsUsingAlternateConnectionString: [],
-  apiRequestHeaders: { 'Content-Type': 'application/json-rpc' },
+  apiRequestHeaders: {
+    'Content-Type': 'application/json-rpc',
+    'Access-Control-Max-Age': 86400,
+  },
 
   // Allow overriding daemon connection string (e.g. to `/api/proxy` for lbryweb)
   setDaemonConnectionString: (value: string) => {

--- a/web/lbry.js
+++ b/web/lbry.js
@@ -13,7 +13,10 @@ const Lbry = {
   daemonConnectionString: 'http://localhost:5279',
   alternateConnectionString: '',
   methodsUsingAlternateConnectionString: [],
-  apiRequestHeaders: { 'Content-Type': 'application/json-rpc' },
+  apiRequestHeaders: {
+    'Content-Type': 'application/json-rpc',
+    'Access-Control-Max-Age': 86400,
+  },
 
   // Allow overriding daemon connection string (e.g. to `/api/proxy` for lbryweb)
   setDaemonConnectionString: (value) => {


### PR DESCRIPTION
I believe Chrome will still cap at 10 minutes, while Firefox will cap at 24 hours.

Requires https://github.com/OdyseeTeam/odysee-api/issues/396 to test.