### PR TITLE
Don't run SecurePrivacy on iframes

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -332,6 +332,20 @@ function App(props: Props) {
 
   // add secure privacy script
   useEffect(() => {
+    // check if loaded from iframe
+    function inIframe() {
+      try {
+        return window.self !== window.top;
+      } catch (e) {
+        return true;
+      }
+    }
+
+    const loadedFromIframe = inIframe();
+    if (loadedFromIframe) {
+      return;
+    }
+
     const script = document.createElement('script');
     script.src = securePrivacyScriptUrl;
     script.async = true;


### PR DESCRIPTION
If page is detected to be loaded in an iframe, don't run SecurePrivacy