### PR TITLE
Mobile: move 'Notifications' to the top

### DIFF
--- a/ui/scss/component/_navigation.scss
+++ b/ui/scss/component/_navigation.scss
@@ -25,9 +25,8 @@
   width: var(--side-nav-width);
   height: calc(100vh - var(--header-height));
   border-right: 1px solid var(--color-border);
-  padding-top: var(--spacing-l);
+  padding-top: var(--spacing-m);
   padding-bottom: var(--spacing-l);
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
 
@@ -39,6 +38,11 @@
       overflow-y: auto;
     }
   }
+
+  ul {
+    padding-bottom: var(--spacing-s);
+    border-bottom: 1px solid var(--color-border);
+  }
 }
 
 .navigation--mac {
@@ -49,9 +53,7 @@
   @extend .navigation;
   z-index: 4;
   width: var(--side-nav-width);
-  padding-top: 0;
   background-color: var(--color-card-background);
-  border-top: 1px solid var(--color-border);
   box-shadow: var(--card-box-shadow);
 
   .navigation-link {
@@ -216,7 +218,6 @@
 
 .navigation-links--absolute {
   @extend .navigation-links;
-  margin-top: 0;
 
   .navigation-link {
     margin-bottom: 0;


### PR DESCRIPTION
## Test
`kp` dev instance

## Behavioral changes
- Moved Notifications to the top for mobile.
- Added separate lines between sections.

## Code changes
The array method is too restrictive (hard to move things with display logic around). It's also hard to read.

Instead of trying to populate an array, just directly populate the return tree. Added `getLink` to make things readable. It's now easier to see the sections in a glance, and move things around in the future.