### PR TITLE
updated the transform origin for menus

### DIFF
--- a/ui/scss/component/menu-button.scss
+++ b/ui/scss/component/menu-button.scss
@@ -74,7 +74,7 @@
 .menu__list {
   box-shadow: var(--card-box-shadow);
   animation: menu-animate-in var(--animation-duration) var(--animation-style);
-
+  transform-origin: top;
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
   padding: var(--spacing-xs) 0;


### PR DESCRIPTION
## Fixes

Issue Number: 

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Currently, menus have their transform origin in the middle so they expand from the center.

![menu-old](https://user-images.githubusercontent.com/7473983/144148310-cfa95d5c-bdab-45fa-8b14-1d3fccfebc27.gif)

## What is the new behavior?

This PR sets the transform origin on the top of the menu. 

![menu-new](https://user-images.githubusercontent.com/7473983/144148372-2e88d2f6-9b6d-460e-a3d1-7c7f53df7491.gif)


## Other information

Unfortunately, when there isn't enough screen space to display the menu below the target element, the menu will appear on top and it will look like this:
![menu-new-badanimation](https://user-images.githubusercontent.com/7473983/144148944-71ba6ef1-fe9d-46e0-97e1-b28f00abcda4.gif)

## Future Enhancement

It would be nice if it was possible set the transform origin on the bottom if the menu is above the target element

That would look like this:
![menu-item-bottom-correct](https://user-images.githubusercontent.com/7473983/144149707-a833c759-4b79-4b8c-8cd6-49ac6a89eb10.gif)

I couldn't figure out an easy way to determine if the menu was above or below the target element, so I jus set the transform origin to the top in all cases. I think this makes sense because according to the [reach ui menu button docs](https://reach.tech/menu-button/#menupopover-position), the menu will always try to position itself below unless there isn't enough screen space. That means in most situations the menu will display below and the transform origin will be correct.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: UX Improvement

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
