### PR TITLE
Change ad script injection method + fix effect dependency

### DIFF
--- a/web/component/ads/view.jsx
+++ b/web/component/ads/view.jsx
@@ -59,11 +59,10 @@ function Ads(props: Props) {
     if (SHOW_ADS) {
       let script;
       try {
-        let fjs = document.getElementsByTagName('script')[0];
         script = document.createElement('script');
         script.src = scriptUrlToUse;
         // $FlowFixMe
-        fjs.parentNode.insertBefore(script, fjs);
+        document.head.appendChild(script);
 
         return () => {
           // $FlowFixMe
@@ -73,7 +72,7 @@ function Ads(props: Props) {
     }
 
     // TODO: remove the script when it exists?
-  }, [type]);
+  }, []);
 
   // display to say "sign up to not see these"
   const adsSignInDriver = (


### PR DESCRIPTION
## Issue
Tom seeing crashes on the line that was trying to remove the script, saying it's not a child of that node.

## Changes
- I'm guessing the found `fjs` sometimes is not in `head`, but we always remove from `head` during cleanup. Just append to the bottom of head, and remove from head. I think script order doesn't matter if we are injecting at runtime?

- Fixed effect dependency while at it (the latest PR removed the need to check for `type`).