### PR TITLE
Blacklist: use existing map instead of looping

### DIFF
--- a/ui/page/channel/index.js
+++ b/ui/page/channel/index.js
@@ -9,7 +9,7 @@ import {
   makeSelectClaimIsPending,
 } from 'redux/selectors/claims';
 import { selectMyUnpublishedCollections } from 'redux/selectors/collections';
-import { selectBlackListedOutpoints, doFetchSubCount, selectSubCountForUri } from 'lbryinc';
+import { selectBlacklistedOutpointMap, doFetchSubCount, selectSubCountForUri } from 'lbryinc';
 import { selectYoutubeChannels } from 'redux/selectors/user';
 import { selectIsSubscribedForUri } from 'redux/selectors/subscriptions';
 import { selectModerationBlockList } from 'redux/selectors/comments';
@@ -28,7 +28,7 @@ const select = (state, props) => {
     page: selectCurrentChannelPage(state),
     claim,
     isSubscribed: selectIsSubscribedForUri(state, props.uri),
-    blackListedOutpoints: selectBlackListedOutpoints(state),
+    blackListedOutpointMap: selectBlacklistedOutpointMap(state),
     subCount: selectSubCountForUri(state, props.uri),
     pending: makeSelectClaimIsPending(props.uri)(state),
     youtubeChannels: selectYoutubeChannels(state),

--- a/ui/page/channel/view.jsx
+++ b/ui/page/channel/view.jsx
@@ -50,10 +50,7 @@ type Props = {
   channelIsMine: boolean,
   isSubscribed: boolean,
   channelIsBlocked: boolean,
-  blackListedOutpoints: Array<{
-    txid: string,
-    nout: number,
-  }>,
+  blackListedOutpointMap: { [string]: number },
   fetchSubCount: (string) => void,
   subCount: number,
   pending: boolean,
@@ -72,7 +69,7 @@ function ChannelPage(props: Props) {
     // page, ?page= may come back some day?
     channelIsMine,
     isSubscribed,
-    blackListedOutpoints,
+    blackListedOutpointMap,
     fetchSubCount,
     subCount,
     pending,
@@ -137,10 +134,8 @@ function ChannelPage(props: Props) {
 
   let channelIsBlackListed = false;
 
-  if (claim && blackListedOutpoints) {
-    channelIsBlackListed = blackListedOutpoints.some(
-      (outpoint) => outpoint.txid === claim.txid && outpoint.nout === claim.nout
-    );
+  if (claim && blackListedOutpointMap) {
+    channelIsBlackListed = blackListedOutpointMap[`${claim.txid}:${claim.nout}`];
   }
 
   // If a user changes tabs, update the url so it stays on the same page if they refresh.

--- a/ui/page/show/index.js
+++ b/ui/page/show/index.js
@@ -24,7 +24,7 @@ import { normalizeURI } from 'util/lbryURI';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
 import { push } from 'connected-react-router';
 import { makeSelectChannelInSubscriptions } from 'redux/selectors/subscriptions';
-import { selectBlackListedOutpoints } from 'lbryinc';
+import { selectBlacklistedOutpointMap } from 'lbryinc';
 import ShowPage from './view';
 
 const select = (state, props) => {
@@ -73,7 +73,7 @@ const select = (state, props) => {
     uri,
     claim,
     isResolvingUri: selectIsUriResolving(state, uri),
-    blackListedOutpoints: selectBlackListedOutpoints(state),
+    blackListedOutpointMap: selectBlacklistedOutpointMap(state),
     totalPages: makeSelectTotalPagesForChannel(uri, PAGE_SIZE)(state),
     isSubscribed: makeSelectChannelInSubscriptions(uri)(state),
     title: selectTitleForUri(state, uri),

--- a/ui/page/show/view.jsx
+++ b/ui/page/show/view.jsx
@@ -28,10 +28,7 @@ type Props = {
   uri: string,
   claim: StreamClaim,
   location: UrlLocation,
-  blackListedOutpoints: Array<{
-    txid: string,
-    nout: number,
-  }>,
+  blackListedOutpointMap: { [string]: number },
   title: string,
   claimIsMine: boolean,
   claimIsPending: boolean,
@@ -50,7 +47,7 @@ function ShowPage(props: Props) {
     resolveUri,
     uri,
     claim,
-    blackListedOutpoints,
+    blackListedOutpointMap,
     location,
     claimIsMine,
     isSubscribed,
@@ -181,14 +178,11 @@ function ShowPage(props: Props) {
   } else if (claim.name.length && claim.name[0] === '@') {
     innerContent = <ChannelPage uri={uri} location={location} />;
   } else if (claim) {
-    let isClaimBlackListed = false;
-
-    isClaimBlackListed =
-      blackListedOutpoints &&
-      blackListedOutpoints.some(
-        (outpoint) =>
-          (signingChannel && outpoint.txid === signingChannel.txid && outpoint.nout === signingChannel.nout) ||
-          (outpoint.txid === claim.txid && outpoint.nout === claim.nout)
+    const isClaimBlackListed =
+      blackListedOutpointMap &&
+      Boolean(
+        (signingChannel && blackListedOutpointMap[`${signingChannel.txid}:${signingChannel.nout}`]) ||
+          blackListedOutpointMap[`${claim.txid}:${claim.nout}`]
       );
 
     if (isClaimBlackListed && !claimIsMine) {


### PR DESCRIPTION
We already have a pre-calculated map, but not used except for comments.
At the expense of pre-calculating it, the subsequent queries are instantaneous compared to the loop.
We are still not perfect in terms of reducing re-renders, so this helps a lot.
