### PR TITLE
Fix category page labels not being translated

### DIFF
--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -176,7 +176,7 @@ function DiscoverPage(props: Props) {
     headerLabel = (
       <span>
         <Icon icon={(dynamicRouteProps && dynamicRouteProps.icon) || discoverIcon} size={10} />
-        {(dynamicRouteProps && dynamicRouteProps.title) || discoverLabel}
+        {(dynamicRouteProps && __(`${dynamicRouteProps.title}`)) || discoverLabel}
       </span>
     );
   }


### PR DESCRIPTION
found by community member:

![image](https://user-images.githubusercontent.com/76502841/144718061-2d660a87-8637-4732-8c5b-2d716e665594.png)
![image](https://user-images.githubusercontent.com/76502841/144718065-66b18080-fdd7-4fbd-bdd0-61a8e159394c.png)
![image](https://user-images.githubusercontent.com/76502841/144718071-1a4e7df9-9e40-4217-bf4f-e9c3ce2ab17c.png)
