### PR TITLE
Videojs css fix

### DIFF
--- a/ui/scss/component/_button.scss
+++ b/ui/scss/component/_button.scss
@@ -167,7 +167,16 @@
 }
 
 .vjs-button--autoplay-next.vjs-button {
-  margin: auto;
+  // TODO: the width and height of a vjs-button should probably retain
+  // its default "100%" value, so that each control-bar button have the same
+  // touch area size.  Anything inside (like this on/off switch, or icons)
+  // should be a child (e.g. vjs-icon-placeholder), so that inner margins will
+  // also be consistent.
+  //
+  // TEMP: for now, just hardcode the left-right margin so that it looks
+  // equally spaced compared to its siblings.
+  margin: auto 0.5rem auto 0.7rem;
+
   order: 1;
   width: 24px;
   height: 14px;

--- a/ui/scss/component/_button.scss
+++ b/ui/scss/component/_button.scss
@@ -120,7 +120,7 @@
     order: 1;
     background-repeat: no-repeat;
     background-position: center;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='14' viewBox='0 -2 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-monitor'%3E%3Crect x='2' y='3' width='20' height='14' rx='2' ry='2'%3E%3C/rect%3E%3Cline x1='8' y1='21' x2='16' y2='21'%3E%3C/line%3E%3Cline x1='12' y1='17' x2='12' y2='21'%3E%3C/line%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-monitor'%3E%3Crect x='2' y='3' width='20' height='14' rx='2' ry='2'%3E%3C/rect%3E%3Cline x1='8' y1='21' x2='16' y2='21'%3E%3C/line%3E%3Cline x1='12' y1='17' x2='12' y2='21'%3E%3C/line%3E%3C/svg%3E");
   }
 
   &:focus:not(:focus-visible) {
@@ -128,7 +128,7 @@
     // see: https://github.com/lbryio/lbry-desktop/pull/5549#discussion_r580406932
     background-repeat: no-repeat;
     background-position: center;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='14' viewBox='0 -2 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-monitor'%3E%3Crect x='2' y='3' width='20' height='14' rx='2' ry='2'%3E%3C/rect%3E%3Cline x1='8' y1='21' x2='16' y2='21'%3E%3C/line%3E%3Cline x1='12' y1='17' x2='12' y2='21'%3E%3C/line%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-monitor'%3E%3Crect x='2' y='3' width='20' height='14' rx='2' ry='2'%3E%3C/rect%3E%3Cline x1='8' y1='21' x2='16' y2='21'%3E%3C/line%3E%3Cline x1='12' y1='17' x2='12' y2='21'%3E%3C/line%3E%3C/svg%3E");
   }
 }
 

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -378,6 +378,12 @@
 // Video
 // ****************************************************************************
 
+// DRY: we'll soon move vjs items to videojs.scss, so just duplicate these for now.
+$control-bar-height: 2.1rem;
+$control-bar-font-size: 0.8rem;
+$control-bar-popup-font-size: 0.8rem;
+$control-bar-icon-size: 0.7rem;
+
 .video-js-parent {
   height: 100%;
   width: 100%;
@@ -410,6 +416,22 @@
     .vjs-time-divider,
     .vjs-duration {
       display: flex;
+    }
+
+    .vjs-menu-button {
+      font-size: $control-bar-font-size;
+      line-height: $control-bar-height;
+    }
+
+    .vjs-icon-placeholder {
+      font-size: $control-bar-icon-size; // videojs icon font
+      line-height: $control-bar-height;
+    }
+
+    .vjs-quality-selector {
+      .vjs-icon-placeholder {
+        font-size: $control-bar-font-size; // quality selector uses regular text font
+      }
     }
   }
 
@@ -547,18 +569,6 @@ video::-internal-media-controls-overlay-cast-button {
 
   .vjs-duration {
     padding-left: 0;
-  }
-
-  .vjs-playback-rate .vjs-playback-rate-value {
-    // Reduce the gigantic font a bit. Default was 1.5em.
-    font-size: 1.25em;
-    line-height: 2.5;
-  }
-
-  .vjs-playback-rate .vjs-menu {
-    // Extend the width to prevent a potential scrollbar from blocking the text.
-    width: 8em;
-    left: -2em;
   }
 }
 

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -412,10 +412,26 @@ $control-bar-icon-size: 0.7rem;
       display: none;
     }
 
-    .vjs-current-time,
-    .vjs-time-divider,
+    .vjs-time-control {
+      line-height: $control-bar-height;
+      font-size: $control-bar-font-size;
+    }
+
+    .vjs-current-time {
+      display: flex;
+      margin-right: 0.4rem;
+    }
+
+    .vjs-time-divider {
+      display: flex;
+      min-width: unset;
+      padding: 0;
+      z-index: 0; // solves the grayed-out divider
+    }
+
     .vjs-duration {
       display: flex;
+      margin-left: 0.4rem;
     }
 
     .vjs-menu-button {

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -526,6 +526,11 @@ video::-internal-media-controls-overlay-cast-button {
     }
   }
 
+  // Note: the '!important' above and below this line was added a quick hack
+  // to negate a change in vjs without having to increase specificity here.
+  // It won't be needed in an upcoming version of vjs, as they have updated
+  // their side https://github.com/videojs/video.js/pull/7098#issuecomment-908438543
+
   &.vjs-layout-small {
     .vjs-current-time,
     .vjs-time-divider,

--- a/ui/scss/component/_videojs.scss
+++ b/ui/scss/component/_videojs.scss
@@ -1,3 +1,5 @@
+$control-bar-height: 41px; // would '3.5em' be better than px?
+
 .video-js {
   font-size: 12px;
   overflow: hidden;
@@ -5,6 +7,8 @@
   // Control Bar (container)
   .vjs-control-bar {
     background: none;
+    color: #dbd8d8;
+    height: $control-bar-height;
 
     &::before {
       position: absolute;
@@ -163,11 +167,6 @@
   @media (max-width: 813px) {
     font-size: 12px;
   }
-}
-
-.vjs-control-bar {
-  height: 41px !important;
-  color: #dbd8d8;
 }
 
 .vjs-playback-rate {

--- a/ui/scss/component/_videojs.scss
+++ b/ui/scss/component/_videojs.scss
@@ -1,4 +1,7 @@
-$control-bar-height: 41px; // would '3.5em' be better than px?
+$control-bar-height: 2.1rem;
+$control-bar-font-size: 0.8rem;
+$control-bar-popup-font-size: 0.8rem;
+$control-bar-icon-size: 0.7rem;
 
 .video-js {
   font-size: 12px;
@@ -82,13 +85,16 @@ $control-bar-height: 41px; // would '3.5em' be better than px?
     position: absolute !important;
   }*/
 
-  // Menu size
-  .vjs-playback-rate .vjs-menu .vjs-menu-content {
-    width: 125%;
-    font-size: 12px;
+  // Playback Rate
+  .vjs-playback-rate {
+    .vjs-playback-rate-value {
+      font-size: $control-bar-font-size; // Reduce the gigantic font a bit. Default was 1.5em.
+      line-height: $control-bar-height; // Vertically center the text.
+    }
 
-    @media (max-width: 652px) {
-      font-size: 10px;
+    .vjs-menu {
+      width: 10em; // Extend the width to prevent a potential scrollbar from blocking the text.
+      left: -3em; // Center the popup on top of the button that invoked it.
     }
   }
 
@@ -161,71 +167,17 @@ $control-bar-height: 41px; // would '3.5em' be better than px?
   background-image: linear-gradient(to top, rgba(0, 0, 0, 0.4) 0%, transparent 72px);
 }
 
-[dir] .video-js .vjs-control {
-  font-size: 14px;
-
-  @media (max-width: 813px) {
-    font-size: 12px;
-  }
-}
-
-.vjs-playback-rate {
-  margin-top: 3px;
-  font-size: 12px !important;
-
-  @media (max-width: 813px) {
-    margin-top: 3px !important;
-    font-size: 10px !important;
-  }
-}
-
-.vjs-quality-selector > .vjs-menu > .vjs-menu-content {
-  margin-bottom: 3px;
-}
-
 .vjs-hover {
   opacity: 1;
 }
 
 [dir] .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
   background-color: rgba(43, 51, 63);
-}
+  max-height: 20em;
 
-.vjs-quality-selector > .vjs-menu > .vjs-menu-content {
-  font-size: 12px;
-
-  @media (max-width: 652px) {
-    font-size: 10px;
+  li {
+    font-size: $control-bar-popup-font-size;
   }
-}
-
-.vjs-quality-selector > .vjs-menu {
-  height: 100%;
-}
-
-.vjs-layout-medium .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-  max-height: 19em;
-}
-
-.vjs-time-divider div span {
-  font-size: 18px;
-  color: #dbd8d8;
-  position: absolute;
-  top: 4px;
-
-  @media (max-width: 813px) {
-    top: 0px;
-  }
-}
-
-.vjs-play-control {
-  font-size: 17px !important;
-  margin-top: -6px !important;
-  margin-right: -14px !important;
-}
-
-.vjs-play-control .vjs-icon-placeholder {
-  margin-right: -5px;
 }
 
 .vjs-slider-horizontal {

--- a/ui/scss/component/_videojs.scss
+++ b/ui/scss/component/_videojs.scss
@@ -229,14 +229,6 @@
   margin-right: -5px;
 }
 
-.vjs-button--autoplay-next {
-  margin-top: 15px;
-}
-
-.vjs-fullscreen-control {
-  margin-top: 2px;
-}
-
 .vjs-slider-horizontal {
   background-color: #474747 !important;
 }


### PR DESCRIPTION
## Ticket/Issues
- Closes [#300 Video: control bar misalignment](https://github.com/OdyseeTeam/odysee-frontend/issues/300)
- So many `!important` overrides that makes it hard to customize for the upcoming chromecast button.
- Weird `813px max-width` check -- it feels random, plus does not adjust accordingly to zoom-levels.
- The button text is not always vertically centered for all layout and zoom-levels because it is being centered using hardcoded margins.
- The 2 popups don't have consistent fonts and styling, plus their customizations are all over the place.

## Changes
- Try to remove as many unnecessary `!important` as possible. Adding specificity is sufficient, and won't block other customizations.
- Try using `rem` instead of hardcoded margins. The icons/text/margin should resize accordingly per zoom-levels.
    - I didn't replicate the `813px max-width` media check. If it is _really_ necessary, please use `vjs-layout-*` to customize them instead.
- Consolidate the 2 popup menu customizations.
