### PR TITLE
Fix cancel sending Sticker anyway

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -692,6 +692,7 @@ export function CommentCreate(props: Props) {
               } else if (stickerSelector || isReviewingStickerComment) {
                 setReviewingStickerComment(false);
                 setStickerSelector(false);
+                setSelectedSticker(null);
               } else if (isReply && !minTip && onCancelReplying) {
                 onCancelReplying();
               }


### PR DESCRIPTION
## Fixes

Issue Number: Closes #315

`Cancel` wasn't clearing the selection, so if a sticker was selected it would consider a sticker is selected to be sent when trying to comment