### PR TITLE
Fix missing livestream in Category Pages

### DIFF
--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -86,7 +86,7 @@ function DiscoverPage(props: Props) {
 
   const initialLiveTileLimit = getPageSize(DEFAULT_LIVESTREAM_TILE_LIMIT);
 
-  const includeLivestreams = window.location.pathname === `/$/${PAGES.WILD_WEST}`;
+  const includeLivestreams = !tagsQuery;
   const [liveSection, setLiveSection] = useState(includeLivestreams ? liveSectionStore : SECTION.HIDDEN);
   const livestreamUris = includeLivestreams && getLivestreamUris(activeLivestreams, channelIds);
   const useDualList = liveSection === SECTION.LESS && livestreamUris && livestreamUris.length > initialLiveTileLimit;


### PR DESCRIPTION
I accidentally over-limited it to Wild West when trying to exclude Tag Searches from showing livestreams.