### PR TITLE
Move MAIN_CLASS to constants file for better code-splitting.

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { MAIN_CLASS } from 'component/page/view';
+import { MAIN_CLASS } from 'constants/classnames';
 import type { Node } from 'react';
 import React, { useEffect } from 'react';
 import classnames from 'classnames';

--- a/ui/component/page/view.jsx
+++ b/ui/component/page/view.jsx
@@ -2,6 +2,7 @@
 import type { Node } from 'react';
 import React, { Fragment } from 'react';
 import classnames from 'classnames';
+import { MAIN_CLASS } from 'constants/classnames';
 import { lazyImport } from 'util/lazyImport';
 import SideNavigation from 'component/sideNavigation';
 import SettingsSideNavigation from 'component/settingsSideNavigation';
@@ -16,12 +17,9 @@ import { parseURI } from 'util/lbryURI';
 
 const Footer = lazyImport(() => import('web/component/footer' /* webpackChunkName: "footer" */));
 
-export const MAIN_CLASS = 'main';
 type Props = {
   children: Node | Array<Node>,
   className: ?string,
-  autoUpdateDownloaded: boolean,
-  isUpgradeAvailable: boolean,
   authPage: boolean,
   filePage: boolean,
   settingsPage?: boolean,

--- a/ui/constants/classnames.js
+++ b/ui/constants/classnames.js
@@ -1,1 +1,2 @@
+export const MAIN_CLASS = 'main';
 export const COMMENT_HIGHLIGHTED = 'comment--highlighted';


### PR DESCRIPTION
Cross-importing was making things hard to code-split efficiently, because the entire file gets evaluated when imported.
