### PR TITLE
Image env changes

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -31,7 +31,7 @@ WELCOME_VERSION=1.0
 # OG
 OG_TITLE_SUFFIX=| odysee.com
 OG_HOMEPAGE_TITLE=odysee.com
-OG_IMAGE_URL=
+OG_IMAGE_URL=https://spee.ch/odysee-og:e.png?quality=90&height=1200&width=630
 SITE_CANONICAL_URL=https://odysee.com
 
 # UI
@@ -47,16 +47,16 @@ LOGO_TITLE=odysee
 TWITTER_ACCOUNT=OdyseeTeam
 BRANDED_SITE=odysee
 
-## IMAGE ASSETS
-YRBL_HAPPY_IMG_URL=https://cdn.lbryplayer.xyz/api/v3/streams/free/yrbl-happy/7aa50a7e5adaf48691935d55e45d697547392929/839d9a
-YRBL_SAD_IMG_URL=https://cdn.lbryplayer.xyz/api/v3/streams/free/yrbl-sad/c2d9649633d974e5ffb503925e1f17d951f1bd0f/f262dd
-#LOGIN_IMG_URL=https://cdn.lbryplayer.xyz/api/v3/streams/free/login/b671946e911c66c5fa7233afb35de2badd9eceb8/0e1d81
-#LOGO=https://cdn.lbryplayer.xyz/api/v3/streams/free/yrbl-sad/c2d9649633d974e5ffb503925e1f17d951f1bd0f/f262dd
-#LOGO_TEXT_LIGHT=https://cdn.lbryplayer.xyz/api/v3/streams/free/yrbl-sad/c2d9649633d974e5ffb503925e1f17d951f1bd0f/f262dd
-#LOGO_TEXT_DARK=https://cdn.lbryplayer.xyz/api/v3/streams/free/yrbl-sad/c2d9649633d974e5ffb503925e1f17d951f1bd0f/f262dd
-#AVATAR_DEFAULT=
-#MISSING_THUMB_DEFAULT=
-#FAVICON=
+# IMAGE ASSETS
+YRBL_HAPPY_IMG_URL=https://spee.ch/spaceman-happy:a.png?quality=85&height=457&width=457
+YRBL_SAD_IMG_URL=https://spee.ch/spaceman-sad:d.png?quality=85&height=457&width=457
+LOGIN_IMG_URL=https://spee.ch/login:b.png?quality=85&height=1268&width=1000
+LOGO=https://spee.ch/odysee-logo-png:3.png?quality=85&height=200&width=200
+LOGO_TEXT_LIGHT=https://spee.ch/odysee-white-png:f.png?quality=85&height=300&width=1000
+LOGO_TEXT_DARK=https://spee.ch/odysee-png:2.png?quality=85&height=300&width=1000
+AVATAR_DEFAULT=https://spee.ch/spaceman-png:2.png?quality=85&height=180&width=180
+MISSING_THUMB_DEFAULT=https://spee.ch/missing-thumb-png?quality=85&height=390&width=220
+FAVICON=https://spee.ch/favicon-png:c.png?quality=85&height=100&width=100
 
 # LOCALE
 DEFAULT_LANGUAGE=en

--- a/.env.defaults
+++ b/.env.defaults
@@ -50,13 +50,13 @@ BRANDED_SITE=odysee
 # IMAGE ASSETS
 YRBL_HAPPY_IMG_URL=https://spee.ch/spaceman-happy:a.png?quality=85&height=457&width=457
 YRBL_SAD_IMG_URL=https://spee.ch/spaceman-sad:d.png?quality=85&height=457&width=457
-LOGIN_IMG_URL=https://spee.ch/login:b.png?quality=85&height=1268&width=1000
+LOGIN_IMG_URL=https://cdn.lbryplayer.xyz/speech/odysee-sign-up:d.png
 LOGO=https://spee.ch/odysee-logo-png:3.png?quality=85&height=200&width=200
 LOGO_TEXT_LIGHT=https://spee.ch/odysee-white-png:f.png?quality=85&height=300&width=1000
 LOGO_TEXT_DARK=https://spee.ch/odysee-png:2.png?quality=85&height=300&width=1000
 AVATAR_DEFAULT=https://spee.ch/spaceman-png:2.png?quality=85&height=180&width=180
 MISSING_THUMB_DEFAULT=https://spee.ch/missing-thumb-png?quality=85&height=390&width=220
-FAVICON=https://spee.ch/favicon-png:c.png?quality=85&height=100&width=100
+FAVICON=https://spee.ch/favicon-png:c.png
 
 # LOCALE
 DEFAULT_LANGUAGE=en


### PR DESCRIPTION
- Moved to default file + store in git for better tracking of changes.
- Updated 2 of them to use a faster version.
    - `LOGIN_IMG_URL`: no need to grab full size + faster from direct url.
    - `FAVICON`: not much benefit resizing an already-small image.

**NOTE:  the affected envs need to be removed from the prod customizations.**

----

For the odysee logo, it's also super huge, but leaving as-is for now as Raphael is looking at converting it to SVG.