### PR TITLE
Disable ads in Wild West until ads fail more gracefully

### DIFF
--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -194,7 +194,7 @@ function DiscoverPage(props: Props) {
   }
 
   React.useEffect(() => {
-    if (isAuthenticated || !SHOW_ADS) {
+    if (isAuthenticated || !SHOW_ADS || window.location.pathname === `/$/${PAGES.WILD_WEST}`) {
       return;
     }
 


### PR DESCRIPTION
## Issue
- Log out
- Wild West
- Click "Show more livestreams"
- Click "Show less livestreams" (top-right corner)
- Crash
