### PR TITLE
`OG_HOMEPAGE_TITLE`: 'odysee.com' --> 'Odysee'

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -30,7 +30,7 @@ WELCOME_VERSION=1.0
 
 # OG
 OG_TITLE_SUFFIX=| odysee.com
-OG_HOMEPAGE_TITLE=odysee.com
+OG_HOMEPAGE_TITLE=Odysee
 OG_IMAGE_URL=https://spee.ch/odysee-og:e.png?quality=85&height=630&width=1200
 SITE_CANONICAL_URL=odysee.com
 


### PR DESCRIPTION
I'm trying to figure out what's causing our "odysee" search term to show simple results ...
<img src="https://user-images.githubusercontent.com/64950861/146146834-1ea640af-8e0c-4ce4-90f1-c5fa165876ea.png" width="300">

...while "odysee.com" shows the rich results:
<img src="https://user-images.githubusercontent.com/64950861/146146875-aa6cf0bd-f450-4d8b-8fa1-db8152a41edf.png" width="300">

I think it is less likely for someone to type "odysee.com" in a search, so this is not ideal.

My guess is `OG_HOMEPAGE_TITLE` might be the culprit.

Even if `OG_HOMEPAGE_TITLE` is not the culprit, I think the cards look better with the change anyways since it is currently showing double URLs.
before --> after
<img src="https://user-images.githubusercontent.com/64950861/146147097-e7238ed5-62fe-4f44-8254-d3d5282bab2d.png" width="300">  -->  <img src="https://user-images.githubusercontent.com/64950861/146147126-de222528-7822-4893-a7a9-76549fe5503d.png" width="300">


