### PR TITLE
Changed max inline player height

### DIFF
--- a/ui/scss/init/_vars.scss
+++ b/ui/scss/init/_vars.scss
@@ -75,7 +75,7 @@ $breakpoint-large: 1600px;
   --header-height: 80px;
 
   // Inline Player
-  --inline-player-max-height: calc(100vh - var(--header-height) - var(--spacing-l) * 2);
+  --inline-player-max-height: calc(100vh - var(--header-height) - var(--spacing-l) * 4);
 
   // Card
   --card-radius: var(--border-radius);


### PR DESCRIPTION
## Fixes

Issue Number: 🧀

## What is the current behavior?
Player height in theater mode is too long that only the title is visible and you have to scroll down to see the like/dislike and share buttons.

## What is the new behavior?
Player height in theater mode is just enough to see like/dislike and share buttons without scrolling down.

## PR Checklist

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

#
- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
