### PR TITLE
Make tiles all have the same height

### DIFF
--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -395,7 +395,7 @@
   display: flex;
   flex-wrap: wrap;
   list-style: none;
-  align-items: flex-start;
+  align-items: stretch;
 }
 
 .claim-grid__wrapper {
@@ -489,6 +489,8 @@
   margin-left: var(--spacing-m);
   justify-content: flex-start;
   list-style: none;
+  display: flex;
+  flex-direction: column;
 
   .media__thumb {
     border-bottom-right-radius: 0;
@@ -791,6 +793,7 @@
 
 .claim-tile__header {
   position: relative;
+  height: 100%;
 
   .claim__menu-button {
     right: 0.2rem;


### PR DESCRIPTION
## Fixes

Issue Number: 

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Tile height can be different
![image](https://user-images.githubusercontent.com/7473983/146285920-33f8e284-4921-4cd3-8d10-da532e21e8b1.png)

## What is the new behavior?

All tiles will be the same height
![image](https://user-images.githubusercontent.com/7473983/146285845-d284bc4c-ca7a-4581-a7c6-f9f3a694af53.png)
The title section will expand to fill in any unused space.

Thought about making the ad size the same height as claim thumbnails, but did not change that because the ads weren't rendering for me and I didn't know if it would look weird.

that would look something like this:
![image](https://user-images.githubusercontent.com/7473983/146286821-c765a35e-8cf6-4c87-b281-e447bb885531.png)


## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
