### PR TITLE
Fixed vars.scss being imported multiple times

### DIFF
--- a/ui/scss/all.scss
+++ b/ui/scss/all.scss
@@ -1,6 +1,7 @@
 @charset "utf-8";
 
 @import 'init/reset';
+@import 'init/breakpoints';
 @import 'init/vars';
 @import 'init/mixins';
 @import 'init/gui';

--- a/ui/scss/component/_animation.scss
+++ b/ui/scss/component/_animation.scss
@@ -5,7 +5,7 @@
   }
 
   100% {
-    margin-top: $spacing-vertical;
+    margin-top: var(--spacing-vertical);
     opacity: 1;
   }
 }

--- a/ui/scss/component/_comment-create.scss
+++ b/ui/scss/component/_comment-create.scss
@@ -1,4 +1,4 @@
-@import '../init/vars';
+@import '../init/breakpoints';
 
 $thumbnailWidth: 1.5rem;
 $thumbnailWidthSmall: 1rem;

--- a/ui/scss/component/_emote-selector.scss
+++ b/ui/scss/component/_emote-selector.scss
@@ -1,4 +1,4 @@
-@import '../init/vars';
+@import '../init/breakpoints';
 
 .emoteSelector {
   animation: menu-animate-in var(--animation-duration) var(--animation-style);

--- a/ui/scss/component/_file-price.scss
+++ b/ui/scss/component/_file-price.scss
@@ -1,4 +1,4 @@
-@import '../init/vars.scss';
+@import '../init/breakpoints';
 
 .filePrice {
   position: relative;

--- a/ui/scss/component/_sticker-selector.scss
+++ b/ui/scss/component/_sticker-selector.scss
@@ -1,4 +1,4 @@
-@import '../init/vars';
+@import '../init/breakpoints';
 
 .stickerSelector {
   animation: menu-animate-in var(--animation-duration) var(--animation-style);

--- a/ui/scss/component/_view_count.scss
+++ b/ui/scss/component/_view_count.scss
@@ -1,4 +1,4 @@
-@import '../init/vars';
+@import '../init/breakpoints';
 
 .contains_view_count {
   // accommodating for large view counts on channel overview

--- a/ui/scss/component/claim-preview-reset.scss
+++ b/ui/scss/component/claim-preview-reset.scss
@@ -1,4 +1,4 @@
-@import '../init/vars';
+@import '../init/breakpoints';
 
 .claimPreviewReset {
   display: flex;

--- a/ui/scss/component/notifications-banner.scss
+++ b/ui/scss/component/notifications-banner.scss
@@ -1,4 +1,4 @@
-@import '../init/vars';
+@import '../init/breakpoints';
 
 .browserNotificationsBanner {
   display: flex;

--- a/ui/scss/init/_breakpoints.scss
+++ b/ui/scss/init/_breakpoints.scss
@@ -1,0 +1,5 @@
+$breakpoint-xxsmall: 450px;
+$breakpoint-xsmall: 600px;
+$breakpoint-small: 900px;
+$breakpoint-medium: 1150px;
+$breakpoint-large: 1600px;

--- a/ui/scss/init/_gui.scss
+++ b/ui/scss/init/_gui.scss
@@ -228,7 +228,7 @@ textarea {
   display: flex;
 
   .column__item:not(:first-child) {
-    padding-left: $spacing-width * 2/3;
+    padding-left: calc(var(--spacing-width) * 2 / 3);
     flex: 1;
   }
 
@@ -361,11 +361,11 @@ textarea {
   border: 3px solid white;
 
   &.qr-code--right-padding {
-    margin-right: $spacing-vertical * 2/3;
+    margin-right: calc(var(--spacing-vertical) * 2 / 3);
   }
 
   &.qr-code--top-padding {
-    margin-top: $spacing-vertical * 2/3;
+    margin-top: calc(var(--spacing-vertical) * 2 / 3);
   }
 }
 

--- a/ui/scss/init/_vars.scss
+++ b/ui/scss/init/_vars.scss
@@ -1,12 +1,4 @@
-// Both of these should probably die and become variables as well
-$spacing-vertical: 2rem;
-$spacing-width: 36px;
-
-$breakpoint-xxsmall: 450px;
-$breakpoint-xsmall: 600px;
-$breakpoint-small: 900px;
-$breakpoint-medium: 1150px;
-$breakpoint-large: 1600px;
+@import 'breakpoints';
 
 :root {
   --border-radius: 10px;
@@ -24,6 +16,8 @@ $breakpoint-large: 1600px;
   --spacing-l: 2rem;
   --spacing-xl: 3rem;
   --spacing-xxl: 4rem;
+  --spacing-vertical: 2rem;
+  --spacing-width: 36px;
 
   // Aspect ratio
   --aspect-ratio-bluray: 41.6666666667%; // 12:5


### PR DESCRIPTION
## Fixes

Issue Number: 🧀🧀

## What is the current behavior?
`init/vars.scss` being imported multiple times to the `<head>`. Probably because breakpoints inside `var.scss` were going to be converted into native css variables but they weren't able to because @media queries doesn't support css variables. So they had to import it multiple times to use breakpoint scss variables. 

## What is the new behavior?
`init/vars.scss` being imported only once and for that breakpoints separated into a new file init/breakpoints.scss

## Other information

No breaking changes I'm aware of.

## PR Checklist

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
