### PR TITLE
Publish: fix Resume button not appearing after 'conflict'

### DIFF
--- a/ui/redux/reducers/publish.js
+++ b/ui/redux/reducers/publish.js
@@ -184,7 +184,7 @@ export const publishReducer = handleActions(
         }
       } else if (status) {
         currentUploads[key].status = status;
-        if (status === 'error') {
+        if (status === 'error' || status === 'conflict') {
           delete currentUploads[key].uploader;
         }
       }


### PR DESCRIPTION
## Issue
Apparently, a user is experiencing `423 locked` errors from the server, which should not happen given the locking mechanism plus the user wasn't trying to do concurrent uploads.

The Resume button was missing, which made things worse.

## Fix
Anyway, fix the Resume button so that at least they can try to resume.

## Note
Still not clue what would cause the `423 locked`, but should be something related the backend's file-locking stuff.