### PR TITLE
OG: Skip 'data:image' when generating cards.odysee.com urls

### DIFF
--- a/ui/util/web.js
+++ b/ui/util/web.js
@@ -50,7 +50,7 @@ function getThumbnailCdnUrl(url) {
     return url;
   }
 
-  if (url) {
+  if (url && !url.startsWith('data:image')) {
     const encodedURL = Buffer.from(url).toString('base64');
     return `${THUMBNAIL_CARDS_CDN_URL}${encodedURL}.jpg`;
   }


### PR DESCRIPTION
## Issue
Closes #513 Meta: Invalid "card.odysee.com" used as thumbnailUrl

## Change
```
const encodedURL = Buffer.from(url).toString('base64');
```
The above won't work for a `data:image` thumbnail, so just skip it.  I believe the rest of the code will fallback to the default OG image when nothing is returned, but need a review just in case I missed something (oEmbed?)

I think the GUI is already blocking `data:image`, so these are just a handful, probably coming from older Desktop app or cli