### PR TITLE
Change logic for daily reward claiming to weekly

### DIFF
--- a/ui/redux/actions/rewards.js
+++ b/ui/redux/actions/rewards.js
@@ -2,7 +2,7 @@ import { Lbryio } from 'lbryinc';
 import { doUpdateBalance } from 'redux/actions/wallet';
 import { doToast } from 'redux/actions/notifications';
 import * as ACTIONS from 'constants/action_types';
-import { selectUnclaimedRewards } from 'redux/selectors/rewards';
+import { selectUnclaimedRewards, selectWeeklyWatchClaimedThisWeek } from 'redux/selectors/rewards';
 import { selectUserIsRewardApproved } from 'redux/selectors/user';
 import { doFetchInviteStatus } from 'redux/actions/user';
 import rewards from 'rewards';
@@ -43,7 +43,7 @@ export function doClaimRewardType(rewardType, options = {}) {
     if (
       rewardType !== rewards.TYPE_REWARD_CODE &&
       rewardType !== rewards.TYPE_CONFIRM_EMAIL &&
-      rewardType !== rewards.TYPE_DAILY_VIEW &&
+      rewardType !== rewards.TYPE_WEEKLY_WATCH &&
       rewardType !== rewards.TYPE_NEW_ANDROID
     ) {
       if (!reward || reward.transaction_id) {
@@ -143,9 +143,11 @@ export function doClaimEligiblePurchaseRewards() {
     if (unclaimedRewards.find((ur) => ur.reward_type === rewards.TYPE_FIRST_STREAM)) {
       dispatch(doClaimRewardType(rewards.TYPE_FIRST_STREAM));
     } else {
-      [rewards.TYPE_MANY_DOWNLOADS, rewards.TYPE_DAILY_VIEW].forEach((type) => {
-        dispatch(doClaimRewardType(type, { failSilently: true }));
-      });
+      dispatch(doClaimRewardType(rewards.TYPE_MANY_DOWNLOADS, { failSilently: true }));
+
+      if (!selectWeeklyWatchClaimedThisWeek(state)) {
+        dispatch(doClaimRewardType(rewards.TYPE_WEEKLY_WATCH, { failSilently: true }));
+      }
     }
   };
 }

--- a/ui/redux/selectors/rewards.js
+++ b/ui/redux/selectors/rewards.js
@@ -70,3 +70,24 @@ export const selectHasClaimedInitialRewards = createSelector(selectClaimedReward
   const confirmEmailClaimed = !!claims.find((claim) => claim && claim.reward_type === REWARDS.TYPE_CONFIRM_EMAIL);
   return newUserClaimed && confirmEmailClaimed;
 });
+
+export const selectWeeklyWatchClaimedThisWeek = createSelector(selectClaimedRewardsById, (claimedRewardsById) => {
+  const claimedRewards = Object.values(claimedRewardsById);
+
+  // The list could be huge, so:
+  // - don't use find() which will look from the top.
+  // - only search until LOOKUP_LIMIT from the back.
+  const LOOKUP_LIMIT = 15;
+  let i = claimedRewards.length;
+  const stopIndex = i > LOOKUP_LIMIT ? i - LOOKUP_LIMIT : 0;
+
+  while (--i >= stopIndex) {
+    if (claimedRewards[i].reward_type === REWARDS.TYPE_WEEKLY_WATCH) {
+      const last = new Date(claimedRewards[i].updated_at || claimedRewards[i].created_at);
+      const diff = new Date() - last;
+      const diffDays = Math.ceil(diff / (1000 * 60 * 60 * 24));
+      return diffDays < 6;
+    }
+  }
+  return false;
+});

--- a/ui/rewards.js
+++ b/ui/rewards.js
@@ -16,7 +16,7 @@ rewards.TYPE_REFEREE = 'referee';
 rewards.TYPE_REWARD_CODE = 'reward_code';
 rewards.TYPE_SUBSCRIPTION = 'subscription';
 rewards.YOUTUBE_CREATOR = 'youtube_creator';
-rewards.TYPE_DAILY_VIEW = 'daily_view';
+rewards.TYPE_WEEKLY_WATCH = 'weekly_watch';
 rewards.TYPE_NEW_ANDROID = 'new_android';
 
 rewards.claimReward = (type, rewardParams) => {


### PR DESCRIPTION
Closes #531

> _but beamer can add to the "recurring" reward, probably easier_

Adding the last claimed date would remove the need for the history loop.
For now, I think there could be users with a long history, so only look up to 15 items from the back. 