### PR TITLE
Fix: unsubsribe action removes all with same name

### DIFF
--- a/ui/redux/reducers/subscriptions.js
+++ b/ui/redux/reducers/subscriptions.js
@@ -50,9 +50,7 @@ export default handleActions(
       const subscriptionToRemove: Subscription = action.data;
       const newSubscriptions = state.subscriptions
         .slice()
-        .filter(
-          (subscription) => subscription.channelName.toLowerCase() !== subscriptionToRemove.channelName.toLowerCase()
-        );
+        .filter((subscription) => subscription.uri !== subscriptionToRemove.uri);
       const newFollowing = state.following
         .slice()
         .filter((subscription) => subscription.uri !== subscriptionToRemove.uri);


### PR DESCRIPTION
This was found by Miko while testing the "fast action" PR, but is reproducible in production.

## Repro
- Do a search like "Test" and filter to "Channels Only".
- Follow a bunch @test channels
- Unfollow any one of them. All of them gets unfollowed.

## Notes
The change in b9fc9b63 to compare the lower-case channel name probably made it even worse, as something like `@TeSt` would be removed too.

## Change
Not sure why channel name was used in the first place ... perhaps it was to cover canon vs perm uri?  Or something to do with deleted channels?

Anyway, comparing uri makes more sense, so doing that instead.
