### PR TITLE
Don't refresh tiles while fetching and if same results

### DIFF
--- a/ui/component/claimTilesDiscover/view.jsx
+++ b/ui/component/claimTilesDiscover/view.jsx
@@ -3,7 +3,6 @@ import type { Node } from 'react';
 import React from 'react';
 import ClaimPreviewTile from 'component/claimPreviewTile';
 import useFetchViewCount from 'effects/use-fetch-view-count';
-import usePrevious from 'effects/use-previous';
 
 function urisEqual(prev: ?Array<string>, next: ?Array<string>) {
   if (!prev || !next) {
@@ -74,6 +73,8 @@ function ClaimTilesDiscover(props: Props) {
     optionsStringified,
   } = props;
 
+  const prevUris = React.useRef();
+
   const claimSearchUris = claimSearchResults || [];
   const isUnfetchedClaimSearch = claimSearchResults === undefined;
 
@@ -98,10 +99,9 @@ function ClaimTilesDiscover(props: Props) {
     uris.push(...Array(pageSize - uris.length).fill(''));
   }
 
-  const prevUris = usePrevious(uris);
-
   // Show previous results while we fetch to avoid blinkies and poor CLS.
-  const finalUris = isUnfetchedClaimSearch && prevUris ? prevUris : uris;
+  const finalUris = isUnfetchedClaimSearch && prevUris.current ? prevUris.current : uris;
+  prevUris.current = finalUris;
 
   // --------------------------------------------------------------------------
   // --------------------------------------------------------------------------

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -616,10 +616,7 @@ export const makeSelectTagsForUri = (uri: string) =>
     return (metadata && metadata.tags) || [];
   });
 
-export const selectFetchingClaimSearchByQuery = createSelector(
-  selectState,
-  (state) => state.fetchingClaimSearchByQuery || {}
-);
+export const selectFetchingClaimSearchByQuery = (state: State) => selectState(state).fetchingClaimSearchByQuery || {};
 
 export const selectFetchingClaimSearch = createSelector(
   selectFetchingClaimSearchByQuery,


### PR DESCRIPTION
Closes [#555 Don't refresh tiles/claim search after blocking results are in + don't change](https://github.com/OdyseeTeam/odysee-frontend/issues/555)

Also includes prop optimization commit, so the diff is larger.  Actual fix is just a few lines in the last commit.