### PR TITLE
Handle new `Jams` category

### DIFF
--- a/ui/constants/pageTitles.js
+++ b/ui/constants/pageTitles.js
@@ -17,6 +17,7 @@ export const PAGE_TITLE = {
   [PAGES.LAB]: 'Lab',
   [PAGES.MOVIES]: 'Movies',
   [PAGES.MUSIC]: 'Music',
+  [PAGES.JAMS]: 'Jams',
   [PAGES.NEWS]: 'News & Politics',
   [PAGES.POP_CULTURE]: 'Pop Culture',
   // [PAGES.RABBIT_HOLE]: 'The Rabbit Hole';

--- a/ui/constants/pages.js
+++ b/ui/constants/pages.js
@@ -10,6 +10,7 @@ exports.DISCOVER = 'discover';
 exports.BIG_HITS = 'bighits';
 exports.MOVIES = 'movies';
 exports.MUSIC = 'music';
+exports.JAMS = 'jams';
 exports.COMMUNITY = 'community';
 exports.EDUCATION = 'education';
 exports.ENLIGHTENMENT = 'enlightenment';

--- a/web/src/category-metadata.js
+++ b/web/src/category-metadata.js
@@ -53,6 +53,11 @@ module.exports.CATEGORY_METADATA = {
     description: 'All the songs, reviews, covers, and how-tos you love on Odysee',
     image: 'https://cdn.lbryplayer.xyz/speech/category-music:8.jpg',
   },
+  [PAGES.JAMS]: {
+    title: 'Jams',
+    description: 'All the songs, reviews, covers, and how-tos you love on Odysee',
+    image: 'https://cdn.lbryplayer.xyz/speech/category-music:8.jpg',
+  },
   [PAGES.TECH]: {
     title: 'Tech',
     description: 'Hardware, software, startups, photography on Odysee',


### PR DESCRIPTION
Seems like `/$/music` is now `/$/jams` ...

- [x] Updated page title
- [x] Updated OG (just copied everything from Music)
- [ ] Update sitemap (I'll do it after this PR is confirmed, just in case this is not what we wanted).
