### PR TITLE
Update push notifications system

### DIFF
--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -526,7 +526,7 @@ export function doSignIn() {
     const state = getState();
     const user = selectUser(state);
 
-    if (pushNotifications.supported) {
+    if (pushNotifications.supported && user) {
       pushNotifications.reconnect(user.id);
       pushNotifications.validate(user.id);
     }
@@ -545,7 +545,7 @@ export function doSignOut() {
     const state = getState();
     const user = selectUser(state);
     try {
-      if (pushNotifications.supported) {
+      if (pushNotifications.supported && user) {
         await pushNotifications.disconnect(user.id);
       }
     } finally {

--- a/web/component/browserNotificationSettings/use-browser-notifications.js
+++ b/web/component/browserNotificationSettings/use-browser-notifications.js
@@ -19,6 +19,7 @@ export default () => {
   const [user] = useState(selectUser(store.getState()));
 
   useEffect(() => {
+    if (!user) return;
     setPushSupported(pushNotifications.supported);
     if (pushNotifications.supported) {
       pushNotifications.subscribed(user.id).then((isSubscribed: boolean) => {
@@ -31,6 +32,7 @@ export default () => {
   useMemo(() => setPushEnabled(pushPermission === 'granted' && subscribed), [pushPermission, subscribed]);
 
   const subscribe = async () => {
+    if (!user) return;
     setEncounteredError(false);
     try {
       if (await pushNotifications.subscribe(user.id)) {
@@ -49,6 +51,7 @@ export default () => {
   };
 
   const unsubscribe = async () => {
+    if (!user) return;
     if (await pushNotifications.unsubscribe(user.id)) {
       setSubscribed(false);
       analytics.reportEvent('browser_notification', { [GA_DIMENSIONS.ACTION]: 'unsubscribed' });

--- a/web/component/browserNotificationSettings/use-browser-notifications.js
+++ b/web/component/browserNotificationSettings/use-browser-notifications.js
@@ -35,19 +35,16 @@ export default () => {
     if (!user) return;
     setEncounteredError(false);
     try {
-      if (await pushNotifications.subscribe(user.id)) {
+      const subscribed = await pushNotifications.subscribe(user.id);
+      if (subscribed) {
         setSubscribed(true);
         setPushPermission(window.Notification?.permission);
-        analytics.reportEvent('browser_notification', { [GA_DIMENSIONS.ACTION]: 'subscribed' });
-        return true;
-      } else {
-        setEncounteredError(true);
-        analytics.reportEvent('browser_notification', { [GA_DIMENSIONS.ACTION]: 'subscribe_failed' });
       }
     } catch {
       setEncounteredError(true);
       analytics.reportEvent('browser_notification', { [GA_DIMENSIONS.ACTION]: 'subscribe_failed' });
     }
+    analytics.reportEvent('browser_notification', { [GA_DIMENSIONS.ACTION]: 'subscribed' });
   };
 
   const unsubscribe = async () => {


### PR DESCRIPTION
## Fixes

- If an API is down the user can be undefined. We should verify user is defined to avoid errors.
- Make sure analytics reporting doesn't interrupt subscription flow.
- clean up duplicate code

Issue Number: N/A

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

- Even though a user object is expected to be present whether logged in or out, if an API is down the user can be undefined. If the user is undefined the push notification code will fail.
- A failure in analytics reporting could potentially cause the notifications ui to report a failure.

## What is the new behavior?

- Push notification code checks user is defined.
- analytics can't affect subscribe ui.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
