### PR TITLE
Remove `channel_list` from end of Sync Loop

### DIFF
--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -671,8 +671,6 @@ export function doHandleSyncComplete(error, hasNewData, syncId) {
         }
 
         dispatch(doGetAndPopulatePreferences(syncId));
-        // we just got sync data, better update our channels
-        dispatch(doFetchChannelListMine());
       }
     } else {
       console.error('Error in doHandleSyncComplete', error);


### PR DESCRIPTION
## Issue
- Slow for users with many channels.
- The need to do it in Sync Loop is more applicable to Desktop.

## Approach
- Decided to just remove it from sync loop.
- It will still be called when entering `/$/channels`, so that's an alternative to fix things when it is out of sync.