### PR TITLE
i18n: restore ability to retrieve new i18n strings

### DIFF
--- a/ui/i18n.js
+++ b/ui/i18n.js
@@ -1,7 +1,3 @@
-// @if TARGET='app'
-let fs = require('fs');
-// @endif
-
 const isProduction = process.env.NODE_ENV === 'production';
 let knownMessages = null;
 let localStorageAvailable;
@@ -13,45 +9,16 @@ try {
 
 window.i18n_messages = window.i18n_messages || {};
 
-// @if TARGET='app'
-function saveMessageDesktop(message) {
-  const messagesFilePath = __static + '/app-strings.json';
-
-  if (knownMessages === null) {
-    try {
-      knownMessages = JSON.parse(fs.readFileSync(messagesFilePath, 'utf-8'));
-    } catch (err) {
-      throw new Error('Error parsing i18n messages file: ' + messagesFilePath + ' err: ' + err);
-    }
-  }
-
-  if (!knownMessages[message]) {
-    const END = '--end--';
-    delete knownMessages[END];
-    knownMessages[message] = removeContextMetadata(message);
-    knownMessages[END] = END;
-
-    fs.writeFile(messagesFilePath, JSON.stringify(knownMessages, null, 2) + '\n', 'utf-8', err => {
-      if (err) {
-        throw err;
-      }
-    });
-  }
-}
-// @endif
-
 /*
  I dislike the below code (and note that it ships all the way to the distributed app),
  but this seems better than silently having this limitation and future devs not knowing.
  */
-// @if TARGET='web'
 function saveMessageWeb(message) {
   if (!isProduction && knownMessages === null) {
     console.log('Note that i18n messages are not saved in web dev mode.'); // eslint-disable-line
     knownMessages = {};
   }
 }
-// @endif
 
 function removeContextMetadata(message) {
   // Example string entries with context-metadata:
@@ -87,7 +54,7 @@ export function __(message, tokens) {
     ? window.localStorage.getItem('language') || 'en'
     : window.navigator.language.slice(0, 2) || 'en';
   if (!isProduction) {
-    IS_WEB ? saveMessageWeb(message) : saveMessageDesktop(message);
+    saveMessageWeb(message);
   }
 
   let translatedMessage = window.i18n_messages[language] ? window.i18n_messages[language][message] || message : message;
@@ -97,7 +64,7 @@ export function __(message, tokens) {
     return translatedMessage;
   }
 
-  return translatedMessage.replace(/%([^%]+)%/g, function($1, $2) {
+  return translatedMessage.replace(/%([^%]+)%/g, ($1, $2) => {
     return tokens.hasOwnProperty($2) ? tokens[$2] : $2;
   });
 }

--- a/ui/i18n.js
+++ b/ui/i18n.js
@@ -1,11 +1,9 @@
+// @flow
+import { isLocalStorageAvailable } from 'util/storage';
+
 const isProduction = process.env.NODE_ENV === 'production';
 let knownMessages = null;
-let localStorageAvailable;
-try {
-  localStorageAvailable = Boolean(window.localStorage);
-} catch (e) {
-  localStorageAvailable = false;
-}
+const localStorageAvailable = isLocalStorageAvailable();
 
 window.i18n_messages = window.i18n_messages || {};
 
@@ -45,7 +43,7 @@ function removeContextMetadata(message) {
   return message;
 }
 
-export function __(message, tokens) {
+export function __(message: string, tokens: { [string]: string }) {
   if (!message) {
     return '';
   }
@@ -53,6 +51,7 @@ export function __(message, tokens) {
   const language = localStorageAvailable
     ? window.localStorage.getItem('language') || 'en'
     : window.navigator.language.slice(0, 2) || 'en';
+
   if (!isProduction) {
     saveMessageWeb(message);
   }

--- a/ui/i18n.js
+++ b/ui/i18n.js
@@ -2,20 +2,32 @@
 import { isLocalStorageAvailable } from 'util/storage';
 
 const isProduction = process.env.NODE_ENV === 'production';
-let knownMessages = null;
 const localStorageAvailable = isLocalStorageAvailable();
 
 window.i18n_messages = window.i18n_messages || {};
 
-/*
- I dislike the below code (and note that it ships all the way to the distributed app),
- but this seems better than silently having this limitation and future devs not knowing.
+/**
+ * Collects new i18n strings encountered during runtime.
+ * The output can be retrieved and pasted into app-strings.json.
+ *
+ * @param message
  */
 function saveMessageWeb(message) {
-  if (!isProduction && knownMessages === null) {
-    console.log('Note that i18n messages are not saved in web dev mode.'); // eslint-disable-line
-    knownMessages = {};
+  // @if process.env.NODE_ENV!='production'
+  if (!window.app_strings) {
+    return;
   }
+
+  if (!window.new_strings) {
+    console.log('Copy new i18n to clipboard:%c copy(window.new_strings)', 'color:yellow'); // eslint-disable-line
+  }
+
+  window.new_strings = window.new_strings || {};
+
+  if (!window.app_strings[message] && !window.new_strings[message]) {
+    window.new_strings[message] = removeContextMetadata(message);
+  }
+  // @endif
 }
 
 function removeContextMetadata(message) {

--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -15,7 +15,7 @@ import { selectPrefsReady } from 'redux/selectors/sync';
 import { Lbryio } from 'lbryinc';
 import { getDefaultLanguage } from 'util/default-languages';
 
-const { DEFAULT_LANGUAGE } = require('config');
+const { DEFAULT_LANGUAGE, URL_DEV } = require('config');
 const { SDK_SYNC_KEYS } = SHARED_PREFERENCES;
 
 export const IS_MAC = process.platform === 'darwin';
@@ -294,6 +294,16 @@ export function doFetchLanguage(language) {
           });
         });
     }
+
+    // @if process.env.NODE_ENV!='production'
+    if (!window.app_strings) {
+      fetch(`${URL_DEV}/app-strings.json`)
+        .then((r) => r.json())
+        .then((j) => {
+          window.app_strings = j;
+        });
+    }
+    // @endif
   };
 }
 

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -100,6 +100,13 @@ if (fs.existsSync(ROBOTS_TXT_PATH)) {
   });
 }
 
+if (!isProduction) {
+  copyWebpackCommands.push({
+    from: `${STATIC_ROOT}/app-strings.json`,
+    to: `${DIST_ROOT}/app-strings.json`,
+  });
+}
+
 let plugins = [
   new WriteFilePlugin(),
   new CopyWebpackPlugin(copyWebpackCommands),


### PR DESCRIPTION
## Issue
In the original Desktop code, new strings encountered during runtime will be automatically added to the local `app-strings.json` file. The feature is unavailable in Web because writing to file would require explicit permissions.

## Change
Partially restore the functionality by saving the strings to memory and retrieving it from the console via `copy(window.new_strings)`. It's a little bit of manual work, but I think it is good as it forces a sanity check before committing (previously, experimental/developmental strings are committed and being translated in Transifex).