### PR TITLE
Uploads: prevent perpetual locked upload

### DIFF
--- a/ui/constants/storage.js
+++ b/ui/constants/storage.js
@@ -1,3 +1,4 @@
 // Local Storage keys
 export const TUS_LOCKED_UPLOADS = 'tusLockedUploads';
 export const TUS_REMOVED_UPLOADS = 'tusRemovedUploads';
+export const TUS_REFRESH_LOCK = 'tusRefreshLock';

--- a/ui/util/tus.js
+++ b/ui/util/tus.js
@@ -9,7 +9,7 @@
  */
 
 import { v4 as uuid } from 'uuid';
-import { TUS_LOCKED_UPLOADS, TUS_REMOVED_UPLOADS } from 'constants/storage';
+import { TUS_LOCKED_UPLOADS, TUS_REFRESH_LOCK, TUS_REMOVED_UPLOADS } from 'constants/storage';
 import { isLocalStorageAvailable } from 'util/storage';
 import { doUpdateUploadRemove, doUpdateUploadProgress } from 'redux/actions/publish';
 
@@ -105,6 +105,12 @@ export function tusClearRemovedUploads() {
   window.localStorage.removeItem(TUS_REMOVED_UPLOADS);
 }
 
+export function tusClearLockedUploads() {
+  if (!localStorageAvailable) return;
+  window.localStorage.removeItem(TUS_LOCKED_UPLOADS);
+  window.localStorage.setItem(TUS_REFRESH_LOCK, Math.random());
+}
+
 // ****************************************************************************
 // Respond to changes from other tabs.
 // ****************************************************************************
@@ -115,6 +121,10 @@ export function tusHandleTabUpdates(storageKey: string) {
       // The locked IDs are in localStorage, but related GUI is unaware.
       // Send a redux update to force an update.
       window.store.dispatch(doUpdateUploadProgress({ guid: 'force--update' }));
+      break;
+
+    case TUS_REFRESH_LOCK:
+      window.store.dispatch(doUpdateUploadProgress({ guid: 'refresh--lock' }));
       break;
 
     case TUS_REMOVED_UPLOADS:


### PR DESCRIPTION
## Issue
- Closes #592
- It was possible for an upload to stay "locked" e.g. when browser is killed.

## Change
When refreshing or opening a new tab, always clear the locks. The on-going sessions will re-lock them immediately.
