### PR TITLE
Make sure view count fetch runs when claim ID changes.

### DIFF
--- a/ui/component/fileViewCount/view.jsx
+++ b/ui/component/fileViewCount/view.jsx
@@ -17,12 +17,11 @@ type Props = {
 function FileViewCount(props: Props) {
   const { claimId, fetchViewCount, viewCount, livestream, activeViewers, isLive = false } = props;
 
-  // @Note: it's important this only runs once on initial render.
   React.useEffect(() => {
     if (claimId) {
       fetchViewCount(claimId);
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [claimId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const formattedViewCount = Number(viewCount).toLocaleString();
 


### PR DESCRIPTION
## Fixes

fetch for view count should not only happen on initial render, but also when the claim id changes. (side effect from misunderstanding of a previous issue)

Issue Number: N/A

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
