### PR TITLE
Sync: fix new user sign up flow

### DIFF
--- a/ui/redux/actions/sync.js
+++ b/ui/redux/actions/sync.js
@@ -223,7 +223,7 @@ export function doGetSync(passedPassword?: string, callback?: (any, ?boolean) =>
         data.changed = response.changed || syncHash !== localHash;
         data.hasSyncedWallet = true;
 
-        if (response.changed) {
+        if (!response.error && response.changed) {
           return Lbry.sync_apply({ password, data: response.data, blocking: true });
         }
       })
@@ -290,7 +290,7 @@ export function doGetSync(passedPassword?: string, callback?: (any, ?boolean) =>
             Lbry.sync_apply({ password })
               .then(({ hash: walletHash, data: syncApplyData }) => {
                 dispatch(doSetSync('', walletHash, syncApplyData));
-                handleCallback();
+                handleCallback(false, true);
               })
               .catch((syncApplyError) => {
                 handleCallback(syncApplyError);


### PR DESCRIPTION
## Issue
- When signing up, the "channel suggestions" page was stuck because `prefsReady` was never set as `preference_get` was never called.
- It was never called due to the optimizations to skip it when there is no difference between the local and server wallet.

## Change
- The first ever `sync/get` will result in a "no wallet" error, and there is already a `catch` to handle it. But the change in 38c13cf5 caused the `catch` to be skipped and went directly to `sync_apply` instead. Although the `catch` is also doing the same thing (`sync_apply`), it also has an additional callback to call `preference_get`.
    - Fixed by ensuring this scenario ends up in the `catch` block like it was originally intended.
- We also did some optimization in the callback to skip the final `preference_get` if there is no difference in hash. But for the case of signing up, we do want to run it (so that `prefsReady` and other stuff gets initialized), so pass `hasNewData = true` to the callback.
