### PR TITLE
Skip checking DIST_ROOT twice

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -33,7 +33,5 @@ app.use(serve(DIST_ROOT, {
   maxage: 3600000, // set a cache time of one hour, helpful for mobile dev
 }));
 
-app.use(serve(DIST_ROOT)); // Check if the request url matches any assets inside of /dist
-
 app.use(router.routes());
 app.listen(config.WEB_SERVER_PORT, () => `Server up at localhost:${config.WEB_SERVER_PORT}`);


### PR DESCRIPTION
f0cd1592 did an additional call instead of replacement.

Aside: the 1 hour value only has effect in dev instances. For prod, CloudFlare seems to override that to 4 hours.