### PR TITLE
Take 2: speech > thumbnails CDN upload

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1371,6 +1371,7 @@
   "Are you sure you want to purchase %claim_title%?": "Are you sure you want to purchase %claim_title%?",
   "Discover": "Discover",
   "Thumbnail upload service may be down, try again later.": "Thumbnail upload service may be down, try again later.",
+  "There was an error in the upload. The format or extension might not be supported.": "There was an error in the upload. The format or extension might not be supported.",
   "You are currently editing your upload.": "You are currently editing your upload.",
   "You are currently editing this claim.": "You are currently editing this claim.",
   "My content for this post...": "My content for this post...",

--- a/ui/component/channelEdit/view.jsx
+++ b/ui/component/channelEdit/view.jsx
@@ -322,7 +322,6 @@ function ChannelForm(props: Props) {
               uri={uri}
               thumbnailPreview={thumbnailPreview}
               allowGifs
-              showDelayedMessage={isUpload.thumbnail}
               setThumbUploadError={setThumbError}
               thumbUploadError={thumbError}
             />

--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -20,10 +20,8 @@ type Props = {
   claim: ?ChannelClaim,
   doResolveUri: (string) => void,
   isResolving: boolean,
-  showDelayedMessage?: boolean,
   noLazyLoad?: boolean,
   hideStakedIndicator?: boolean,
-  xsmall?: boolean,
   noOptimization?: boolean,
   setThumbUploadError: (boolean) => void,
   ThumbUploadError: boolean,
@@ -42,7 +40,6 @@ function ChannelThumbnail(props: Props) {
     claim,
     doResolveUri,
     isResolving,
-    showDelayedMessage = false,
     noLazyLoad,
     hideStakedIndicator = false,
     setThumbUploadError,
@@ -91,25 +88,19 @@ function ChannelThumbnail(props: Props) {
         'channel-thumbnail--resolving': isResolving,
       })}
     >
-      {showDelayedMessage ? (
-        <div className="channel-thumbnail--waiting">
-          {__('This will be visible in a few minutes after you submit this form.')}
-        </div>
-      ) : (
-        <OptimizedImage
-          alt={__('Channel profile picture')}
-          className={!channelThumbnail ? 'channel-thumbnail__default' : 'channel-thumbnail__custom'}
-          src={(!thumbLoadError && channelThumbnail) || defaultAvatar}
-          loading={noLazyLoad ? undefined : 'lazy'}
-          onError={() => {
-            if (setThumbUploadError) {
-              setThumbUploadError(true);
-            } else {
-              setThumbLoadError(true);
-            }
-          }}
-        />
-      )}
+      <OptimizedImage
+        alt={__('Channel profile picture')}
+        className={!channelThumbnail ? 'channel-thumbnail__default' : 'channel-thumbnail__custom'}
+        src={(!thumbLoadError && channelThumbnail) || defaultAvatar}
+        loading={noLazyLoad ? undefined : 'lazy'}
+        onError={() => {
+          if (setThumbUploadError) {
+            setThumbUploadError(true);
+          } else {
+            setThumbLoadError(true);
+          }
+        }}
+      />
       {!hideStakedIndicator && <ChannelStakedIndicator uri={uri} claim={claim} />}
     </div>
   );

--- a/ui/component/selectAsset/view.jsx
+++ b/ui/component/selectAsset/view.jsx
@@ -1,16 +1,14 @@
 // @flow
 import React from 'react';
 import FileSelector from 'component/common/file-selector';
-import * as SPEECH_URLS from 'constants/speech_urls';
+import { IMG_CDN_PUBLISH_URL } from 'constants/cdn_urls';
 import { FormField, Form } from 'component/common/form';
 import Button from 'component/button';
 import Card from 'component/common/card';
-import { generateThumbnailName } from 'util/generate-thumbnail-name';
 import usePersistedState from 'effects/use-persisted-state';
 
 const accept = '.png, .jpg, .jpeg, .gif';
-const SPEECH_READY = 'READY';
-const SPEECH_UPLOADING = 'UPLOADING';
+const STATUS = { READY: 'READY', UPLOADING: 'UPLOADING' };
 
 type Props = {
   assetName: string,
@@ -26,7 +24,7 @@ function SelectAsset(props: Props) {
   const { onUpdate, onDone, assetName, currentValue, recommended, title, inline } = props;
   const [pathSelected, setPathSelected] = React.useState('');
   const [fileSelected, setFileSelected] = React.useState<any>(null);
-  const [uploadStatus, setUploadStatus] = React.useState(SPEECH_READY);
+  const [uploadStatus, setUploadStatus] = React.useState(STATUS.READY);
   const [useUrl, setUseUrl] = usePersistedState('thumbnail-upload:mode', false);
   const [url, setUrl] = React.useState(currentValue);
   const [error, setError] = React.useState();
@@ -37,7 +35,7 @@ function SelectAsset(props: Props) {
     };
 
     const onSuccess = (thumbnailUrl) => {
-      setUploadStatus(SPEECH_READY);
+      setUploadStatus(STATUS.READY);
       onUpdate(thumbnailUrl, !useUrl);
 
       if (onDone) {
@@ -45,22 +43,27 @@ function SelectAsset(props: Props) {
       }
     };
 
-    setUploadStatus(SPEECH_UPLOADING);
+    setUploadStatus(STATUS.UPLOADING);
 
     const data = new FormData();
-    const name = generateThumbnailName();
-    data.append('name', name);
-    data.append('file', fileSelected);
+    data.append('file-input', fileSelected);
+    data.append('upload', 'Upload');
 
-    return fetch(SPEECH_URLS.SPEECH_PUBLISH, {
+    return fetch(IMG_CDN_PUBLISH_URL, {
       method: 'POST',
       body: data,
     })
       .then((response) => response.json())
-      .then((json) => (json.success ? onSuccess(`${json.data.serveUrl}`) : uploadError(json.message)))
+      .then((json) => {
+        return json.type === 'success'
+          ? onSuccess(`${json.message}`)
+          : uploadError(
+              json.message || __('There was an error in the upload. The format or extension might not be supported.')
+            );
+      })
       .catch((err) => {
         uploadError(err.message);
-        setUploadStatus(SPEECH_READY);
+        setUploadStatus(STATUS.READY);
       });
   }
 
@@ -70,7 +73,7 @@ function SelectAsset(props: Props) {
   const selectedLabel = pathSelected ? __('URL Selected') : __('File Selected');
 
   let fileSelectorLabel;
-  if (uploadStatus === SPEECH_UPLOADING) {
+  if (uploadStatus === STATUS.UPLOADING) {
     fileSelectorLabel = __('Uploading...');
   } else {
     // Include the same label/recommendation for both 'URL' and 'UPLOAD'.
@@ -96,7 +99,7 @@ function SelectAsset(props: Props) {
         ) : (
           <FileSelector
             autoFocus
-            disabled={uploadStatus === SPEECH_UPLOADING}
+            disabled={uploadStatus === STATUS.UPLOADING}
             label={fileSelectorLabel}
             name="assetSelector"
             currentPath={pathSelected}
@@ -119,7 +122,7 @@ function SelectAsset(props: Props) {
             button="primary"
             type="submit"
             label={useUrl ? __('Done') : __('Upload')}
-            disabled={!useUrl && (uploadStatus === SPEECH_UPLOADING || !pathSelected || !fileSelected)}
+            disabled={!useUrl && (uploadStatus === STATUS.UPLOADING || !pathSelected || !fileSelected)}
             onClick={() => doUploadAsset()}
           />
         )}

--- a/ui/constants/cdn_urls.js
+++ b/ui/constants/cdn_urls.js
@@ -1,0 +1,2 @@
+export const IMG_CDN_PUBLISH_URL = 'https://thumbs.odycdn.com/upload.php';
+export const IMG_CDN_STATUS_URL = 'https://thumbs.odycdn.com/status.php';


### PR DESCRIPTION
Should handle more file types now, and return errors (need to add proper error parsing: ```webparray(2) { ["type"]=> string(5) "error" ["message"]=> string(56) "Upload valid images. Only GIF, PNG and JPEG are allowed." }```