### PR TITLE
Fix: account header doesn't refresh on sign up / log in

### DIFF
--- a/ui/component/headerProfileMenuButton/index.js
+++ b/ui/component/headerProfileMenuButton/index.js
@@ -1,11 +1,12 @@
 import { connect } from 'react-redux';
 import { doSignOut } from 'redux/actions/app';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
-import { selectUserEmail } from 'redux/selectors/user';
+import { selectUserEmail, selectUserVerifiedEmail } from 'redux/selectors/user';
 import HeaderProfileMenuButton from './view';
 
 const select = (state) => ({
   activeChannelClaim: selectActiveChannelClaim(state),
+  authenticated: selectUserVerifiedEmail(state),
   email: selectUserEmail(state),
 });
 

--- a/ui/component/headerProfileMenuButton/view.jsx
+++ b/ui/component/headerProfileMenuButton/view.jsx
@@ -13,12 +13,13 @@ import Skeleton from '@mui/material/Skeleton';
 
 type HeaderMenuButtonProps = {
   activeChannelClaim: ?ChannelClaim,
+  authenticated: boolean,
   email: ?string,
   signOut: () => void,
 };
 
 export default function HeaderProfileMenuButton(props: HeaderMenuButtonProps) {
-  const { activeChannelClaim, email, signOut } = props;
+  const { activeChannelClaim, authenticated, email, signOut } = props;
 
   const activeChannelUrl = activeChannelClaim && activeChannelClaim.permanent_url;
 
@@ -45,7 +46,7 @@ export default function HeaderProfileMenuButton(props: HeaderMenuButtonProps) {
         )}
 
         <MenuList className="menu__list--header">
-          {email ? (
+          {authenticated ? (
             <>
               <HeaderMenuLink page={PAGES.UPLOADS} icon={ICONS.PUBLISH} name={__('Uploads')} />
               <HeaderMenuLink page={PAGES.CHANNELS} icon={ICONS.CHANNEL} name={__('Channels')} />


### PR DESCRIPTION
## Issue
Closes [#627 account header doesn't refresh on sign up / log in](https://github.com/OdyseeTeam/odysee-frontend/issues/627)

## Changes
Looking back at [[Header] Changes, fixes and improvements (#493)](https://github.com/OdyseeTeam/odysee-frontend/pull/493), noticed that old code was looking at `has_verified_email` instead of just checking whether an email exists. So, restored original code.

This does have a side-effect of the Logout button not showing any email address underneath it immediately after sign up (with the flow cancelled). But I vaguely recall it was that way previously. A refresh cleans it up.

Perhaps another `user/me` when leaving the Sign Up page can make everything in sync, but this PR simpler to test.
