### PR TITLE
Thumbnail uploads: handle non-JSON responses

### DIFF
--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -441,7 +441,13 @@ export const doUploadThumbnail = (
       body: data,
     })
       .then((res) => res.text())
-      .then((text) => (text.length ? JSON.parse(text) : {}))
+      .then((text) => {
+        try {
+          return text.length ? JSON.parse(text) : {};
+        } catch {
+          throw new Error(text);
+        }
+      })
       .then((json) => {
         if (json.type !== 'success') {
           return uploadError(
@@ -470,7 +476,7 @@ export const doUploadThumbnail = (
         }
 
         const userInput = [fileName, fileExt, fileType, thumbnail];
-        uploadError(`${message}\nUser input:  ${userInput.join(', ')}`);
+        uploadError(`${message}\nUser input:  ${userInput.join(' | ')}`);
       });
   };
 


### PR DESCRIPTION
Ok ... from the log, seeing png is also causing errors.  Now curious to see what the actual error message is, plus Nick hasn't responded yet, so handling the non-json responses to debug ...