### PR TITLE
Fix vidcrunch on ios to only show ad when its scrolled to

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -338,22 +338,27 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       // $FlowFixMe
       vjsPlayer.load();
 
-      // fix invisible vidcrunch overlay
+      // fix invisible vidcrunch overlay on IOS
       if (IS_IOS) {
+        // ads video player
         const adsClaimDiv = document.querySelector('.ads__claim-item');
 
-        // hide ad div
         if (adsClaimDiv) {
+          // hide ad video by default
           adsClaimDiv.style.display = 'none';
 
+          // ad containing div, we can keep part on page
           const adsClaimParentDiv = adsClaimDiv.parentNode;
 
-          // when ad div parent becomes visible, show the ad div
+          // watch parent div for when it is on viewport
           const observer = new IntersectionObserver(function(entries) {
+            // when ad div parent becomes visible by 1px, show the ad video
             if (entries[0].isIntersecting === true) {
               adsClaimDiv.style.display = 'block';
             }
-          }, { threshold: [0] });
+
+            observer.disconnect();
+          });
 
           // $FlowFixMe
           observer.observe(adsClaimParentDiv);

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -337,6 +337,28 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       // load video once source setup
       // $FlowFixMe
       vjsPlayer.load();
+
+      // fix invisible vidcrunch overlay
+      if (IS_IOS) {
+        const adsClaimDiv = document.querySelector('.ads__claim-item');
+
+        // hide ad div
+        if (adsClaimDiv) {
+          adsClaimDiv.style.display = 'none';
+
+          const adsClaimParentDiv = adsClaimDiv.parentNode;
+
+          // when ad div parent becomes visible, show the ad div
+          const observer = new IntersectionObserver(function(entries) {
+            if (entries[0].isIntersecting === true) {
+              adsClaimDiv.style.display = 'block';
+            }
+          }, { threshold: [0] });
+
+          // $FlowFixMe
+          observer.observe(adsClaimParentDiv);
+        }
+      }
     })();
 
     // Cleanup


### PR DESCRIPTION
Vidcrunch makes an invisible Aniview video player div that covers up the DOM and breaks the app because it causes a lot of the buttons to not work. It shows up after you scroll down to the video div. This code hides the video player until the user scrolls to the ad and the video is rendered and becomes visible.