### PR TITLE
mobile menu fix animation close on page load

### DIFF
--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -221,14 +221,17 @@ function SideNavigation(props: Props) {
   const isAbsolute = isOnFilePage || isMediumScreen;
   const isMobile = useIsMobile();
 
-  const menuCanCloseCompletely = isOnFilePage || isMobile;
+  const [menuInitialized, setMenuInitialized] = React.useState(false);
+
+  const menuCanCloseCompletely = (isOnFilePage && !isMobile) || (isMobile && menuInitialized);
   const hideMenuFromView = menuCanCloseCompletely && !sidebarOpen;
 
   const [canDisposeMenu, setCanDisposeMenu] = React.useState(false);
 
   React.useEffect(() => {
-    if (hideMenuFromView) {
+    if (hideMenuFromView || !menuInitialized) {
       const handler = setTimeout(() => {
+        setMenuInitialized(true);
         setCanDisposeMenu(true);
       }, 250);
       return () => {
@@ -237,7 +240,7 @@ function SideNavigation(props: Props) {
     } else {
       setCanDisposeMenu(false);
     }
-  }, [hideMenuFromView]);
+  }, [hideMenuFromView, menuInitialized]);
 
   const shouldRenderLargeMenu = menuCanCloseCompletely || sidebarOpen;
 


### PR DESCRIPTION
## Fixes

[Issue Number: 594](https://github.com/OdyseeTeam/odysee-frontend/issues/594)

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

On mobile, when the page loads the menu is initialized to open and then animates to closed.

## What is the new behavior?

On mobile, when the page loads the menu is initialized to closed.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
