### PR TITLE
Fix infinite scroll when "Upcoming livestream" appears

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -132,10 +132,10 @@ export default function ClaimList(props: Props) {
     const handleScroll = debounce((e) => {
       if (page && pageSize && onScrollBottom) {
         const mainEl = document.querySelector(`.${MAIN_CLASS}`);
-
         if (mainEl && !loading && urisLength >= pageSize) {
-          const contentWrapperAtBottomOfPage = mainEl.getBoundingClientRect().bottom - 0.5 <= window.innerHeight;
-
+          const ROUGH_TILE_HEIGHT_PX = 200;
+          const mainBoundingRect = mainEl.getBoundingClientRect();
+          const contentWrapperAtBottomOfPage = mainBoundingRect.bottom - ROUGH_TILE_HEIGHT_PX <= window.innerHeight;
           if (contentWrapperAtBottomOfPage) {
             onScrollBottom();
           }


### PR DESCRIPTION
## Issue
When the "Upcoming livestream" appears in a list, infinite scroll stops working.

## Cause
The difference between `mainEl.getBoundingClientRect().bottom` and `window.innerHeight` became slightly greater than 0.5, so it was deemed as "haven't reached the bottom".

## Change
Coincidently, I've been wanting to make the inf scroll load earlier (instead of after reaching the absolute bottom) to make the experience smoother, so added a 200px threshold, which is roughly the height of a tile. This gets us the new behavior while also fixes the original problem.
