### PR TITLE
Don't show the hide setting on the upcoming list on channel page.

### DIFF
--- a/ui/component/channelContent/view.jsx
+++ b/ui/component/channelContent/view.jsx
@@ -150,6 +150,7 @@ function ChannelContent(props: Props) {
           liveUris={
             isChannelBroadcasting && activeLivestreamForChannel.claimUri ? [activeLivestreamForChannel.claimUri] : []
           }
+          showHideSetting={false}
         />
       )}
 

--- a/ui/component/scheduledStreams/view.jsx
+++ b/ui/component/scheduledStreams/view.jsx
@@ -17,6 +17,7 @@ type Props = {
   liveUris: Array<string>,
   limitClaimsPerChannel?: number,
   onLoad: (number) => void,
+  showHideSetting: boolean,
   // --- perform ---
   setClientSetting: (string, boolean | string | number, boolean) => void,
   doShowSnackBar: (string) => void,
@@ -31,6 +32,7 @@ const ScheduledStreams = (props: Props) => {
     setClientSetting,
     doShowSnackBar,
     onLoad,
+    showHideSetting = true,
   } = props;
   const isMediumScreen = useIsMediumScreen();
   const isLargeScreen = useIsLargeScreen();
@@ -62,7 +64,9 @@ const ScheduledStreams = (props: Props) => {
     return (
       <div>
         {__('Upcoming Livestreams')}
-        <Button button="link" label={__('Hide')} onClick={hideScheduledStreams} className={'ml-s text-s'} />
+        {showHideSetting && (
+          <Button button="link" label={__('Hide')} onClick={hideScheduledStreams} className={'ml-s text-s'} />
+        )}
       </div>
     );
   };


### PR DESCRIPTION
## Fixes

Don't show the hide setting on the upcoming list on channel page.

Issue Number: N/A

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?


The scheduled stream hide setting is visible on channel pages.

## What is the new behavior?

The scheduled stream hide setting is visible only on home and following pages.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
