### PR TITLE
Make sure to specifically query for streams in the scheduled listing

### DIFF
--- a/ui/component/scheduledStreams/view.jsx
+++ b/ui/component/scheduledStreams/view.jsx
@@ -80,6 +80,7 @@ const ScheduledStreams = (props: Props) => {
         orderBy={CS.ORDER_BY_NEW_ASC}
         tileLayout={tileLayout}
         tags={[SCHEDULED_LIVESTREAM_TAG]}
+        claimType={[CS.CLAIM_STREAM]}
         releaseTime={`>${moment().subtract(LIVESTREAM_UPCOMING_BUFFER, 'minutes').startOf('minute').unix()}`}
         hideAdvancedFilter
         hideFilters


### PR DESCRIPTION
## Fixes

This wasn't causing any issues, but in any case, we should be more precise and query specifically for streams. 

Issue Number: N/A

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

The query for scheduled streams uses the default claim types in it's query. (stream, repost, channel)

## What is the new behavior?

The query for scheduled streams specifically queries just for streams.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I added a line describing my change to CHANGELOG.md
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
