### PR TITLE
Fallback to main language (xx) when sub-language (xx-yy) is not supported

### DIFF
--- a/ui/util/default-languages.js
+++ b/ui/util/default-languages.js
@@ -4,7 +4,21 @@ const DEFAULT_LANG = 'en';
 
 export const getDefaultLanguage = () => {
   const browserLanguage = window.navigator.language;
-  return SUPPORTED_BROWSER_LANGUAGES[browserLanguage] || DEFAULT_LANG;
+
+  if (SUPPORTED_BROWSER_LANGUAGES[browserLanguage]) {
+    return SUPPORTED_BROWSER_LANGUAGES[browserLanguage];
+  }
+
+  if (browserLanguage.includes('-')) {
+    // Perhaps it is a sub-lang that we are currently not supporting.
+    // See if we support the main one.
+    const mainLang = browserLanguage.substring(0, browserLanguage.indexOf('-'));
+    if (SUPPORTED_BROWSER_LANGUAGES[mainLang]) {
+      return SUPPORTED_BROWSER_LANGUAGES[mainLang];
+    }
+  }
+
+  return DEFAULT_LANG;
 };
 
 // If homepages has a key "zh-Hant" return that, otherwise return "zh", otherwise "en"


### PR DESCRIPTION
## Issue
Closes #656 Automatic language detection can't recognize de-DE as de

## Note
We do fallback to the main language, but seems like the code got lost ... not sure when, but probably during the CN/TW or PT-BR support. The refactor in  81e47300 still had that, but the refactor was reverted due to some web compilation issue (should revisit that someday).

## Change
Put back equivalent code.
