### PR TITLE
Fix ignored 'Content Type' filter

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -133,8 +133,8 @@ function ClaimListDiscover(props: Props) {
     claimType,
     pageSize,
     defaultClaimType,
-    streamType = SIMPLE_SITE ? [CS.FILE_VIDEO, CS.FILE_AUDIO] : undefined,
-    defaultStreamType = SIMPLE_SITE ? CS.FILE_VIDEO : undefined, // add param for DEFAULT_STREAM_TYPE
+    streamType,
+    defaultStreamType = SIMPLE_SITE ? [CS.FILE_VIDEO, CS.FILE_AUDIO] : undefined, // add param for DEFAULT_STREAM_TYPE
     freshness,
     defaultFreshness = CS.FRESH_WEEK,
     renderProperties,


### PR DESCRIPTION
Putting up on `kp` for testing (building...)

----

## Issue
After enabling Advanced Filter in Category Pages, the 'Content Type' filter only works for "repost/video/list".

## Root-cause
When `streamType` is not provided, it defaults to 'Video|Audio', making it always "defined":

```
streamType = SIMPLE_SITE ? [CS.FILE_VIDEO, CS.FILE_AUDIO] : undefined,
```

This seem to override the purpose of `defaultStreamType`, which will not be used unless the client explicitly set `streamType=null`, which currently is only being applied for `RECENT_FROM_FOLLOWING[]`.

```
  const streamTypeParam =
    streamType || (CS.FILE_TYPES.includes(contentTypeParam) && contentTypeParam) || defaultStreamType || null;
```

## Change
Cleared the forced default and let it fall back to `defaultStreamType` instead.