### PR TITLE
Fix advanced filter showing up in Wild West

### DIFF
--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -218,7 +218,6 @@ function DiscoverPage(props: Props) {
             headerLabel={headerLabel}
             header={repostedUri ? <span /> : undefined}
             tileLayout={repostedUri ? false : tileLayout}
-            hideAdvancedFilter
             hideFilters
             infiniteScroll={false}
             loading={false}
@@ -245,8 +244,7 @@ function DiscoverPage(props: Props) {
       <ClaimListDiscover
         prefixUris={useDualList ? undefined : livestreamUris}
         pins={useDualList ? undefined : getPins(dynamicRouteProps)}
-        hideAdvancedFilter={SIMPLE_SITE ? tags && dynamicRouteProps : undefined}
-        hideFilters={SIMPLE_SITE ? tags && dynamicRouteProps : undefined}
+        hideFilters={SIMPLE_SITE ? !dynamicRouteProps : undefined}
         header={useDualList ? <span /> : repostedUri ? <span /> : undefined}
         tileLayout={repostedUri ? false : tileLayout}
         defaultOrderBy={SIMPLE_SITE ? (dynamicRouteProps ? undefined : CS.ORDER_BY_TRENDING) : undefined}


### PR DESCRIPTION
Behavior we want:
- hide Advanced Filter for Wild West
- show Advanded Filter & Filter for everything else

Note:
Requires the other PR for the filters to work correctly, but both are testable in `kp`
