### PR TITLE
Resolve claim and stream types when there is a filter

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -348,9 +348,9 @@ function ClaimListDiscover(props: Props) {
     options.reposted_claim_id = repostedClaimId;
   }
   // IF release time, set it, else set fallback release times using the hack below.
-  if (releaseTime) {
+  if (releaseTime && claimTypeParam !== CS.CLAIM_CHANNEL) {
     options.release_time = releaseTime;
-  } else if (claimType !== CS.CLAIM_CHANNEL) {
+  } else if (claimTypeParam !== CS.CLAIM_CHANNEL) {
     if (orderParam === CS.ORDER_BY_TOP && freshnessParam !== CS.FRESH_ALL) {
       options.release_time = `>${Math.floor(moment().subtract(1, freshnessParam).startOf('hour').unix())}`;
     } else if (orderParam === CS.ORDER_BY_NEW || orderParam === CS.ORDER_BY_TRENDING) {

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -205,11 +205,42 @@ function ClaimListDiscover(props: Props) {
     ? null
     : langParam.concat(langParam === 'en' ? ',none' : '');
 
+  let claimTypeParam = claimType || defaultClaimType || null;
+  let streamTypeParam = streamType || defaultStreamType || null;
+
   const contentTypeParam = urlParams.get(CS.CONTENT_KEY);
-  const claimTypeParam =
-    claimType || (CS.CLAIM_TYPES.includes(contentTypeParam) && contentTypeParam) || defaultClaimType || null;
-  const streamTypeParam =
-    streamType || (CS.FILE_TYPES.includes(contentTypeParam) && contentTypeParam) || defaultStreamType || null;
+  if (contentTypeParam) {
+    switch (contentTypeParam) {
+      case CS.CLAIM_COLLECTION:
+      case CS.CLAIM_REPOST:
+        claimTypeParam = contentTypeParam;
+        break;
+
+      case CS.CLAIM_CHANNEL:
+        claimTypeParam = CS.CLAIM_CHANNEL;
+        streamTypeParam = undefined;
+        break;
+
+      case CS.FILE_VIDEO:
+      case CS.FILE_AUDIO:
+      case CS.FILE_IMAGE:
+      case CS.FILE_MODEL:
+      case CS.FILE_BINARY:
+      case CS.FILE_DOCUMENT:
+        streamTypeParam = contentTypeParam;
+        break;
+
+      case CS.CONTENT_ALL:
+        claimTypeParam = undefined;
+        streamTypeParam = undefined;
+        break;
+
+      default:
+        console.log('Invalid or unhandled CONTENT_KEY:', contentTypeParam);
+        break;
+    }
+  }
+
   const durationParam = urlParams.get(CS.DURATION_KEY) || null;
   const channelIdsInUrl = urlParams.get(CS.CHANNEL_IDS_KEY);
   const channelIdsParam = channelIdsInUrl ? channelIdsInUrl.split(',') : channelIds;


### PR DESCRIPTION
## Test
`kp`

## Symptom
Channel Page 'Content Type' filter not working

## Issue
The Advanced Filter work by placing a `?content=` URL param. The list component then parses it and makes the `claim_search` params accordingly. But:

1. There is a mix up in how the list component treats `?content=`.
    - The original code seems to treat this as a way to define the type externally but only for a list without `claimType` defined via code. In other words, if `claimType="something"`, `?content=` is ignored.
    - On the other hand, the Advanced Filter relies on `?content=` being used.
2. `?content=` is then split between `claimTypeParam` and `streamTypeParam`. The current code does not check if the split makes sense, e.g. if `?content=channel` and `streamType` was `['video']`, these 2 are incompatible and produces no results.

## Change
1. Not really sure what's the original intention, but let's just make `?content=` as an override/filter for now on.  Otherwise, the whole filter system doesn't work.
2. `?content=` should probably be limited to always be a subset of `claimType` and `streamType`. But this seems complicated to do, so for now let's just make sure the filtered `claimType` -- `streamType` combo makes sense.

----

# Fix 'Channel' filter not working in Wild West 

## Cause
The Wild West list defines `release_time` to be 1 week ago. As long as this parameter exists, a channel `claim_search` produces no results (I thought channels have creation dates?). That is why an unfiltered Wild West never showed Channel Tiles.

## Change
The existing `release_time` handling does seem to hint that we should not set the parameter when searching for Channels. Expanded that to consider the final (filtered) claim type, not just the original.
