### PR TITLE
Watchman fixes

### DIFF
--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -146,6 +146,11 @@ async function sendAndResetWatchmanData() {
     return 'Video player not initialized';
   }
 
+  // don't send data if there was no buffering
+  if (!amountOfBufferEvents && !amountOfBufferTimeInMS) {
+    return;
+  }
+
   let timeSinceLastIntervalSend = new Date() - lastSentTime;
   lastSentTime = new Date();
 
@@ -231,6 +236,7 @@ const analytics: Analytics = {
 
   // receive buffer events from tracking plugin and save buffer amounts and times for backend call
   videoBufferEvent: async (claim, data) => {
+    console.log('received buffer event');
     amountOfBufferEvents = amountOfBufferEvents + 1;
     amountOfBufferTimeInMS = amountOfBufferTimeInMS + data.bufferDuration;
   },
@@ -259,7 +265,7 @@ const analytics: Analytics = {
       sendAndResetWatchmanData();
       stopWatchmanInterval();
       startWatchmanIntervalIfNotRunning();
-      // is being told to play, and seeking, don't do anything,
+      // if being told to play, and seeking, don't do anything,
       // assume it's been started already from pause
     } else if (isPlaying && playerIsSeeking) {
       // start but not a seek, assuming a start from paused content

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -161,7 +161,9 @@ function VideoViewer(props: Props) {
 
   // TODO: analytics functionality
   function doTrackingBuffered(e: Event, data: any) {
+    analytics.debugLog('buffer event!');
     fetch(source, { method: 'HEAD', cache: 'no-store' }).then((response) => {
+      analytics.debugLog('got back from fetch');
       data.playerPoweredBy = response.headers.get('x-powered-by');
       doAnalyticsBuffer(uri, data);
     });


### PR DESCRIPTION
Fixes pointed out by Tom, basically if there is a buffer event over 10s the plugin will error due to the event only being sent every 10 seconds (with a duration of 10 seconds) but buffer events only being sent once per buffer regardless of the time of buffer.