### PR TITLE
CHANNEL_UNSUBSCRIBE: handle colon vs. hash uris

### DIFF
--- a/ui/redux/reducers/subscriptions.js
+++ b/ui/redux/reducers/subscriptions.js
@@ -48,12 +48,14 @@ export default handleActions(
     },
     [ACTIONS.CHANNEL_UNSUBSCRIBE]: (state: SubscriptionState, action): SubscriptionState => {
       const subscriptionToRemove: Subscription = action.data;
+
       const newSubscriptions = state.subscriptions
         .slice()
-        .filter((subscription) => subscription.uri !== subscriptionToRemove.uri);
+        .filter((subscription) => !isURIEqual(subscription.uri, subscriptionToRemove.uri));
+
       const newFollowing = state.following
         .slice()
-        .filter((subscription) => subscription.uri !== subscriptionToRemove.uri);
+        .filter((subscription) => !isURIEqual(subscription.uri, subscriptionToRemove.uri));
 
       return {
         ...state,


### PR DESCRIPTION
## Ticket
Closes #644 investigate following vs subscription preference data

## Issue
- iOS app uses colon for following/subscriptions.
- Front-end code handled the "colon vs. hash" for `CHANNEL_SUBSCRIBE,` but not for `CHANNEL_UNSUBSCRIBE`

## ??
Not really sure what's going on in the iOS side:  unfollowing from Web does clear the entry in the wallet (confirmed from Desktop), but iOS stays followed.  Is it just not syncing correctly?
_update: yeah, just a live sync problem.  Killing the app and restarting fixes it ... I guess it syncs only on startup_
