### PR TITLE
Ignore .vscode directory to allow disabling js typechecking.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ yarn-error.log
 package-lock.json
 .transifexrc
 .idea/
+.vscode/
 /build/daemon*
 /lbrytv/dist/
 /lbrytv/node_modules


### PR DESCRIPTION
I'm proposing a minor addition to the .gitignore file to accommodate vscode.  By default, even with the flow extension installed, it throws errors about the flow types that it is mistaking for typescript type annotations, which are only allowed in .ts(x) files:

![image](https://user-images.githubusercontent.com/128739/149643638-1b185e1e-83c2-41be-ab99-7aca10e7ff90.png)

By ignoring this directory, we can disable the validation for the workspace, allowing leaving this to flow.

![image](https://user-images.githubusercontent.com/128739/149643577-69673bcb-c453-45c8-abb5-70c05a80a8ad.png)
