### PR TITLE
Corrected `mentioned_channels` parameter name

### DIFF
--- a/flow-typed/Comment.js
+++ b/flow-typed/Comment.js
@@ -176,6 +176,11 @@ declare type CommentAbandonParams = {
   mod_channel_name?: string,
 };
 
+declare type MentionedChannel = {
+  channel_name: string,
+  channel_id: string,
+};
+
 declare type CommentCreateParams = {
   comment: string,
   claim_id: string,
@@ -183,6 +188,7 @@ declare type CommentCreateParams = {
   signature: string,
   signing_ts: string,
   support_tx_id?: string,
+  mentioned_channels?: Array<MentionedChannel>,
 };
 
 declare type SuperListParams = {};

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -29,11 +29,6 @@ const PROMISE_FULFILLED = 'fulfilled';
 
 const MENTION_REGEX = /(?:^| |\n)@[^\s=&#$@%?:;/"<>%{}|^~[]*(?::[\w]+)?/gm;
 
-declare type MentionedChannel = {
-  channelName: string,
-  channelID: string,
-};
-
 function devToast(dispatch, msg) {
   if (isDev) {
     console.error(msg); // eslint-disable-line
@@ -521,10 +516,10 @@ export function doCommentCreate(
         const claim = selectClaimForUri(state, mentionUri);
 
         if (claim) {
-          mentionedChannels.push({ channelName: claim.name, channelID: claim.claim_id });
+          mentionedChannels.push({ channel_name: claim.name, channel_id: claim.claim_id });
         } else if (claim === undefined) {
           dispatch(doResolveUri(mentionUri))
-            .then((response) => mentionedChannels.push({ channelName: response.name, channelID: response.claim_id }))
+            .then((response) => mentionedChannels.push({ channel_name: response.name, channel_id: response.claim_id }))
             .catch((e) => {});
         }
       });


### PR DESCRIPTION
Commentron json params are usually underscored instead of camel-cased.
Double-checked commentron code:

```
// MentionedChannel channels mentioned in comment
type MentionedChannel struct {
	ChannelName string `json:"channel_name"`
	ChannelID   string `json:"channel_id"`
}
```

## Test
I don't get notified on either format though ... maybe it's not enabled in commentron yet.