### PR TITLE
Fix "don't cache html" meta tags

### DIFF
--- a/static/index-web.html
+++ b/static/index-web.html
@@ -20,6 +20,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Expires" content="0" />
 
     <link rel="preload" href="/public/font/v1/300.woff" as="font" type="font/woff" crossorigin />
     <link rel="preload" href="/public/font/v1/300i.woff" as="font" type="font/woff" crossorigin />


### PR DESCRIPTION
In 36fe7366, the approach to fix the "missing chunk" error and user using old code was to disable caching on the html so that user always grabs the one that's pointing to the latest ui.js.

But https://cristian.sulea.net/blog/disable-browser-caching-with-meta-html-tags/ says 3 sets of `meta` is needed to, and we missed out one. That probably explains why refreshing sometimes does not work, although I've also read that some browsers simply ignores these meta.
