### PR TITLE
The case of the missing Collection item

### DIFF
--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -160,8 +160,8 @@ export const doFetchItemsInCollections = (
 
       for (let i = 0; i < Math.ceil(totalItems / batchSize); i++) {
         batches[i] = Lbry.claim_search({
-          claim_ids: claim.value.claims,
-          page: i + 1,
+          claim_ids: claim.value.claims.slice(i * batchSize, (i + 1) * batchSize),
+          page: 1,
           page_size: batchSize,
           no_totals: true,
         });


### PR DESCRIPTION
## Issue
A huge list like http://localhost:9090/$/list/d91815c1bc8c80a1f354284a8c8e92d84d5f07a6 (193 items) often produces fewer results in the final rendered list.

## Cause
The same list of IDs was passed into `claim_search`, and we just increment the `page` for each batch of 50. However, it seems like `claim_search` does not honor the order between each call, and some results from the previous page took the place of the results in the next page.

## Fix
When batching, slice the ID list ourselves to bypass the problem for now.
