### PR TITLE
Top Search: handle sub count for Repost

### DIFF
--- a/ui/component/claimPreviewSubtitle/index.js
+++ b/ui/component/claimPreviewSubtitle/index.js
@@ -14,7 +14,7 @@ const select = (state, props) => {
     claim,
     pending: makeSelectClaimIsPending(props.uri)(state),
     isLivestream,
-    subCount: isChannel ? selectSubCountForUri(state, props.uri) : 0,
+    subCount: isChannel ? selectSubCountForUri(state, claim.repost_url ? claim.canonical_url : props.uri) : 0,
   };
 };
 


### PR DESCRIPTION
## Issue
Closes #87 Repost - Top result should show followers properly"

The winning url for "bret" search is "lbry://bret", which is a repost.

## Change
We need to use the canon url to retrieved the fetched view count.
