### PR TITLE
ClaimList: fix missing key

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -162,6 +162,7 @@ export default function ClaimList(props: Props) {
   const getClaimPreview = (uri: string, index: number, draggableProvided?: any) => (
     <ClaimPreview
       uri={uri}
+      key={uri}
       indexInContainer={index}
       type={type}
       active={activeUri && uri === activeUri}


### PR DESCRIPTION
## Issue
From the Draggable PR, the draggables retained the key but regular lists lost it.
