### PR TITLE
Comment options: hide "Remove" when comment is removed.

### DIFF
--- a/ui/component/livestreamComment/view.jsx
+++ b/ui/component/livestreamComment/view.jsx
@@ -135,6 +135,7 @@ export default function LivestreamComment(props: Props) {
             isPinned={isPinned}
             isTopLevel
             disableEdit
+            disableRemove={comment.removed}
             isLiveComment
           />
         </Menu>


### PR DESCRIPTION
## Issue
Closes #295 Livestream chat: Deleting comment that was already deleted by someone else, makes chat blank.
