### PR TITLE
Correctly encode the path for query string

### DIFF
--- a/ui/component/fileActions/view.jsx
+++ b/ui/component/fileActions/view.jsx
@@ -108,7 +108,7 @@ function FileActions(props: Props) {
       push(`/$/${PAGES.CHANNEL_NEW}?redirect=${pathname}`);
       doToast({ message: __('A channel is required to repost on %SITE_NAME%', { SITE_NAME }) });
     } else {
-      push(`/$/${PAGES.REPOST_NEW}?from=${encodeURIComponent(uri)}&redirect=${pathname}`);
+      push(`/$/${PAGES.REPOST_NEW}?from=${encodeURIComponent(uri)}&redirect=${encodeURIComponent(pathname)}`);
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/OdyseeTeam/odysee-frontend/issues/663

The query param was not being encoded for the query string side. A "+" on the path side is valid, but represents a space in the query string and needs to be encoded.