### PR TITLE
Fix play btn calcs as audio tag was not measuring as expected

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -292,7 +292,7 @@ function VideoViewer(props: Props) {
   function centerPlayButton() {
     // center play button
     const playBT = document.getElementsByClassName('vjs-big-play-button')[0];
-    const videoDiv = window.player.children_[0];
+    const videoDiv = window.player.children_[0].closest('video-js-parent');
     const controlBar = document.getElementsByClassName('vjs-control-bar')[0];
     const leftWidth = (videoDiv.offsetWidth - playBT.offsetWidth) / 2 + 'px';
     const availableHeight = videoDiv.offsetHeight - controlBar.offsetHeight;


### PR DESCRIPTION
Fixes https://github.com/OdyseeTeam/odysee-frontend/issues/689

The core issue is that the function `centerPlayButton` was utilizing the audio tag, which was not rendered and giving 0's for initial measurement variables.  Walking up the dom to the video parent element guarantees a div that can be measured with the expected dimensions.

This fixes the immediate bug, but likely worth returning to at some point to see if this can be done with CSS.

Verified fixed when embedded:
![image](https://user-images.githubusercontent.com/128739/151649570-a470b810-b419-4499-a15e-d4395d15b2c7.png)

Verified no regressions on post pages:
![image](https://user-images.githubusercontent.com/128739/151649899-b58656ec-f6e8-468f-8408-38f34781c1ae.png)

![image](https://user-images.githubusercontent.com/128739/151650040-34669d6e-a1da-4551-b0d5-812ed7681b9a.png)

