### PR TITLE
Fix empty url params

### DIFF
--- a/ui/page/show/view.jsx
+++ b/ui/page/show/view.jsx
@@ -63,7 +63,7 @@ function ShowPage(props: Props) {
     doAnalyticsView,
   } = props;
 
-  const { search } = location;
+  const { search, pathname } = location;
 
   const signingChannel = claim && claim.signing_channel;
   const canonicalUrl = claim && claim.canonical_url;
@@ -91,7 +91,8 @@ function ShowPage(props: Props) {
       // Only redirect if we are in lbry.tv land
       // replaceState will fail if on a different domain (like webcache.googleusercontent.com)
       const hostname = isDev ? 'localhost' : DOMAIN;
-      if (canonicalUrlPath !== window.location.pathname && hostname === window.location.hostname) {
+
+      if (canonicalUrlPath !== pathname && hostname === window.location.hostname) {
         const urlParams = new URLSearchParams(search);
         let replaceUrl = canonicalUrlPath;
         if (urlParams.get(COLLECTIONS_CONSTS.COLLECTION_ID)) {
@@ -100,6 +101,12 @@ function ShowPage(props: Props) {
           replaceUrl += `?${urlParams.toString()}`;
         }
         history.replaceState(history.state, '', replaceUrl);
+      }
+
+      const windowHref = window.location.href;
+      const noUrlParams = search.length === 0;
+      if (windowHref.includes('?') && noUrlParams) {
+        history.replaceState(history.state, '', windowHref.substring(0, windowHref.length - 1));
       }
     }
     // @endif

--- a/web/src/oEmbed.js
+++ b/web/src/oEmbed.js
@@ -121,7 +121,7 @@ async function getOEmbed(ctx) {
 
   const decodedQueryUri = decodeURIComponent(urlQuery);
   const hasUrlParams = RegExp(/[?&]\w=/).test(decodedQueryUri);
-  const claimUrl = hasUrlParams ? decodedQueryUri.substring(0, decodedQueryUri.search(/[?&]\w=/)) : decodedQueryUri;
+  const claimUrl = hasUrlParams ? decodedQueryUri.substring(0, decodedQueryUri.search(/[?&](?:\w=)?/)) : decodedQueryUri;
 
   const { claim, error } = await getClaim(claimUrl);
 


### PR DESCRIPTION
## Fixes

Issue Number: n/a

I don't know how so many people get urls ending with a lone `?` (found on reddit newest posts: https://www.reddit.com/search/?q=site%3Aodysee.com&sort=new) so this change should both 1) avoid having a persistent question mark at the end of urls in case there is no params being passed 2) fix regex so the embed can get the proper claimUrl