### PR TITLE
fix RESOLVE_URIS_COMPLETED, to have one large action instead of hundr…

### DIFF
--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -313,58 +313,58 @@ export const doFetchItemsInCollections = (
 
   const resolveReposts = true;
 
-  if (collectionItemsById[0].items) {
-    collectionItemsById[0].items
-      .map((e) => ({ [e.canonical_url]: e }))
-      .forEach((result) => {
-        const fallbackResolveInfo = {
-          stream: null,
-          claimsInChannel: null,
-          channel: null,
-        };
-
-        function processResult(result, resolveInfo = {}, checkReposts = false) {
-          Object.entries(result).forEach(([uri, uriResolveInfo]) => {
-            // Flow has terrible Object.entries support
-            // https://github.com/facebook/flow/issues/2221
-            if (uriResolveInfo) {
-              if (uriResolveInfo.error) {
-                // $FlowFixMe
-                resolveInfo[uri] = { ...fallbackResolveInfo };
-              } else {
-                let result = {};
-                if (uriResolveInfo.value_type === 'channel') {
-                  result.channel = uriResolveInfo;
-                  // $FlowFixMe
-                  result.claimsInChannel = uriResolveInfo.meta.claims_in_channel;
-                } else if (uriResolveInfo.value_type === 'collection') {
-                  result.collection = uriResolveInfo;
-                  // $FlowFixMe
-                } else {
-                  result.stream = uriResolveInfo;
-                  if (uriResolveInfo.signing_channel) {
-                    result.channel = uriResolveInfo.signing_channel;
-                    result.claimsInChannel =
-                      (uriResolveInfo.signing_channel.meta && uriResolveInfo.signing_channel.meta.claims_in_channel) ||
-                      0;
-                  }
-                }
-                // $FlowFixMe
-                resolveInfo[uri] = result;
-              }
-            }
-          });
-        }
-
+  collectionItemsById.forEach((collection) => {
+    // GenericClaim type probably needs to be updated to avoid this "Any"
+    collection.items &&
+      collection.items.forEach((result: any) => {
+        result = { [result.canonical_url]: result };
         processResult(result, resolveInfo, resolveReposts);
       });
+  });
 
-    dispatch({
-      type: ACTIONS.RESOLVE_URIS_COMPLETED,
-      data: { resolveInfo },
-    });
-  }
+  dispatch({
+    type: ACTIONS.RESOLVE_URIS_COMPLETED,
+    data: { resolveInfo },
+  });
 };
+
+function processResult(result, resolveInfo = {}, checkReposts = false) {
+  const fallbackResolveInfo = {
+    stream: null,
+    claimsInChannel: null,
+    channel: null,
+  };
+
+  Object.entries(result).forEach(([uri, uriResolveInfo]) => {
+    // Flow has terrible Object.entries support
+    // https://github.com/facebook/flow/issues/2221
+    if (uriResolveInfo) {
+      if (uriResolveInfo.error) {
+        // $FlowFixMe
+        resolveInfo[uri] = { ...fallbackResolveInfo };
+      } else {
+        let result = {};
+        if (uriResolveInfo.value_type === 'channel') {
+          result.channel = uriResolveInfo;
+          // $FlowFixMe
+          result.claimsInChannel = uriResolveInfo.meta.claims_in_channel;
+        } else if (uriResolveInfo.value_type === 'collection') {
+          result.collection = uriResolveInfo;
+          // $FlowFixMe
+        } else {
+          result.stream = uriResolveInfo;
+          if (uriResolveInfo.signing_channel) {
+            result.channel = uriResolveInfo.signing_channel;
+            result.claimsInChannel =
+              (uriResolveInfo.signing_channel.meta && uriResolveInfo.signing_channel.meta.claims_in_channel) || 0;
+          }
+        }
+        // $FlowFixMe
+        resolveInfo[uri] = result;
+      }
+    }
+  });
+}
 
 export const doFetchItemsInCollection = (options: { collectionId: string, pageSize?: number }, cb?: () => void) => {
   const { collectionId, pageSize } = options;

--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -289,19 +289,6 @@ export const doFetchItemsInCollections = (
   });
   const formattedClaimsByUri = formatForClaimActions(collectionItemsById);
 
-  dispatch({
-    type: ACTIONS.RESOLVE_URIS_COMPLETED,
-    data: { resolveInfo: formattedClaimsByUri },
-  });
-
-  dispatch({
-    type: ACTIONS.COLLECTION_ITEMS_RESOLVE_COMPLETED,
-    data: {
-      resolvedCollections: newCollectionObjectsById,
-      failedCollectionIds: invalidCollectionIds,
-    },
-  });
-
   const resolveInfo: {
     [string]: {
       stream: ?StreamClaim,
@@ -324,7 +311,20 @@ export const doFetchItemsInCollections = (
 
   dispatch({
     type: ACTIONS.RESOLVE_URIS_COMPLETED,
+    data: { resolveInfo: formattedClaimsByUri },
+  });
+
+  dispatch({
+    type: ACTIONS.RESOLVE_URIS_COMPLETED,
     data: { resolveInfo },
+  });
+
+  dispatch({
+    type: ACTIONS.COLLECTION_ITEMS_RESOLVE_COMPLETED,
+    data: {
+      resolvedCollections: newCollectionObjectsById,
+      failedCollectionIds: invalidCollectionIds,
+    },
   });
 };
 


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/OdyseeTeam/odysee-frontend/issues/727

## What is the current behavior?

On http://localhost:9090/$/list/d91815c1bc8c80a1f354284a8c8e92d84d5f07a6 5x claim_search and 193x resolve requests are made.

## What is the new behavior?

On http://localhost:9090/$/list/d91815c1bc8c80a1f354284a8c8e92d84d5f07a6 5x claim_search requests are made.

## Other information

Nothing crashes as far as I've tested but probably needs a review by someone who knows whats what. 

I didn't write much of this it was basically taken from `ui/redux/actions/claims.js` and I made sure that the data mapping made sense in redux.


## PR Checklist

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change (Could be wrong though)
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

