### PR TITLE
Patch to restore position upon returning to video until more fully fleshed out fix can be introduced

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -32,6 +32,7 @@ export type Player = {
   chromecast: (any) => void,
   currentTime: (?number) => number,
   dispose: () => void,
+  duration: () => number,
   ended: () => boolean,
   error: () => any,
   exitFullscreen: () => boolean,
@@ -292,7 +293,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
   /** instantiate videoJS and dispose of it when done with code **/
   // This lifecycle hook is only called once (on mount), or when `isAudio` or `source` changes.
   useEffect(() => {
-    (async function() {
+    (async function () {
       // test if perms to play video are available
       let canAutoplayVideo = await canAutoplay.video({ timeout: 2000, inline: true });
 
@@ -351,7 +352,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
           const adsClaimParentDiv = adsClaimDiv.parentNode;
 
           // watch parent div for when it is on viewport
-          const observer = new IntersectionObserver(function(entries) {
+          const observer = new IntersectionObserver(function (entries) {
             // when ad div parent becomes visible by 1px, show the ad video
             if (entries[0].isIntersecting === true) {
               adsClaimDiv.style.display = 'block';

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -267,9 +267,9 @@ function VideoViewer(props: Props) {
     handlePosition(player);
     analytics.videoIsPlaying(false, player);
 
-    const almostFinsished = player.currentTime() / player.duration() >= VIDEO_ALMOST_FINISHED_THRESHOLD;
+    const almostFinisished = player.currentTime() / player.duration() >= VIDEO_ALMOST_FINISHED_THRESHOLD;
 
-    if (player.ended() || almostFinsished) {
+    if (player.ended() || almostFinisished) {
       clearPosition(permanentUrl);
     }
   }

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -2,6 +2,7 @@
 import { ENABLE_PREROLL_ADS } from 'config';
 import * as PAGES from 'constants/pages';
 import * as ICONS from 'constants/icons';
+import { VIDEO_ALMOST_FINISHED_THRESHOLD } from 'constants/pages';
 import React, { useEffect, useState, useContext, useCallback } from 'react';
 import { stopContextMenu } from 'util/context-menu';
 import type { Player } from './internal/videojs';
@@ -265,6 +266,12 @@ function VideoViewer(props: Props) {
   function onDispose(event, player) {
     handlePosition(player);
     analytics.videoIsPlaying(false, player);
+
+    const almostFinsished = player.currentTime() / player.duration() >= VIDEO_ALMOST_FINISHED_THRESHOLD;
+
+    if (player.ended() || almostFinsished) {
+      clearPosition(permanentUrl);
+    }
   }
 
   function handlePosition(player) {

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -1,8 +1,8 @@
 // @flow
 import { ENABLE_PREROLL_ADS } from 'config';
 import * as PAGES from 'constants/pages';
+import { VIDEO_ALMOST_FINISHED_THRESHOLD } from 'constants/player';
 import * as ICONS from 'constants/icons';
-import { VIDEO_ALMOST_FINISHED_THRESHOLD } from 'constants/pages';
 import React, { useEffect, useState, useContext, useCallback } from 'react';
 import { stopContextMenu } from 'util/context-menu';
 import type { Player } from './internal/videojs';

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -267,9 +267,9 @@ function VideoViewer(props: Props) {
     handlePosition(player);
     analytics.videoIsPlaying(false, player);
 
-    const almostFinisished = player.currentTime() / player.duration() >= VIDEO_ALMOST_FINISHED_THRESHOLD;
+    const almostFinished = player.currentTime() / player.duration() >= VIDEO_ALMOST_FINISHED_THRESHOLD;
 
-    if (player.ended() || almostFinisished) {
+    if (player.ended() || almostFinished) {
       clearPosition(permanentUrl);
     }
   }

--- a/ui/constants/pages.js
+++ b/ui/constants/pages.js
@@ -86,3 +86,4 @@ exports.LIVESTREAM_CURRENT = 'live';
 exports.GENERAL = 'general';
 exports.LIST = 'list';
 exports.POPOUT = 'popout';
+exports.VIDEO_ALMOST_FINISHED_THRESHOLD = 0.8;

--- a/ui/constants/pages.js
+++ b/ui/constants/pages.js
@@ -86,4 +86,3 @@ exports.LIVESTREAM_CURRENT = 'live';
 exports.GENERAL = 'general';
 exports.LIST = 'list';
 exports.POPOUT = 'popout';
-exports.VIDEO_ALMOST_FINISHED_THRESHOLD = 0.8;

--- a/ui/constants/player.js
+++ b/ui/constants/player.js
@@ -1,0 +1,1 @@
+export const VIDEO_ALMOST_FINISHED_THRESHOLD = 0.8;

--- a/ui/page/file/view.jsx
+++ b/ui/page/file/view.jsx
@@ -1,5 +1,6 @@
 // @flow
 import * as PAGES from 'constants/pages';
+import { VIDEO_ALMOST_FINISHED_THRESHOLD } from 'constants/player';
 import * as React from 'react';
 import classnames from 'classnames';
 import { lazyImport } from 'util/lazyImport';
@@ -72,7 +73,7 @@ function FilePage(props: Props) {
     const durationInSecs =
       fileInfo && fileInfo.metadata && fileInfo.metadata.video ? fileInfo.metadata.video.duration : 0;
     const isVideoTooShort = durationInSecs <= 45;
-    const almostFinishedPlaying = position / durationInSecs >= PAGES.VIDEO_ALMOST_FINISHED_THRESHOLD;
+    const almostFinishedPlaying = position / durationInSecs >= VIDEO_ALMOST_FINISHED_THRESHOLD;
 
     return durationInSecs ? isVideoTooShort || almostFinishedPlaying : false;
   }, [fileInfo, position]);

--- a/ui/page/file/view.jsx
+++ b/ui/page/file/view.jsx
@@ -72,9 +72,9 @@ function FilePage(props: Props) {
     const durationInSecs =
       fileInfo && fileInfo.metadata && fileInfo.metadata.video ? fileInfo.metadata.video.duration : 0;
     const isVideoTooShort = durationInSecs <= 45;
-    const almostFinishedPlaying = position / durationInSecs >= 0.8;
+    const almostFinishedPlaying = position / durationInSecs >= PAGES.VIDEO_ALMOST_FINISHED_THRESHOLD;
 
-    return isVideoTooShort || almostFinishedPlaying;
+    return durationInSecs ? isVideoTooShort || almostFinishedPlaying : false;
   }, [fileInfo, position]);
 
   React.useEffect(() => {

--- a/ui/redux/actions/content.js
+++ b/ui/redux/actions/content.js
@@ -229,14 +229,14 @@ export function savePosition(uri: string, position: number) {
           position,
         })
       );
-
-      dispatch({
-        type: ACTIONS.SET_CONTENT_POSITION,
-        data: { claimId, outpoint, position },
-      });
     } catch (e) {
       console.error('localStorage not available');
     }
+
+    dispatch({
+      type: ACTIONS.SET_CONTENT_POSITION,
+      data: { claimId, outpoint, position },
+    });
   };
 }
 

--- a/ui/redux/actions/content.js
+++ b/ui/redux/actions/content.js
@@ -220,19 +220,23 @@ export function savePosition(uri: string, position: number) {
     const { claim_id: claimId, txid, nout } = claim;
     const outpoint = `${txid}:${nout}`;
 
-    localStorage.setItem(
-      ACTIONS.SET_CONTENT_POSITION,
-      JSON.stringify({
-        claimId,
-        outpoint,
-        position,
-      })
-    );
+    try {
+      localStorage.setItem(
+        ACTIONS.SET_CONTENT_POSITION,
+        JSON.stringify({
+          claimId,
+          outpoint,
+          position,
+        })
+      );
 
-    dispatch({
-      type: ACTIONS.SET_CONTENT_POSITION,
-      data: { claimId, outpoint, position },
-    });
+      dispatch({
+        type: ACTIONS.SET_CONTENT_POSITION,
+        data: { claimId, outpoint, position },
+      });
+    } catch (e) {
+      console.error('localStorage not available');
+    }
   };
 }
 

--- a/ui/redux/actions/content.js
+++ b/ui/redux/actions/content.js
@@ -220,6 +220,15 @@ export function savePosition(uri: string, position: number) {
     const { claim_id: claimId, txid, nout } = claim;
     const outpoint = `${txid}:${nout}`;
 
+    localStorage.setItem(
+      ACTIONS.SET_CONTENT_POSITION,
+      JSON.stringify({
+        claimId,
+        outpoint,
+        position,
+      })
+    );
+
     dispatch({
       type: ACTIONS.SET_CONTENT_POSITION,
       data: { claimId, outpoint, position },

--- a/ui/store.js
+++ b/ui/store.js
@@ -230,4 +230,13 @@ const store = createStore(
 const persistor = persistStore(store);
 window.persistor = persistor;
 
+window.addEventListener('storage', (e) => {
+  if (e.key === ACTIONS.SET_CONTENT_POSITION) {
+    store.dispatch({
+      type: ACTIONS.SET_CONTENT_POSITION,
+      data: JSON.parse(e.newValue),
+    });
+  }
+});
+
 export { store, persistor, history, whiteListedReducers };


### PR DESCRIPTION
"Fixes" https://github.com/OdyseeTeam/odysee-frontend/issues/20

@infinite-persistence, I'm not certain if this interfere's with what you might have in flight on this ticket, but this will patch two of the three issues until the api issue can be resolved.  Essentially, it just assumes that if there's a time stored, but there is no length known, then it assumes the stored time is correct.  Also, on dispose, if it's almost done, we'll just clear the saved time.

Of the three bugs noted, this won't address the cross-tab issue.