### PR TITLE
Fix autoplay next

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -134,6 +134,16 @@ function VideoViewer(props: Props) {
   breaks because some browsers (e.g. Firefox) block autoplay but leave the player.play Promise pending */
   const [replay, setReplay] = useState(false);
   const [videoNode, setVideoNode] = useState();
+  const [localAutoplayNext, setLocalAutoplayNext] = useState(autoplayNext);
+  const isFirstRender = React.useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    toggleAutoplayNext();
+  }, [localAutoplayNext]);
 
   const updateVolumeState = React.useCallback(
     debounce((volume, muted) => {
@@ -318,7 +328,13 @@ function VideoViewer(props: Props) {
           addPlayNextButton(player, doPlayNext);
           addPlayPreviousButton(player, doPlayPrevious);
         } else {
-          addAutoplayNextButton(player, toggleAutoplayNext, autoplayNext);
+          addAutoplayNextButton(
+            player,
+            () => {
+              setLocalAutoplayNext((e) => !e);
+            },
+            autoplayNext
+          );
         }
       }
     }
@@ -457,7 +473,7 @@ function VideoViewer(props: Props) {
         startMuted={autoplayIfEmbedded}
         toggleVideoTheaterMode={toggleVideoTheaterMode}
         autoplay={!embedded || autoplayIfEmbedded}
-        autoplaySetting={autoplayNext}
+        autoplaySetting={localAutoplayNext}
         claimId={claimId}
         title={claim && ((claim.value && claim.value.title) || claim.name)}
         channelName={channelName}


### PR DESCRIPTION
## Fixes

Issue Number:https://github.com/OdyseeTeam/odysee-frontend/issues/776

## What is the current behavior?

click => dispatch => updateProps => render
this takes about 1000ms - 1500ms (Macbook pro 16 (2019), i7, 16gb, chrome 6x slowdown)

## What is the new behavior?

click => updateLocalState => render => dispatch => updateProps => render
this takes about 100ms - 300ms (Macbook pro 16 (2019), i7, 16gb, chrome 6x slowdown)

## Other information

This is following a design principal known as "optimistic UI" where you do an action later but show its optimistic response first, not the biggest fan but in situations like this it works in a pinch.

One improvement that I could recommend is what if dispatch fails then the toggle should go back to its original state, but I don't ever see that happening so I undid that part for now.     

## PR Checklist

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below
