### PR TITLE
Limit embed generation to just Audio and Video

### DIFF
--- a/ui/constants/file_render_modes.js
+++ b/ui/constants/file_render_modes.js
@@ -20,7 +20,7 @@ export const COMIC = 'comic';
 export const NON_STREAM_MODES = IS_WEB ? [CAD, COMIC] : [CAD, COMIC, ...TEXT_MODES];
 
 export const AUTO_RENDER_MODES = [IMAGE].concat(TEXT_MODES);
-export const WEB_SHAREABLE_MODES = AUTO_RENDER_MODES.concat(FLOATING_MODES);
+export const WEB_SHAREABLE_MODES = FLOATING_MODES;
 
 export const DOWNLOAD = 'download';
 export const APPLICATION = 'application';


### PR DESCRIPTION
## Ticket
Closes [#761 Should Posts have embed links](https://github.com/OdyseeTeam/odysee-frontend/issues/761)

The original code also supported text modes like PDF and also images, all of which looked really bad, so it's unlikely someone is utilizing it.

Disabling them until a designer can fix 'em.
