### PR TITLE
Move recsys endpoint to .env for easier debugging

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -15,6 +15,7 @@ COMMENT_SERVER_API=https://comments.odysee.com/api/v2
 SEARCH_SERVER_API_ALT=https://recsys.odysee.com/search
 SEARCH_SERVER_API=https://lighthouse.odysee.com/search
 SOCKETY_SERVER_API=wss://sockety.odysee.com/ws
+RECSYS_ENDPOINT=https://recsys.odysee.com/log/video/view
 THUMBNAIL_CDN_URL=https://thumbnails.odycdn.com/optimize/
 THUMBNAIL_CARDS_CDN_URL=https://cards.odycdn.com/
 THUMBNAIL_HEIGHT=220

--- a/config.js
+++ b/config.js
@@ -20,6 +20,7 @@ const config = {
   DOMAIN: process.env.DOMAIN,
   SHARE_DOMAIN_URL: process.env.SHARE_DOMAIN_URL,
   URL: process.env.URL,
+  RECSYS_ENDPOINT: process.env.RECSYS_ENDPOINT,
   THUMBNAIL_CDN_URL: process.env.THUMBNAIL_CDN_URL,
   THUMBNAIL_CARDS_CDN_URL: process.env.THUMBNAIL_CARDS_CDN_URL,
   THUMBNAIL_HEIGHT: process.env.THUMBNAIL_HEIGHT,

--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -1,3 +1,4 @@
+import { RECSYS_ENDPOINT } from 'config';
 import { selectUser } from 'redux/selectors/user';
 import { makeSelectRecommendedRecsysIdForClaimId } from 'redux/selectors/search';
 import { v4 as Uuidv4 } from 'uuid';
@@ -8,7 +9,7 @@ import { selectPlayingUri, selectPrimaryUri } from 'redux/selectors/content';
 import { selectClientSetting, selectDaemonSettings } from 'redux/selectors/settings';
 import { history } from 'ui/store';
 
-const recsysEndpoint = 'https://recsys.odysee.com/log/video/view';
+const recsysEndpoint = RECSYS_ENDPOINT;
 const recsysId = 'lighthouse-v0';
 
 const getClaimIdsFromUris = (uris) => {


### PR DESCRIPTION
Easier to point to a localhost server to capture the beacons for debugging.
