### PR TITLE
Unscape uri before Claim resolve

### DIFF
--- a/ui/util/web.js
+++ b/ui/util/web.js
@@ -79,6 +79,17 @@ function escapeHtmlProperty(property) {
     : '';
 }
 
+function unscapeHtmlProperty(property) {
+  return property
+    ? String(property)
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#039;/g, "'")
+    : '';
+}
+
 // module.exports needed since the web server imports this function
 module.exports = {
   CONTINENT_COOKIE,
@@ -91,4 +102,5 @@ module.exports = {
   getParameterByName,
   getThumbnailCdnUrl,
   escapeHtmlProperty,
+  unscapeHtmlProperty,
 };

--- a/web/src/html.js
+++ b/web/src/html.js
@@ -19,6 +19,7 @@ const {
   getParameterByName,
   getThumbnailCdnUrl,
   escapeHtmlProperty,
+  unscapeHtmlProperty,
 } = require('../../ui/util/web');
 const { getJsBundleId } = require('../bundle-id.js');
 const { lbryProxy: Lbry } = require('../lbry');
@@ -307,7 +308,7 @@ async function getHtml(ctx) {
     ctx.request.url = encodeURIComponent(escapeHtmlProperty(decodeURIComponent(ctx.request.url)));
   }
 
-  const requestPath = decodeURIComponent(ctx.path);
+  const requestPath = unscapeHtmlProperty(decodeURIComponent(ctx.path));
   if (requestPath.length === 0) {
     const ogMetadata = buildBasicOgMetadata();
     return insertToHead(html, ogMetadata);


### PR DESCRIPTION
## Fixes

Issue Number: closes #828

working here: https://salt.odysee.com/@MasoniteShadow:9/odysee!-what-has-changed-and-why-i'm:4

simply reversed the `escapeHtmlProperty` into a new `unscapeHtmlProperty` and even if some characters are invalid for claim uris, the app should return the appropriate response then. Should be fine here since `requestPath` is used for resolve and nothing else is replaced? still needs review