### PR TITLE
Fix broken resolves due to escaped characters

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -304,14 +304,14 @@ async function getHtml(ctx) {
     html = fs.readFileSync(path.join(__dirname, '/../dist/index.html'), 'utf8');
   }
 
-  if (ctx?.request?.url) {
-    ctx.request.url = encodeURIComponent(escapeHtmlProperty(decodeURIComponent(ctx.request.url)));
-  }
-
   const requestPath = unscapeHtmlProperty(decodeURIComponent(ctx.path));
   if (requestPath.length === 0) {
     const ogMetadata = buildBasicOgMetadata();
     return insertToHead(html, ogMetadata);
+  }
+
+  if (ctx?.request?.url) {
+    ctx.request.url = encodeURIComponent(escapeHtmlProperty(decodeURIComponent(ctx.request.url)));
   }
 
   const invitePath = `/$/${PAGES.INVITE}/`;


### PR DESCRIPTION
## Issue
`/$/embed/尾崎豊--－-大阪球場ライブ%E3%80%801_6/bfd63daa9453bb1a11674ca8a7c5f5dd6b49d024?r=2ituZftpdG18f1TBADDbCaaEZ9ecYYYm` wasn't working

## Change
Probably need to revisit this properly, but for now, grab the `requestPath` that's needed for resolving before escaping the characters.

Tested that `http://localhost:1337/$/search?q=%22\/%3E%3Cimg%20s+src+c=x%20on+onerror+%20=alert(1)+\%3E` would still be blocked.
