### PR TITLE
Fix css specificity issue on skip-button.

### DIFF
--- a/ui/scss/component/_header.scss
+++ b/ui/scss/component/_header.scss
@@ -14,7 +14,7 @@
   -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
 
-  .skip-button {
+  button.skip-button {
     opacity: 0;
     position: absolute;
     top: 0;


### PR DESCRIPTION
When attempting to open the navigation on mobile, I often end up revealing the hidden "skip navigation" accessibility button.

![image](https://user-images.githubusercontent.com/128739/153793786-3d298e80-3a9e-4a3f-9725-1cf147e4b4f5.png)

This is due to a CSS specificity issue with the new theme.  This PR increases the rule specificity to address the issue.

Before
![image](https://user-images.githubusercontent.com/128739/153793595-b892cc87-ed90-431a-a54f-f15a9a1fbac7.png)

After
![image](https://user-images.githubusercontent.com/128739/153793544-3e43beb3-ed28-40d5-bd79-b87bf16833f0.png)
