### PR TITLE
Comments: inline image not working for level4/5 channels

### DIFF
--- a/ui/component/comment/index.js
+++ b/ui/component/comment/index.js
@@ -22,7 +22,7 @@ import Comment from './view';
 
 const select = (state, props) => {
   const { comment, uri } = props;
-  const { comment_id, author_uri } = comment || {};
+  const { comment_id, channel_url } = comment || {};
 
   const activeChannelClaim = selectActiveChannelClaim(state);
   const activeChannelId = activeChannelClaim && activeChannelClaim.claim_id;
@@ -31,14 +31,14 @@ const select = (state, props) => {
   return {
     myChannelIds: selectMyClaimIdsRaw(state),
     claim: makeSelectClaimForUri(uri)(state),
-    thumbnail: author_uri && selectThumbnailForUri(state, author_uri),
-    channelIsBlocked: author_uri && makeSelectChannelIsMuted(author_uri)(state),
+    thumbnail: channel_url && selectThumbnailForUri(state, channel_url),
+    channelIsBlocked: channel_url && makeSelectChannelIsMuted(channel_url)(state),
     commentingEnabled: IS_WEB ? Boolean(selectUserVerifiedEmail(state)) : true,
     othersReacts: selectOthersReactsForComment(state, reactionKey),
     activeChannelClaim,
     hasChannels: selectHasChannels(state),
     playingUri: selectPlayingUri(state),
-    stakedLevel: selectStakedLevelForChannelUri(state, author_uri),
+    stakedLevel: selectStakedLevelForChannelUri(state, channel_url),
     linkedCommentAncestors: selectLinkedCommentAncestors(state),
     totalReplyPages: makeSelectTotalReplyPagesForParentId(comment_id)(state),
   };


### PR DESCRIPTION
## Ticket
Closes [#852 Markdown inline images in comments don't work for any channel level](https://github.com/OdyseeTeam/odysee-frontend/issues/852)

## Change
The prior commit simplified the props from individual comment fields to just 1 `Comment` object, but there was a typo in the parameter where it should be `channel_url` instead of `author_uri`.
