### PR TITLE
tus: log reason for QuotaExceededError

### DIFF
--- a/web/setup/publish-v2.js
+++ b/web/setup/publish-v2.js
@@ -83,6 +83,17 @@ export function makeResumableUploadRequest(
           customErr = 'File is locked. Try resuming after waiting a few minutes';
         }
 
+        let localStorageInfo;
+        if (errMsg.includes('QuotaExceededError')) {
+          try {
+            localStorageInfo = `${window.localStorage.length} items; ${
+              JSON.stringify(window.localStorage).length
+            } bytes`;
+          } catch (e) {
+            localStorageInfo = 'inaccessible';
+          }
+        }
+
         window.store.dispatch(doUpdateUploadProgress({ guid, status: 'error' }));
 
         analytics.sentryError('tus-upload', err);
@@ -97,6 +108,7 @@ export function makeResumableUploadRequest(
               ...(uploader._retryAttempt ? { retryAttempt: uploader._retryAttempt } : {}),
               ...(uploader._offsetBeforeRetry ? { offsetBeforeRetry: uploader._offsetBeforeRetry } : {}),
               ...(customErr ? { original: errMsg } : {}),
+              ...(localStorageInfo ? { localStorageInfo } : {}),
             },
           })
         );


### PR DESCRIPTION
We no longer ask tus to save the upload URL since December, so there should no reason for it to be writing to localStorage.

Adding more logs to determine what is the actual cause -- localStorage being full, or not available. Neither should affect the upload but they are the only known causes for that error message, so try to narrow down the investigation path.
