### PR TITLE
Fix livestream date incorrect if short url is used

### DIFF
--- a/ui/component/livestreamDateTime/index.js
+++ b/ui/component/livestreamDateTime/index.js
@@ -1,13 +1,13 @@
 import { connect } from 'react-redux';
 import { makeSelectClaimForUri } from 'redux/selectors/claims';
+import { selectActiveLivestreamForClaimId } from 'redux/selectors/livestream';
 import LivestreamDateTime from './view';
-import { selectActiveLivestreamForUri } from 'redux/selectors/livestream';
 
 const select = (state, props) => {
   const claim = props.uri && makeSelectClaimForUri(props.uri)(state);
   return {
     claim,
-    activeLivestream: selectActiveLivestreamForUri(state, props.uri),
+    activeLivestream: selectActiveLivestreamForClaimId(state, claim?.claim_id),
   };
 };
 

--- a/ui/redux/selectors/livestream.js
+++ b/ui/redux/selectors/livestream.js
@@ -62,19 +62,19 @@ export const selectIsActiveLivestreamForUri = createCachedSelector(
   }
 )((state, uri) => String(uri));
 
-export const selectActiveLivestreamForUri = createCachedSelector(
-  (state, uri) => uri,
+export const selectActiveLivestreamForClaimId = createCachedSelector(
+  (state, claimId) => claimId,
   selectActiveLivestreams,
-  (uri, activeLivestreams) => {
-    if (!uri || !activeLivestreams) {
+  (claimId, activeLivestreams) => {
+    if (!claimId || !activeLivestreams) {
       return null;
     }
 
     const activeLivestreamValues = Object.values(activeLivestreams);
-    // $FlowFixMe - unable to resolve claimUri
-    return activeLivestreamValues.find((v) => v.claimUri === uri) || null;
+    // $FlowFixMe - https://github.com/facebook/flow/issues/2221
+    return activeLivestreamValues.find((v) => v.claimId === claimId) || null;
   }
-)((state, uri) => String(uri));
+)((state, claimId) => String(claimId));
 
 export const selectActiveLivestreamForChannel = createCachedSelector(
   (state, channelId) => channelId,


### PR DESCRIPTION
## Issue
- "https://odysee.com/LIVE:6dd" yields "Live 3 months ago" (incorrect)
- "https://odysee.com/@RekietaLaw:a/LIVE:6dd" yields "Live 30 minutes ago" (correct)

## Approach
Use claim ID instead of uri when searching `activeLivestreams`
