### PR TITLE
Fix video thumbnail selector exceeding the modal size

### DIFF
--- a/ui/modal/modalAutoGenerateThumbnail/view.jsx
+++ b/ui/modal/modalAutoGenerateThumbnail/view.jsx
@@ -87,7 +87,14 @@ function ModalAutoGenerateThumbnail(props: Props) {
       onAborted={closeModal}
     >
       <p className="section__subtitle">{__('Pause at any time to select a thumbnail from your video')}.</p>
-      <video ref={playerRef} src={videoSrc} onLoadedMetadata={resize} onError={onError} controls />
+      <video
+        className="video-thumbnail-generator"
+        ref={playerRef}
+        src={videoSrc}
+        onLoadedMetadata={resize}
+        onError={onError}
+        controls
+      />
     </Modal>
   );
 }

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -861,6 +861,11 @@ $control-bar-icon-size: 0.8rem;
   display: none !important; // yes this is dumb, but this was broken and the above CSS was overriding
 }
 
+.video-thumbnail-generator {
+  width: 100%;
+  max-height: 30vh;
+}
+
 // ****************************************************************************
 // Autoplay Countdown
 // ****************************************************************************


### PR DESCRIPTION
## Issue
- Closes #655 
- It also exceeds horizontally on mobile.

## Fix
Just add css constraints.
