### PR TITLE
Fix/use has window width changed enough

### DIFF
--- a/ui/effects/use-screensize.js
+++ b/ui/effects/use-screensize.js
@@ -31,7 +31,7 @@ function useHasWindowWidthChangedEnough(comparisonFn: (windowSize: number) => bo
   React.useEffect(() => {
     function setSize() {
       const curr = comparisonFn(window.innerWidth);
-      if (prev !== curr) {
+      if (prev.current !== curr) {
         setWindowSize(curr);
         prev.current = curr;
       }

--- a/ui/effects/use-screensize.js
+++ b/ui/effects/use-screensize.js
@@ -24,9 +24,9 @@ export function useWindowSize() {
 
 function useHasWindowWidthChangedEnough(comparisonFn: (windowSize: number) => boolean) {
   const isWindowClient = typeof window === 'object';
-  const initialState = isWindowClient ? comparisonFn(window.innerWidth) : comparisonFn(DEFAULT_SCREEN_SIZE);
-  const [windowSize, setWindowSize] = React.useState(initialState);
-  const prev = useRef(window.innerWidth);
+  const initialState: boolean = isWindowClient ? comparisonFn(window.innerWidth) : comparisonFn(DEFAULT_SCREEN_SIZE);
+  const [windowSize, setWindowSize] = React.useState<boolean>(initialState);
+  const prev = useRef<boolean>(initialState);
 
   React.useEffect(() => {
     function setSize() {


### PR DESCRIPTION
## Fixes

Issue Number: N/A

## What is the current behavior?

useHasWindowWidthChangedEnough renders every time as object and boolean have no overlap.

## What is the new behavior?

useHasWindowWidthChangedEnough does not render every time

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below
