### PR TITLE
Fix missing homepage placeholder while waiting for livestream data

### DIFF
--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -185,13 +185,13 @@ function HomePage(props: Props) {
           {authenticated && hasScheduledStreams && !hideScheduledLivestreams && (
             <SectionHeader title={__('Following')} navigate={`/$/${PAGES.CHANNELS_FOLLOWING}`} icon={ICONS.SUBSCRIBE} />
           )}
-
-          {rowData.map(({ title, route, link, icon, help, pinnedUrls: pinUrls, options = {} }, index) => {
-            // add pins here
-            return getRowElements(title, route, link, icon, help, options, index, pinUrls);
-          })}
         </>
       )}
+
+      {rowData.map(({ title, route, link, icon, help, pinnedUrls: pinUrls, options = {} }, index) => {
+        // add pins here
+        return getRowElements(title, route, link, icon, help, options, index, pinUrls);
+      })}
     </Page>
   );
 }


### PR DESCRIPTION
## Issue
When loading the homepage, I kept seeing a blank page with footer for a while. Even Google pageSpeed has picked that up:

<img width="881" alt="image" src="https://user-images.githubusercontent.com/64950861/154492295-3832ef36-d452-4e53-a07f-d9869e80b874.png">

## Ticket
Closes #572 Slow appearance of tiles

## Notes
The tiles were originally delayed to prevent the "Upcoming Livestream" section from causing layout shifts.

With the new theme, the footer would cause a visible shift anyway.  Hiding the footer is one solution, but I think not showing anything until the fetch is done is bad because the livestream fetch could stall.

Also, even with the delay, there is some visible shift anyways as shown in the second video:

https://user-images.githubusercontent.com/64950861/154492452-a2336650-d494-4e44-918a-d5ec23c3776c.mp4

https://user-images.githubusercontent.com/64950861/154492464-97edf3ef-b926-4364-a3f6-0e00b5e32dfb.mp4

## Known issues
There is a double-render of the livestream section, but it's irrelevant to this change, and there is a separate issue for it.

