### PR TITLE
Band-aid: warn about AdGuard blocking our CDN

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1294,6 +1294,7 @@
   "Are you sure you want to purchase %claim_title%?": "Are you sure you want to purchase %claim_title%?",
   "Discover": "Discover",
   "Thumbnail upload service may be down, try again later.": "Thumbnail upload service may be down, try again later.",
+  "Thumbnail upload service may be down, try again later. Some plugins like AdGuard Français may be blocking the service.": "Thumbnail upload service may be down, try again later. Some plugins like AdGuard Français may be blocking the service.",
   "You are currently editing your upload.": "You are currently editing your upload.",
   "You are currently editing this claim.": "You are currently editing this claim.",
   "My content for this post...": "My content for this post...",

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1294,7 +1294,7 @@
   "Are you sure you want to purchase %claim_title%?": "Are you sure you want to purchase %claim_title%?",
   "Discover": "Discover",
   "Thumbnail upload service may be down, try again later.": "Thumbnail upload service may be down, try again later.",
-  "Thumbnail upload service may be down, try again later. Some plugins like AdGuard Français may be blocking the service.": "Thumbnail upload service may be down, try again later. Some plugins like AdGuard Français may be blocking the service.",
+  "Thumbnail upload service may be down, try again later. Some plugins like AdGuard Français may be blocking the service. If using Brave, go to brave://adblock and disable it, or turn down shields.": "Thumbnail upload service may be down, try again later. Some plugins like AdGuard Français may be blocking the service. If using Brave, go to brave://adblock and disable it, or turn down shields.",
   "You are currently editing your upload.": "You are currently editing your upload.",
   "You are currently editing this claim.": "You are currently editing this claim.",
   "My content for this post...": "My content for this post...",

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -473,7 +473,10 @@ export const doUploadThumbnail = (
 
         // This sucks but ¯\_(ツ)_/¯
         if (message === 'Failed to fetch') {
-          message = __('Thumbnail upload service may be down, try again later.');
+          // message = __('Thumbnail upload service may be down, try again later.');
+          message = __(
+            'Thumbnail upload service may be down, try again later. Some plugins like AdGuard Français may be blocking the service.'
+          );
         }
 
         const userInput = [fileName, fileExt, fileType, thumbnail, size];

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -475,7 +475,7 @@ export const doUploadThumbnail = (
         if (message === 'Failed to fetch') {
           // message = __('Thumbnail upload service may be down, try again later.');
           message = __(
-            'Thumbnail upload service may be down, try again later. Some plugins like AdGuard Français may be blocking the service.'
+            'Thumbnail upload service may be down, try again later. Some plugins like AdGuard Français may be blocking the service. If using Brave, go to brave://adblock and disable it, or turn down shields.'
           );
         }
 


### PR DESCRIPTION
<sub>Related: #889</sub>

> _I think a big part of the problem is a brave / adblock list that we turned up on. Maybe if we get the failed to fetch, we can mention to try disabling that. It's called "AdGuard Français" , and on Brave, it's on: brave://adblock/_
> _This also prevents thumbs from loading...not sure how we can poke for that..._

Getting 50-100 errors per day, mostly in French. This will be a band-aid until the AdGuard fixes it.  
Not the best solution since it singles out a product (right thing to do?)

Attempted/discarded solutions:
1. Check if all tiles are blank and then only warn the user
    - Unfortunately, we are using a `div` rather than `img`, which doesn't have an `onError` to detect it.  Don't feel like adding bloat to `ClaimPreviewTile`
2. Try to detect `ERR_NET_BLOCKED_BY_CLIENT` to differentiate between server down and blocked by browser
    - Seems like there is no way to get that info from the browser, so no luck there.
