### PR TITLE
Ignore "search in language" setting in Channel Page

### DIFF
--- a/ui/component/channelContent/view.jsx
+++ b/ui/component/channelContent/view.jsx
@@ -179,6 +179,7 @@ function ChannelContent(props: Props) {
 
       {!fetching && (
         <ClaimListDiscover
+          ignoreSearchInLanguage
           hasSource
           defaultFreshness={CS.FRESH_ALL}
           showHiddenByUser={viewHiddenChannels}
@@ -201,6 +202,7 @@ function ChannelContent(props: Props) {
               <Form onSubmit={() => {}} className="wunderbar--inline">
                 <Icon icon={ICONS.SEARCH} />
                 <FormField
+                  name="channel_search"
                   className="wunderbar__input--inline"
                   value={searchQuery}
                   onChange={handleInputChange}

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -40,6 +40,7 @@ type Props = {
   showHiddenByUser?: boolean,
   showNoSourceClaims?: boolean,
   tileLayout: boolean,
+  ignoreSearchInLanguage?: boolean,
 
   orderBy?: Array<string>, // Trending, New, Top
   defaultOrderBy?: string,
@@ -155,6 +156,7 @@ function ClaimListDiscover(props: Props) {
     forceShowReposts = false,
     languageSetting,
     searchInLanguage,
+    ignoreSearchInLanguage,
     limitClaimsPerChannel,
     releaseTime,
     scrollAnchor,
@@ -193,17 +195,18 @@ function ClaimListDiscover(props: Props) {
   );
 
   const langParam = urlParams.get(CS.LANGUAGE_KEY) || null;
-  const languageParams = searchInLanguage
-    ? langParam === null
-      ? languageSetting.concat(languageSetting === 'en' ? ',none' : '')
+  const languageParams =
+    searchInLanguage && !ignoreSearchInLanguage
+      ? langParam === null
+        ? languageSetting.concat(languageSetting === 'en' ? ',none' : '')
+        : langParam === 'any'
+        ? null
+        : langParam.concat(langParam === 'en' ? ',none' : '')
+      : langParam === null
+      ? null
       : langParam === 'any'
       ? null
-      : langParam.concat(langParam === 'en' ? ',none' : '')
-    : langParam === null
-    ? null
-    : langParam === 'any'
-    ? null
-    : langParam.concat(langParam === 'en' ? ',none' : '');
+      : langParam.concat(langParam === 'en' ? ',none' : '');
 
   let claimTypeParam = claimType || defaultClaimType || null;
   let streamTypeParam = streamType || defaultStreamType || null;


### PR DESCRIPTION
It's confusing to see blank channel pages due to this setting.

Closes #943 