### PR TITLE
fix mobile scrolling issue

### DIFF
--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -380,6 +380,10 @@ function SideNavigation(props: Props) {
   React.useEffect(() => {
     // $FlowFixMe
     document.body.style.overflowY = showOverlay ? 'hidden' : '';
+    return () => {
+      // $FlowFixMe
+      document.body.style.overflowY = '';
+    };
   }, [showOverlay]);
 
   React.useEffect(() => {


### PR DESCRIPTION
## Fixes

Issue Number:
Closes #941 

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

cannot scroll after clicking settings on mobile

## What is the new behavior?

can scroll after clicking settings on mobile

## Other information

when the side navigation is destroyed, it enables scrolling

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
