### PR TITLE
WildWest: always show boosting message

### DIFF
--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -89,38 +89,43 @@ function DiscoverPage(props: Props) {
   const useDualList = liveSection === SECTION.LESS && liveTilesOverLimit;
 
   function getMeta() {
-    if (liveSection === SECTION.MORE && liveTilesOverLimit) {
-      return (
-        <Button
-          label={__('Show less livestreams')}
-          button="link"
-          iconRight={ICONS.UP}
-          className="claim-grid__title--secondary"
-          onClick={() => setLiveSection(SECTION.LESS)}
-        />
-      );
-    }
+    return (
+      <>
+        {!dynamicRouteProps ? (
+          <a
+            className="help"
+            href="https://odysee.com/@OdyseeHelp:b/trending:50"
+            title={__('Learn more about Credits on %DOMAIN%', { DOMAIN })}
+          >
+            <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>Results boosted by %lbc%</I18nMessage>
+          </a>
+        ) : (
+          tag &&
+          !isMobile && (
+            <Button
+              ref={buttonRef}
+              button="alt"
+              icon={ICONS.SUBSCRIBE}
+              iconColor="red"
+              onClick={handleFollowClick}
+              requiresAuth={IS_WEB}
+              label={label}
+            />
+          )
+        )}
 
-    return !dynamicRouteProps ? (
-      <a
-        className="help"
-        href="https://odysee.com/@OdyseeHelp:b/trending:50"
-        title={__('Learn more about Credits on %DOMAIN%', { DOMAIN })}
-      >
-        <I18nMessage tokens={{ lbc: <LbcSymbol /> }}>Results boosted by %lbc%</I18nMessage>
-      </a>
-    ) : (
-      tag && !isMobile && (
-        <Button
-          ref={buttonRef}
-          button="alt"
-          icon={ICONS.SUBSCRIBE}
-          iconColor="red"
-          onClick={handleFollowClick}
-          requiresAuth={IS_WEB}
-          label={label}
-        />
-      )
+        {liveSection === SECTION.MORE && liveTilesOverLimit && (
+          <div className="livestream-list--view-more">
+            <Button
+              label={__('Show less livestreams')}
+              button="link"
+              iconRight={ICONS.UP}
+              className="claim-grid__title--secondary"
+              onClick={() => setLiveSection(SECTION.LESS)}
+            />
+          </div>
+        )}
+      </>
     );
   }
 

--- a/ui/scss/component/_livestream.scss
+++ b/ui/scss/component/_livestream.scss
@@ -171,6 +171,21 @@
 
 .livestream-list--view-more {
   display: flex;
-  align-items: flex-end;
-  margin-bottom: var(--spacing-m);
+  margin-left: var(--spacing-s);
+  margin-bottom: var(--spacing-xxxs);
+
+  @media (max-width: $breakpoint-small) {
+    button {
+      .button__content {
+        span {
+          // This is being set in '.section__actions' to '--font-xxsmall',
+          // causing the button to shrink in mobile.
+          // I think it is only needed for the mobile comments and shouldn't
+          // be applied globally?
+          // Anyway, reverting for this use-case only for now to reduce testing.
+          font-size: unset;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Ticket
Closes [#948 wildwest: always show boosting message, move next to category name](https://github.com/OdyseeTeam/odysee-frontend/issues/948)

## Changes
1. Make "Show less livestreams" share the same space as "Boosted by LBC", instead of only showing either 1.
    - It's a bit troublesome to move it next to the filter without tweaking the generic `ClaimListDiscover`, so I think this would be a good compromise.
2. Fix "Show less livestreams" being super tiny in mobile.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/64950861/155452482-266db967-1052-4ebf-9f37-8b5b8fc580c1.png">