### PR TITLE
6205 remember last used playlist choice odysee

### DIFF
--- a/ui/component/claimMenuList/index.js
+++ b/ui/component/claimMenuList/index.js
@@ -7,6 +7,7 @@ import {
   makeSelectCollectionIsMine,
   makeSelectEditedCollectionForId,
   makeSelectUrlsForCollectionId,
+  selectLastUsedCollection,
 } from 'redux/selectors/collections';
 import { makeSelectFileInfoForUri } from 'redux/selectors/file_info';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
@@ -44,6 +45,7 @@ const select = (state, props) => {
   const shuffleList = selectListShuffle(state);
   const shuffle = shuffleList && shuffleList.collectionId === collectionId && shuffleList.newUrls;
   const playNextUri = shuffle && shuffle[0];
+  const lastUsedCollection = selectLastUsedCollection(state);
 
   return {
     claim,
@@ -72,6 +74,9 @@ const select = (state, props) => {
     isAuthenticated: Boolean(selectUserVerifiedEmail(state)),
     resolvedList: makeSelectUrlsForCollectionId(collectionId)(state),
     playNextUri,
+    lastUsedCollection,
+    hasClaimInLastUsedCollection:
+      lastUsedCollection && makeSelectCollectionForIdHasClaimUrl(lastUsedCollection.id, contentPermanentUri)(state),
   };
 };
 

--- a/ui/component/claimMenuList/index.js
+++ b/ui/component/claimMenuList/index.js
@@ -77,6 +77,10 @@ const select = (state, props) => {
     lastUsedCollection,
     hasClaimInLastUsedCollection:
       lastUsedCollection && makeSelectCollectionForIdHasClaimUrl(lastUsedCollection.id, contentPermanentUri)(state),
+    lastUsedCollectionIsNotBuiltin:
+      lastUsedCollection &&
+      lastUsedCollection.id !== COLLECTIONS_CONSTS.WATCH_LATER_ID &&
+      lastUsedCollection.id !== COLLECTIONS_CONSTS.FAVORITES_ID,
   };
 };
 

--- a/ui/component/claimMenuList/index.js
+++ b/ui/component/claimMenuList/index.js
@@ -3,6 +3,7 @@ import { selectClaimForUri, selectClaimIsMine } from 'redux/selectors/claims';
 import { doCollectionEdit, doFetchItemsInCollection } from 'redux/actions/collections';
 import { doEditForChannel } from 'redux/actions/publish';
 import {
+  makeSelectCollectionForId,
   makeSelectCollectionForIdHasClaimUrl,
   makeSelectCollectionIsMine,
   makeSelectEditedCollectionForId,
@@ -45,7 +46,8 @@ const select = (state, props) => {
   const shuffleList = selectListShuffle(state);
   const shuffle = shuffleList && shuffleList.collectionId === collectionId && shuffleList.newUrls;
   const playNextUri = shuffle && shuffle[0];
-  const lastUsedCollection = selectLastUsedCollection(state);
+  const lastUsedCollectionId = selectLastUsedCollection(state);
+  const lastUsedCollection = makeSelectCollectionForId(lastUsedCollectionId)(state);
 
   return {
     claim,
@@ -75,12 +77,13 @@ const select = (state, props) => {
     resolvedList: makeSelectUrlsForCollectionId(collectionId)(state),
     playNextUri,
     lastUsedCollection,
-    hasClaimInLastUsedCollection:
-      lastUsedCollection && makeSelectCollectionForIdHasClaimUrl(lastUsedCollection.id, contentPermanentUri)(state),
+    hasClaimInLastUsedCollection: makeSelectCollectionForIdHasClaimUrl(
+      lastUsedCollectionId,
+      contentPermanentUri
+    )(state),
     lastUsedCollectionIsNotBuiltin:
-      lastUsedCollection &&
-      lastUsedCollection.id !== COLLECTIONS_CONSTS.WATCH_LATER_ID &&
-      lastUsedCollection.id !== COLLECTIONS_CONSTS.FAVORITES_ID,
+      lastUsedCollectionId !== COLLECTIONS_CONSTS.WATCH_LATER_ID &&
+      lastUsedCollectionId !== COLLECTIONS_CONSTS.FAVORITES_ID,
   };
 };
 

--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -69,6 +69,7 @@ type Props = {
   doToggleShuffleList: (string) => void,
   lastUsedCollection: ?Collection,
   hasClaimInLastUsedCollection: boolean,
+  lastUsedCollectionIsNotBuiltin: boolean,
 };
 
 function ClaimMenuList(props: Props) {
@@ -112,6 +113,7 @@ function ClaimMenuList(props: Props) {
     doToggleShuffleList,
     lastUsedCollection,
     hasClaimInLastUsedCollection,
+    lastUsedCollectionIsNotBuiltin,
   } = props;
   const [doShuffle, setDoShuffle] = React.useState(false);
   const incognitoClaim = contentChannelUri && !contentChannelUri.includes('@');
@@ -359,7 +361,7 @@ function ClaimMenuList(props: Props) {
                     {__('Add to Lists')}
                   </div>
                 </MenuItem>
-                {lastUsedCollection && (
+                {lastUsedCollection && lastUsedCollectionIsNotBuiltin && (
                   <MenuItem
                     className="comment__menu-option"
                     onSelect={() =>

--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -67,6 +67,8 @@ type Props = {
   resolvedList: boolean,
   fetchCollectionItems: (string) => void,
   doToggleShuffleList: (string) => void,
+  lastUsedCollection: ?Collection,
+  hasClaimInLastUsedCollection: boolean,
 };
 
 function ClaimMenuList(props: Props) {
@@ -108,6 +110,8 @@ function ClaimMenuList(props: Props) {
     resolvedList,
     fetchCollectionItems,
     doToggleShuffleList,
+    lastUsedCollection,
+    hasClaimInLastUsedCollection,
   } = props;
   const [doShuffle, setDoShuffle] = React.useState(false);
   const incognitoClaim = contentChannelUri && !contentChannelUri.includes('@');
@@ -355,6 +359,22 @@ function ClaimMenuList(props: Props) {
                     {__('Add to Lists')}
                   </div>
                 </MenuItem>
+                {lastUsedCollection && (
+                  <MenuItem
+                    className="comment__menu-option"
+                    onSelect={() =>
+                      handleAdd(hasClaimInLastUsedCollection, lastUsedCollection.name, lastUsedCollection.id)
+                    }
+                  >
+                    <div className="menu__link">
+                      {!hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.ADD} />}
+                      {hasClaimInLastUsedCollection && <Icon aria-hidden icon={ICONS.DELETE} />}
+                      {!hasClaimInLastUsedCollection &&
+                        __('Add to %collection%', { collection: lastUsedCollection.name })}
+                      {hasClaimInLastUsedCollection && __('In %collection%', { collection: lastUsedCollection.name })}
+                    </div>
+                  </MenuItem>
+                )}
                 <hr className="menu__separator" />
               </>
             )

--- a/ui/redux/reducers/collections.js
+++ b/ui/redux/reducers/collections.js
@@ -74,6 +74,7 @@ const collectionsReducer = handleActions(
         return {
           ...state,
           [collectionKey]: newList,
+          lastUsedCollection: isDeletingLastUsedCollection ? undefined : lastUsedCollection,
         };
       } else {
         if (newEditList[id]) {
@@ -117,6 +118,7 @@ const collectionsReducer = handleActions(
         edited: newEditList,
         unpublished: newUnpublishedList,
         pending: newPendingList,
+        lastUsedCollection: newPendingList[claimId],
       };
     },
 
@@ -128,6 +130,7 @@ const collectionsReducer = handleActions(
         return {
           ...state,
           [collectionKey]: { ...lists, [id]: collection },
+          lastUsedCollection: collection,
         };
       }
 
@@ -136,6 +139,7 @@ const collectionsReducer = handleActions(
         return {
           ...state,
           edited: { ...lists, [id]: collection },
+          lastUsedCollection: collection,
         };
       }
       const { unpublished: lists } = state;

--- a/ui/redux/reducers/collections.js
+++ b/ui/redux/reducers/collections.js
@@ -26,6 +26,7 @@ const defaultState: CollectionState = {
   },
   resolved: {},
   unpublished: {}, // sync
+  lastUsedCollection: undefined,
   edited: {},
   pending: {},
   saved: [],
@@ -53,14 +54,17 @@ const collectionsReducer = handleActions(
       return {
         ...state,
         unpublished: newLists,
+        lastUsedCollection: newList,
       };
     },
 
     [ACTIONS.COLLECTION_DELETE]: (state, action) => {
+      const { lastUsedCollection } = state;
       const { id, collectionKey } = action.data;
       const { edited: editList, unpublished: unpublishedList, pending: pendingList } = state;
       const newEditList = Object.assign({}, editList);
       const newUnpublishedList = Object.assign({}, unpublishedList);
+      const isDeletingLastUsedCollection = lastUsedCollection && lastUsedCollection.id === id;
 
       const newPendingList = Object.assign({}, pendingList);
 
@@ -85,6 +89,7 @@ const collectionsReducer = handleActions(
         edited: newEditList,
         unpublished: newUnpublishedList,
         pending: newPendingList,
+        lastUsedCollection: isDeletingLastUsedCollection ? undefined : lastUsedCollection,
       };
     },
 
@@ -137,6 +142,7 @@ const collectionsReducer = handleActions(
       return {
         ...state,
         unpublished: { ...lists, [id]: collection },
+        lastUsedCollection: collection,
       };
     },
 

--- a/ui/redux/reducers/collections.js
+++ b/ui/redux/reducers/collections.js
@@ -181,7 +181,7 @@ const collectionsReducer = handleActions(
     },
     [ACTIONS.COLLECTION_ITEMS_RESOLVE_COMPLETED]: (state, action) => {
       const { resolvedCollections, failedCollectionIds } = action.data;
-      const { pending, edited, isResolvingCollectionById, resolved } = state;
+      const { pending, edited, isResolvingCollectionById, resolved, lastUsedCollection } = state;
       const newPending = Object.assign({}, pending);
       const newEdited = Object.assign({}, edited);
       const newResolved = Object.assign({}, resolved, resolvedCollections);
@@ -208,12 +208,31 @@ const collectionsReducer = handleActions(
         });
       }
 
+      const newAllCollections = [
+        ...Object.values(newPending),
+        ...Object.values(newResolved),
+        ...Object.values(newEdited),
+      ];
+
+      let newLastUsedCollection = lastUsedCollection;
+
+      // If a collection is being published or got published,
+      // its id will get updated which means, we have to sync
+      // the last used collection.
+      if (lastUsedCollection) {
+        newLastUsedCollection = newAllCollections.find((collection) => {
+          // $FlowFixMe
+          return collection.name === lastUsedCollection.name;
+        });
+      }
+
       return Object.assign({}, state, {
         ...state,
         pending: newPending,
         resolved: newResolved,
         edited: newEdited,
         isResolvingCollectionById: newResolving,
+        lastUsedCollection: newLastUsedCollection,
       });
     },
     [ACTIONS.COLLECTION_ITEMS_RESOLVE_FAILED]: (state, action) => {

--- a/ui/redux/reducers/collections.js
+++ b/ui/redux/reducers/collections.js
@@ -54,7 +54,7 @@ const collectionsReducer = handleActions(
       return {
         ...state,
         unpublished: newLists,
-        lastUsedCollection: newList,
+        lastUsedCollection: params.id,
       };
     },
 
@@ -64,7 +64,7 @@ const collectionsReducer = handleActions(
       const { edited: editList, unpublished: unpublishedList, pending: pendingList } = state;
       const newEditList = Object.assign({}, editList);
       const newUnpublishedList = Object.assign({}, unpublishedList);
-      const isDeletingLastUsedCollection = lastUsedCollection && lastUsedCollection.id === id;
+      const isDeletingLastUsedCollection = lastUsedCollection === id;
 
       const newPendingList = Object.assign({}, pendingList);
 
@@ -118,7 +118,7 @@ const collectionsReducer = handleActions(
         edited: newEditList,
         unpublished: newUnpublishedList,
         pending: newPendingList,
-        lastUsedCollection: newPendingList[claimId],
+        lastUsedCollection: claimId,
       };
     },
 
@@ -130,7 +130,7 @@ const collectionsReducer = handleActions(
         return {
           ...state,
           [collectionKey]: { ...lists, [id]: collection },
-          lastUsedCollection: collection,
+          lastUsedCollection: id,
         };
       }
 
@@ -139,14 +139,14 @@ const collectionsReducer = handleActions(
         return {
           ...state,
           edited: { ...lists, [id]: collection },
-          lastUsedCollection: collection,
+          lastUsedCollection: id,
         };
       }
       const { unpublished: lists } = state;
       return {
         ...state,
         unpublished: { ...lists, [id]: collection },
-        lastUsedCollection: collection,
+        lastUsedCollection: id,
       };
     },
 
@@ -181,7 +181,7 @@ const collectionsReducer = handleActions(
     },
     [ACTIONS.COLLECTION_ITEMS_RESOLVE_COMPLETED]: (state, action) => {
       const { resolvedCollections, failedCollectionIds } = action.data;
-      const { pending, edited, isResolvingCollectionById, resolved, lastUsedCollection } = state;
+      const { pending, edited, isResolvingCollectionById, resolved } = state;
       const newPending = Object.assign({}, pending);
       const newEdited = Object.assign({}, edited);
       const newResolved = Object.assign({}, resolved, resolvedCollections);
@@ -208,31 +208,12 @@ const collectionsReducer = handleActions(
         });
       }
 
-      const newAllCollections = [
-        ...Object.values(newPending),
-        ...Object.values(newResolved),
-        ...Object.values(newEdited),
-      ];
-
-      let newLastUsedCollection = lastUsedCollection;
-
-      // If a collection is being published or got published,
-      // its id will get updated which means, we have to sync
-      // the last used collection.
-      if (lastUsedCollection) {
-        newLastUsedCollection = newAllCollections.find((collection) => {
-          // $FlowFixMe
-          return collection.name === lastUsedCollection.name;
-        });
-      }
-
       return Object.assign({}, state, {
         ...state,
         pending: newPending,
         resolved: newResolved,
         edited: newEdited,
         isResolvingCollectionById: newResolving,
-        lastUsedCollection: newLastUsedCollection,
       });
     },
     [ACTIONS.COLLECTION_ITEMS_RESOLVE_FAILED]: (state, action) => {

--- a/ui/redux/selectors/collections.js
+++ b/ui/redux/selectors/collections.js
@@ -15,6 +15,8 @@ export const selectMyUnpublishedCollections = (state: State) => selectState(stat
 export const selectMyEditedCollections = (state: State) => selectState(state).edited;
 export const selectPendingCollections = (state: State) => selectState(state).pending;
 
+export const selectLastUsedCollection = createSelector(selectState, (state) => state.lastUsedCollection);
+
 export const makeSelectEditedCollectionForId = (id: string) =>
   createSelector(selectMyEditedCollections, (eLists) => eLists[id]);
 


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/lbryio/lbry-desktop/issues/6205

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
The last used collection is not displayed in the menu options.

## What is the new behavior?
The last used collection is displayed in the menu options:

![image](https://user-images.githubusercontent.com/1719111/155234356-e826cafe-ef70-4663-80a7-5682a3f2fccc.png)
![image](https://user-images.githubusercontent.com/1719111/155234369-bdf30d6a-d2b4-4137-b711-9b4b7876c197.png)


## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
