### PR TITLE
FormFieldDuration: 'mo' incorrectly hinted as 'month' + i18n fix

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1691,6 +1691,8 @@
   "Enter the timeout duration. Examples: %examples%": "Enter the timeout duration. Examples: %examples%",
   "Wow, banned for more than 100 years?": "Wow, banned for more than 100 years?",
   "Invalid duration.": "Invalid duration.",
+  "Value exceeded maximum.": "Value exceeded maximum.",
+  "Units:\n • s:  seconds\n • m:  minutes \n • h:  hours\n • d:  days\n • b:  months\n • month:  months\n • y:  years": "Units:\n • s:  seconds\n • m:  minutes \n • h:  hours\n • d:  days\n • b:  months\n • month:  months\n • y:  years",
   "Permanent": "Permanent",
   "Timeout --[time-based ban instead of permanent]--": "Timeout",
   "(Remaining: %duration%) --[timeout ban duration]--": "(Remaining: %duration%)",

--- a/ui/component/formFieldDuration/view.jsx
+++ b/ui/component/formFieldDuration/view.jsx
@@ -6,7 +6,8 @@ import { FormField } from 'component/common/form';
 import Icon from 'component/common/icon';
 import * as ICONS from 'constants/icons';
 
-const INPUT_EXAMPLES = '\n- 30s\n- 10m\n- 1h\n- 2d\n- 3mo\n- 1y';
+// prettier-ignore
+const TOOLTIP = 'Units:\n • s:  seconds\n • m:  minutes \n • h:  hours\n • d:  days\n • b:  months\n • month:  months\n • y:  years';
 const ONE_HUNDRED_YEARS_IN_SECONDS = 3154000000;
 
 type Props = {
@@ -72,16 +73,10 @@ export default function FormFieldDuration(props: Props) {
       label={
         <>
           {label || __('Duration')}
-          <Icon
-            customTooltipText={__('Examples: %examples%', { examples: INPUT_EXAMPLES })}
-            className="icon--help"
-            icon={ICONS.HELP}
-            tooltip
-            size={16}
-          />
+          <Icon customTooltipText={__(TOOLTIP)} className="icon--help" icon={ICONS.HELP} tooltip size={16} />
         </>
       }
-      placeholder={placeholder || '30s, 10m, 1h, 2d, 3mo, 1y'}
+      placeholder={placeholder || '30s, 10m, 1h, 2d, 3month, 1y'}
       value={value}
       onChange={onChange}
       error={valueErr}


### PR DESCRIPTION
The unit is either `month` or `b`, so the tooltip and placeholder was incorrect.

Also fixed the tooltip to make it localizable.
