### PR TITLE
Swipe livestream + re-implement category livestreams

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2170,6 +2170,7 @@
   "Starting Soon": "Starting Soon",
   "Streaming Now": "Streaming Now",
   "Live": "Live",
+  "Livestreams": "Livestreams",
   "Upcoming Livestreams": "Upcoming Livestreams",
   "Show more upcoming livestreams": "Show more upcoming livestreams",
   "Show less upcoming livestreams": "Show less upcoming livestreams",

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -76,6 +76,7 @@ type Props = {
   hiddenNsfwMessage?: Node,
   injectedItem: ?Node,
   meta?: Node,
+  subSection?: Node, // Additional section below [Header|Meta]
   renderProperties?: (Claim) => Node,
 
   history: { action: string, push: (string) => void, replace: (string) => void },
@@ -118,6 +119,7 @@ function ClaimListDiscover(props: Props) {
     defaultTags,
     loading,
     meta,
+    subSection,
     channelIds,
     showNsfw,
     hideReposts,
@@ -651,6 +653,7 @@ function ClaimListDiscover(props: Props) {
               {meta && <div className="section__actions--no-margin">{meta}</div>}
             </div>
           )}
+          {subSection && <div>{subSection}</div>}
           <ClaimList
             tileLayout
             loading={loading}
@@ -691,6 +694,7 @@ function ClaimListDiscover(props: Props) {
               {meta && <div className="section__actions--no-margin">{meta}</div>}
             </div>
           )}
+          {subSection && <div>{subSection}</div>}
           <ClaimList
             type={type}
             loading={loading}

--- a/ui/page/channelsFollowing/view.jsx
+++ b/ui/page/channelsFollowing/view.jsx
@@ -2,9 +2,10 @@
 import * as PAGES from 'constants/pages';
 import * as ICONS from 'constants/icons';
 import * as CS from 'constants/claim_search';
-import { SIMPLE_SITE, ENABLE_NO_SOURCE_CLAIMS } from 'config';
+import { SIMPLE_SITE } from 'config';
 import React from 'react';
 import ChannelsFollowingDiscoverPage from 'page/channelsFollowingDiscover';
+import LivestreamSection from 'page/discover/livestreamSection';
 import ClaimListDiscover from 'component/claimListDiscover';
 import Page from 'component/page';
 import Button from 'component/button';
@@ -75,7 +76,14 @@ function ChannelsFollowingPage(props: Props) {
                 navigate={`/$/${PAGES.CHANNELS_FOLLOWING_DISCOVER}`}
               />
             }
-            showNoSourceClaims={ENABLE_NO_SOURCE_CLAIMS}
+            subSection={
+              <LivestreamSection
+                tileLayout={tileLayout}
+                channelIds={channelIds}
+                activeLivestreams={activeLivestreams}
+                doFetchActiveLivestreams={doFetchActiveLivestreams}
+              />
+            }
             hasSource
           />
         </>

--- a/ui/page/discover/livestreamSection.jsx
+++ b/ui/page/discover/livestreamSection.jsx
@@ -1,0 +1,159 @@
+// @flow
+import React from 'react';
+import Button from 'component/button';
+import { ENABLE_NO_SOURCE_CLAIMS } from 'config';
+import * as CS from 'constants/claim_search';
+import * as ICONS from 'constants/icons';
+import ClaimListDiscover from 'component/claimListDiscover';
+import { useIsMobile, useIsLargeScreen } from 'effects/use-screensize';
+import usePersistedState from 'effects/use-persisted-state';
+import { getLivestreamUris } from 'util/livestream';
+import { resolveLangForClaimSearch } from '../../util/default-languages';
+
+const DEFAULT_LIVESTREAM_TILE_LIMIT = 8;
+const SECTION = Object.freeze({ COLLAPSED: 1, EXPANDED: 2 });
+
+function getTileLimit(isLargeScreen, originalSize) {
+  return isLargeScreen ? originalSize * (3 / 2) : originalSize;
+}
+
+// ****************************************************************************
+// ****************************************************************************
+
+type Props = {
+  tileLayout: boolean,
+  channelIds?: Array<string>,
+  activeLivestreams: ?LivestreamInfo,
+  doFetchActiveLivestreams: (orderBy: ?Array<string>, lang: ?Array<string>) => void,
+  languageSetting?: string,
+  searchInLanguage?: boolean,
+  langParam?: string | null,
+};
+
+export default function LivestreamSection(props: Props) {
+  const {
+    tileLayout,
+    channelIds,
+    activeLivestreams,
+    doFetchActiveLivestreams,
+    languageSetting,
+    searchInLanguage,
+    langParam,
+  } = props;
+
+  const [liveSectionStore, setLiveSectionStore] = usePersistedState('discover:lsSection', SECTION.COLLAPSED);
+  const [expandedYPos, setExpandedYPos] = React.useState(null);
+
+  const isMobile = useIsMobile();
+  const isLargeScreen = useIsLargeScreen();
+
+  const initialLiveTileLimit = getTileLimit(isLargeScreen, DEFAULT_LIVESTREAM_TILE_LIMIT);
+  const [liveSection, setLiveSection] = React.useState(liveSectionStore || SECTION.COLLAPSED);
+  const livestreamUris = getLivestreamUris(activeLivestreams, channelIds);
+  const liveTilesOverLimit = livestreamUris && livestreamUris.length > initialLiveTileLimit;
+
+  function collapseSection() {
+    window.scrollTo(0, 0);
+    setLiveSection(SECTION.COLLAPSED);
+  }
+
+  React.useEffect(() => {
+    // Sync liveSection --> liveSectionStore
+    if (liveSection !== liveSectionStore) {
+      setLiveSectionStore(liveSection);
+    }
+  }, [liveSection, setLiveSectionStore, liveSectionStore]);
+
+  React.useEffect(() => {
+    // Fetch active livestreams on mount
+    const langCsv = resolveLangForClaimSearch(languageSetting, searchInLanguage, langParam);
+    const lang = langCsv ? langCsv.split(',') : null;
+    doFetchActiveLivestreams(CS.ORDER_BY_NEW_VALUE, lang);
+    // eslint-disable-next-line react-hooks/exhaustive-deps, (on mount only)
+  }, []);
+
+  React.useEffect(() => {
+    // Maintain y-position when expanding livestreams section:
+    if (liveSection === SECTION.EXPANDED && expandedYPos !== null) {
+      window.scrollTo(0, expandedYPos);
+      setExpandedYPos(null);
+    }
+  }, [liveSection, expandedYPos]);
+
+  if (!livestreamUris || livestreamUris.length === 0) {
+    return null;
+  }
+
+  if (isMobile) {
+    return (
+      <div className="livestream-list">
+        <ClaimListDiscover
+          uris={livestreamUris}
+          tileLayout={livestreamUris.length > 1 ? true : tileLayout}
+          swipeLayout={livestreamUris.length > 1}
+          headerLabel={<div className="section__title">{__('Livestreams')}</div>}
+          useSkeletonScreen={false}
+          showHeader={false}
+          hideFilters
+          infiniteScroll={false}
+          loading={false}
+          showNoSourceClaims={ENABLE_NO_SOURCE_CLAIMS}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="livestream-list">
+      {liveTilesOverLimit && liveSection === SECTION.EXPANDED && (
+        <div className="livestream-list--view-more">
+          <Button
+            label={__('Show less livestreams')}
+            button="link"
+            iconRight={ICONS.UP}
+            className="claim-grid__title--secondary"
+            onClick={collapseSection}
+          />
+        </div>
+      )}
+
+      <ClaimListDiscover
+        uris={liveSection === SECTION.COLLAPSED ? livestreamUris.slice(0, initialLiveTileLimit) : livestreamUris}
+        tileLayout={tileLayout}
+        showHeader={false}
+        hideFilters
+        infiniteScroll={false}
+        loading={false}
+        showNoSourceClaims={ENABLE_NO_SOURCE_CLAIMS}
+      />
+
+      {liveTilesOverLimit && liveSection === SECTION.COLLAPSED && (
+        <div className="livestream-list--view-more">
+          <Button
+            label={__('Show more livestreams')}
+            button="link"
+            iconRight={ICONS.DOWN}
+            className="claim-grid__title--secondary"
+            onClick={() => {
+              doFetchActiveLivestreams();
+              setExpandedYPos(window.scrollY);
+              setLiveSection(SECTION.EXPANDED);
+            }}
+          />
+        </div>
+      )}
+
+      {liveTilesOverLimit && liveSection === SECTION.EXPANDED && (
+        <div className="livestream-list--view-more">
+          <Button
+            label={__('Show less livestreams')}
+            button="link"
+            iconRight={ICONS.UP}
+            className="claim-grid__title--secondary"
+            onClick={collapseSection}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -183,7 +183,7 @@ function DiscoverPage(props: Props) {
   }, [isAuthenticated]);
 
   return (
-    <Page noFooter fullWidthPage={tileLayout}>
+    <Page noFooter fullWidthPage={tileLayout} className="main__discover">
       <Ads type="homepage" />
       <ClaimListDiscover
         pins={getPins(dynamicRouteProps)}

--- a/ui/scss/component/_livestream.scss
+++ b/ui/scss/component/_livestream.scss
@@ -169,23 +169,17 @@
   }
 }
 
+.livestream-list {
+  margin-bottom: var(--spacing-l);
+  border-bottom: 1px solid var(--color-border);
+
+  .claim-list__header-label {
+    margin-top: 0;
+  }
+}
+
 .livestream-list--view-more {
   display: flex;
-  margin-left: var(--spacing-s);
-  margin-bottom: var(--spacing-xxxs);
-
-  @media (max-width: $breakpoint-small) {
-    button {
-      .button__content {
-        span {
-          // This is being set in '.section__actions' to '--font-xxsmall',
-          // causing the button to shrink in mobile.
-          // I think it is only needed for the mobile comments and shouldn't
-          // be applied globally?
-          // Anyway, reverting for this use-case only for now to reduce testing.
-          font-size: unset;
-        }
-      }
-    }
-  }
+  align-items: flex-end;
+  margin-bottom: var(--spacing-s);
 }

--- a/ui/scss/component/_main.scss
+++ b/ui/scss/component/_main.scss
@@ -1134,6 +1134,14 @@ body {
   max-width: 32rem;
 }
 
+.main__discover {
+  .section__actions--no-margin {
+    @media (max-width: $breakpoint-small) {
+      width: unset; // It was being set to '100%' globally. Not sure why.
+    }
+  }
+}
+
 .main-wrapper--scrollbar {
   // The W3C future standard; currently supported by Firefox only.
   // It'll hopefully auto fallback to this when 'webkit-scrollbar' below is deprecated in the future.


### PR DESCRIPTION
The `useDualLayout` junk is super confusing to maintain and no longer extensible.

At the expense of making the "livestream + regular" list no longer seamlessly continuous when expanded (or when there just a handful of livestreams), use the new `subSection` feature to inject the livestream tiles.  This is far easier to manage and tweak.

Requires more testing.

## Ticket
Part of #728 