### PR TITLE
Moved "Dismiss Pin" to the top

### DIFF
--- a/ui/component/commentMenuList/view.jsx
+++ b/ui/component/commentMenuList/view.jsx
@@ -186,6 +186,13 @@ function CommentMenuList(props: Props) {
         </MenuItem>
       )}
 
+      {isPinned && isLiveComment && isMobile && (
+        <MenuItem className="comment__menu-option menu__link" onSelect={handleDismissPin}>
+          <Icon aria-hidden icon={ICONS.DISMISS_ALL} />
+          {__('Dismiss Pin')}
+        </MenuItem>
+      )}
+
       {activeChannelIsCreator && activeChannelClaim && activeChannelClaim.permanent_url !== authorUri && (
         <MenuItem className="comment__menu-option" onSelect={assignAsModerator}>
           <div className="menu__link">
@@ -253,13 +260,6 @@ function CommentMenuList(props: Props) {
             <Icon aria-hidden icon={ICONS.COPY_LINK} />
             {__('Copy Link')}
           </div>
-        </MenuItem>
-      )}
-
-      {isPinned && isLiveComment && isMobile && (
-        <MenuItem className="comment__menu-option menu__link" onSelect={handleDismissPin}>
-          <Icon aria-hidden icon={ICONS.DISMISS_ALL} />
-          {__('Dismiss Pin')}
         </MenuItem>
       )}
 


### PR DESCRIPTION
If it's a pinned comment, dismissing it is probably the action that the user is looking for, so doesn't make sense to put at the bottom.

<img width="273" alt="image" src="https://user-images.githubusercontent.com/64950861/156181286-5d5ae59d-4dca-41e5-9d65-b451daac0cae.png">
