### PR TITLE
Embedded images: serve via CDN for IP protection.

### DIFF
--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -1,8 +1,9 @@
 // @flow
-import { CHANNEL_STAKED_LEVEL_VIDEO_COMMENTS, SIMPLE_SITE } from 'config';
+import { CHANNEL_STAKED_LEVEL_VIDEO_COMMENTS, MISSING_THUMB_DEFAULT } from 'config';
 import { formattedEmote, inlineEmote } from 'util/remark-emote';
 import { formattedLinks, inlineLinks } from 'util/remark-lbry';
 import { formattedTimestamp, inlineTimestamp } from 'util/remark-timestamp';
+import { getThumbnailCdnUrl } from 'util/thumbnail';
 import * as ICONS from 'constants/icons';
 import * as React from 'react';
 import Button from 'component/button';
@@ -194,17 +195,22 @@ export default React.memo<MarkdownProps>(function MarkdownPreview(props: Markdow
           ),
       // Workaraund of remarkOptions.Fragment
       div: React.Fragment,
-      img: (imgProps) =>
-        isStakeEnoughForPreview(stakedLevel) && !isEmote(imgProps.title, imgProps.src) ? (
-          <ZoomableImage {...imgProps} />
-        ) : (
-          <SimpleImageLink
-            src={imgProps.src}
-            alt={imgProps.alt}
-            title={imgProps.title}
-            helpText={SIMPLE_SITE ? __("This channel isn't staking enough Credits for inline image previews.") : ''}
-          />
-        ),
+      img: (imgProps) => {
+        const imageCdnUrl =
+          getThumbnailCdnUrl({ thumbnail: imgProps.src, width: 0, height: 0, quality: 85 }) || MISSING_THUMB_DEFAULT;
+        if (isStakeEnoughForPreview(stakedLevel) && !isEmote(imgProps.title, imgProps.src)) {
+          return <ZoomableImage {...imgProps} src={imageCdnUrl} />;
+        } else {
+          return (
+            <SimpleImageLink
+              src={imageCdnUrl}
+              alt={imgProps.alt}
+              title={imgProps.title}
+              helpText={__("This channel isn't staking enough Credits for inline image previews.")}
+            />
+          );
+        }
+      },
     },
   };
 


### PR DESCRIPTION
## Ticket
[#536 "Embedding images without proxy is probably not in compliance with data protection regulations in Germany/Europe (GDPR)"
](https://github.com/OdyseeTeam/odysee-frontend/issues/536)

Not handling gifs for now, since the CDN doesn't support passthrough and gifs, so the ticket remains open.

## Screenshot
Here a sample Post with images, compared to current production
- production: uses direct url
- new:  goes through CDN

Hope I understood the issue right.

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/64950861/156385999-376a9bac-841d-4678-ac67-d2c802db5ef8.png">

## Test
`kp` dev instance
