### PR TITLE
When video is playing, save position intermittently

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -31,7 +31,7 @@ import useInterval from 'effects/use-interval';
 
 // const PLAY_TIMEOUT_ERROR = 'play_timeout_error';
 // const PLAY_TIMEOUT_LIMIT = 2000;
-const PLAY_POSITION_SAVE_INTERVAL = 15000;
+const PLAY_POSITION_SAVE_INTERVAL_MS = 15000;
 
 type Props = {
   position: number,
@@ -153,7 +153,7 @@ function VideoViewer(props: Props) {
     if (playerRef.current && isPlaying) {
       handlePosition(playerRef.current);
     }
-  }, PLAY_POSITION_SAVE_INTERVAL);
+  }, PLAY_POSITION_SAVE_INTERVAL_MS);
 
   const updateVolumeState = React.useCallback(
     debounce((volume, muted) => {

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -27,9 +27,11 @@ import { getAllIds } from 'util/buildHomepage';
 import type { HomepageCat } from 'util/buildHomepage';
 import debounce from 'util/debounce';
 import { formatLbryUrlForWeb, generateListSearchUrlParams } from 'util/url';
+import useInterval from 'effects/use-interval';
 
 // const PLAY_TIMEOUT_ERROR = 'play_timeout_error';
 // const PLAY_TIMEOUT_LIMIT = 2000;
+const PLAY_POSITION_SAVE_INTERVAL = 1500;
 
 type Props = {
   position: number,
@@ -137,6 +139,7 @@ function VideoViewer(props: Props) {
   const [videoNode, setVideoNode] = useState();
   const [localAutoplayNext, setLocalAutoplayNext] = useState(autoplayNext);
   const isFirstRender = React.useRef(true);
+  const playerRef = React.useRef(null);
 
   useEffect(() => {
     if (isFirstRender.current) {
@@ -145,6 +148,12 @@ function VideoViewer(props: Props) {
     }
     toggleAutoplayNext();
   }, [localAutoplayNext]);
+
+  useInterval(() => {
+    if (playerRef.current && isPlaying) {
+      handlePosition(playerRef.current);
+    }
+  }, PLAY_POSITION_SAVE_INTERVAL);
 
   const updateVolumeState = React.useCallback(
     debounce((volume, muted) => {
@@ -420,6 +429,8 @@ function VideoViewer(props: Props) {
     if (position) {
       player.currentTime(position);
     }
+
+    playerRef.current = player;
   }, playerReadyDependencyList); // eslint-disable-line
 
   return (

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -31,7 +31,7 @@ import useInterval from 'effects/use-interval';
 
 // const PLAY_TIMEOUT_ERROR = 'play_timeout_error';
 // const PLAY_TIMEOUT_LIMIT = 2000;
-const PLAY_POSITION_SAVE_INTERVAL = 1500;
+const PLAY_POSITION_SAVE_INTERVAL = 15000;
 
 type Props = {
   position: number,

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -127,7 +127,6 @@ function VideoViewer(props: Props) {
   const [ended, setEnded] = useState(false);
   const [showAutoplayCountdown, setShowAutoplayCountdown] = useState(false);
   const [isEndedEmbed, setIsEndedEmbed] = useState(false);
-  const [playerObj, setPlayerObj] = useState(null);
   const vjsCallbackDataRef: any = React.useRef();
   const previousUri = usePrevious(uri);
   const embedded = useContext(EmbedContext);
@@ -140,7 +139,7 @@ function VideoViewer(props: Props) {
   const [videoNode, setVideoNode] = useState();
   const [localAutoplayNext, setLocalAutoplayNext] = useState(autoplayNext);
   const isFirstRender = React.useRef(true);
-  const savePositionInterval = isPlaying ? PLAY_POSITION_SAVE_INTERVAL_MS : null;
+  const playerRef = React.useRef(null);
 
   useEffect(() => {
     if (isFirstRender.current) {
@@ -151,10 +150,10 @@ function VideoViewer(props: Props) {
   }, [localAutoplayNext]);
 
   useInterval(() => {
-    if (playerObj) {
-      handlePosition(playerObj);
+    if (playerRef.current && isPlaying) {
+      handlePosition(playerRef.current);
     }
-  }, savePositionInterval);
+  }, PLAY_POSITION_SAVE_INTERVAL_MS);
 
   const updateVolumeState = React.useCallback(
     debounce((volume, muted) => {
@@ -431,7 +430,7 @@ function VideoViewer(props: Props) {
       player.currentTime(position);
     }
 
-    setPlayerObj(player);
+    playerRef.current = player;
   }, playerReadyDependencyList); // eslint-disable-line
 
   return (

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -127,6 +127,7 @@ function VideoViewer(props: Props) {
   const [ended, setEnded] = useState(false);
   const [showAutoplayCountdown, setShowAutoplayCountdown] = useState(false);
   const [isEndedEmbed, setIsEndedEmbed] = useState(false);
+  const [playerObj, setPlayerObj] = useState(null);
   const vjsCallbackDataRef: any = React.useRef();
   const previousUri = usePrevious(uri);
   const embedded = useContext(EmbedContext);
@@ -139,7 +140,7 @@ function VideoViewer(props: Props) {
   const [videoNode, setVideoNode] = useState();
   const [localAutoplayNext, setLocalAutoplayNext] = useState(autoplayNext);
   const isFirstRender = React.useRef(true);
-  const playerRef = React.useRef(null);
+  const savePositionInterval = isPlaying ? PLAY_POSITION_SAVE_INTERVAL_MS : null;
 
   useEffect(() => {
     if (isFirstRender.current) {
@@ -150,10 +151,10 @@ function VideoViewer(props: Props) {
   }, [localAutoplayNext]);
 
   useInterval(() => {
-    if (playerRef.current && isPlaying) {
-      handlePosition(playerRef.current);
+    if (playerObj) {
+      handlePosition(playerObj);
     }
-  }, PLAY_POSITION_SAVE_INTERVAL_MS);
+  }, savePositionInterval);
 
   const updateVolumeState = React.useCallback(
     debounce((volume, muted) => {
@@ -430,7 +431,7 @@ function VideoViewer(props: Props) {
       player.currentTime(position);
     }
 
-    playerRef.current = player;
+    setPlayerObj(player);
   }, playerReadyDependencyList); // eslint-disable-line
 
   return (

--- a/ui/effects/use-interval.js
+++ b/ui/effects/use-interval.js
@@ -12,7 +12,7 @@ export default function useInterval(callback, delay) {
       savedCallback.current();
     };
     if (delay !== null) {
-      let id = setInterval(tick, delay);
+      const id = setInterval(tick, delay);
       return () => clearInterval(id);
     }
   }, [delay]);

--- a/ui/effects/use-interval.js
+++ b/ui/effects/use-interval.js
@@ -1,0 +1,19 @@
+import { useRef, useEffect } from 'react';
+
+export default function useInterval(callback, delay) {
+  const savedCallback = useRef();
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const tick = () => {
+      savedCallback.current();
+    };
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}


### PR DESCRIPTION
## What is the current behavior?
Currently, the position of a video is saved when pausing, seeking, or navigating to a url that is handled by the router. However, if you close the tab or navigate away from the site with a hard link, the play position is lost.

## What is the new behavior?
This patch will intermittently save while the video is playing to better prevent losing video progress.  An arbitrary interval of 15 seconds was chose, but this can be adjusted if there is some more appropriate interval.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
