### PR TITLE
Recommended: fix "no results found" flashing after search

### DIFF
--- a/ui/redux/selectors/search.js
+++ b/ui/redux/selectors/search.js
@@ -101,7 +101,9 @@ export const selectRecommendedContentForUri = createCachedSelector(
       recommendedContent = searchResult['uris'].filter((searchUri) => {
         const searchClaim = claimsByUri[searchUri];
 
-        if (!searchClaim) return;
+        if (!searchClaim) {
+          return true;
+        }
 
         const signingChannel = searchClaim && searchClaim.signing_channel;
         const channelUri = signingChannel && signingChannel.canonical_url;


### PR DESCRIPTION
## Cause
When 'selectRecommendedContentForUri' is filtering results against the blocklist, it relies on claim data which could be unresolved yet. It filters to empty results for this scenario, hence the flashing message.

## Change
Just return raw results when claims are not resolved yet, so that the GUI knows it needs to show the placeholders while resolving. After resolving, it'll go through the blocklist filtering again.