### PR TITLE
SignUp: don't show spinner when in focus (aka GetSync)

### DIFF
--- a/ui/component/userSignUp/view.jsx
+++ b/ui/component/userSignUp/view.jsx
@@ -119,7 +119,8 @@ function UserSignUp(props: Props) {
   const showFollowIntro = step === 'channels' || (hasVerifiedEmail && !followingAcknowledged);
   const showTagsIntro = SHOW_TAGS_INTRO && (step === 'tags' || (hasVerifiedEmail && !tagsAcknowledged));
   const canHijackSignInFlowWithSpinner = hasVerifiedEmail && !showFollowIntro && !showTagsIntro && !rewardsAcknowledged;
-  const isCurrentlyFetchingSomething = fetchingChannels || claimingReward || syncingWallet || creatingChannel;
+  const showSpinnerForSync = syncingWallet && !hasSynced && balance === undefined;
+  const isCurrentlyFetchingSomething = fetchingChannels || claimingReward || showSpinnerForSync || creatingChannel;
   const isWaitingForSomethingToFinish =
     // If the user has claimed the email award, we need to wait until the balance updates sometime in the future
     (!hasFetchedReward && !hasClaimedEmailAward) || (syncEnabled && !hasSynced);


### PR DESCRIPTION
## Issue
Closes #1020 strange refresh on signup + youtube sync

It's due to the sync-on-focus.

## Change
Only show the spinner for the initial wallet sync. I thought we can do without the spinner for sync completely, but based on the comments below, better to retain that for the initial sync.  I think the rest of the stages don't need to block over a sync call.

```
// Don't claim the reward if sync is enabled until after a sync has been completed successfully
// If we do it before, we could end up trying to sync a wallet with a non-zero balance which will fail to sync
```