### PR TITLE
Hide comment thread-line when no replies

### DIFF
--- a/ui/component/commentsReplies/view.jsx
+++ b/ui/component/commentsReplies/view.jsx
@@ -48,7 +48,9 @@ export default function CommentsReplies(props: Props) {
         </div>
       ) : (
         <div className="comment__replies">
-          <Button className="comment__threadline" aria-label="Hide Replies" onClick={() => setExpanded(false)} />
+          {fetchedReplies.length > 0 && (
+            <Button className="comment__threadline" aria-label="Hide Replies" onClick={() => setExpanded(false)} />
+          )}
 
           <ul className="comments--replies">
             {fetchedReplies.map((comment) => (


### PR DESCRIPTION
No replies when:
- haven't fetched yet
- replies blocked/muted

It's being displayed as a dot in these scenarios.
