### PR TITLE
Channel Search pagination

### DIFF
--- a/ui/component/channelContent/internal/searchResults.jsx
+++ b/ui/component/channelContent/internal/searchResults.jsx
@@ -1,0 +1,92 @@
+// @flow
+import React from 'react';
+import ClaimList from 'component/claimList';
+import { DEBOUNCE_WAIT_DURATION_MS, SEARCH_PAGE_SIZE } from 'constants/search';
+import { lighthouse } from 'redux/actions/search';
+
+type Props = {
+  searchQuery: string,
+  claimId: ?string,
+  showMature: ?boolean,
+  tileLayout: boolean,
+  onResults?: (results: ?Array<string>) => void,
+  doResolveUris: (Array<string>, boolean) => void,
+};
+
+export function SearchResults(props: Props) {
+  const { searchQuery, claimId, showMature, tileLayout, onResults, doResolveUris } = props;
+
+  const [page, setPage] = React.useState(1);
+  const [searchResults, setSearchResults] = React.useState(undefined);
+  const [isSearching, setIsSearching] = React.useState(false);
+  const noMoreResults = React.useRef(false);
+
+  React.useEffect(() => {
+    setPage(1);
+  }, [searchQuery]);
+
+  React.useEffect(() => {
+    if (onResults) {
+      onResults(searchResults);
+    }
+  }, [searchResults, onResults]);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchQuery.trim().length < 3 || !claimId) {
+        return setSearchResults(null);
+      }
+
+      setIsSearching(true);
+
+      lighthouse
+        .search(
+          `from=${SEARCH_PAGE_SIZE * (page - 1)}` +
+            `&s=${encodeURIComponent(searchQuery)}` +
+            `&channel_id=${encodeURIComponent(claimId)}` +
+            `&nsfw=${showMature ? 'true' : 'false'}` +
+            `&size=${SEARCH_PAGE_SIZE}`
+        )
+        .then(({ body: results }) => {
+          const urls = results.map(({ name, claimId }) => {
+            return `lbry://${name}#${claimId}`;
+          });
+
+          // Batch-resolve the urls before calling 'setSearchResults', as the
+          // latter will immediately cause the tiles to resolve, ending up
+          // calling doResolveUri one by one before the batched one.
+          doResolveUris(urls, true);
+
+          // De-dup (LH will return some duplicates) and concat results
+          setSearchResults((prev) => (page === 1 ? urls : Array.from(new Set((prev || []).concat(urls)))));
+          noMoreResults.current = !urls || urls.length < SEARCH_PAGE_SIZE;
+        })
+        .catch(() => {
+          setPage(1);
+          setSearchResults(null);
+          noMoreResults.current = false;
+        })
+        .finally(() => {
+          setIsSearching(false);
+        });
+    }, DEBOUNCE_WAIT_DURATION_MS);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery, claimId, page, showMature, doResolveUris]);
+
+  if (!searchResults) {
+    return null;
+  }
+
+  return (
+    <ClaimList
+      uris={searchResults}
+      loading={isSearching}
+      onScrollBottom={() => setPage((prev) => (noMoreResults.current ? prev : prev + 1))}
+      page={page}
+      pageSize={SEARCH_PAGE_SIZE}
+      tileLayout={tileLayout}
+      useLoadingSpinner
+    />
+  );
+}

--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -100,9 +100,8 @@ export default function ClaimList(props: Props) {
 
   const [currentSort, setCurrentSort] = usePersistedState(persistedStorageKey, SORT_NEW);
 
-  // reference to the claim-grid
+  // Resolve the index for injectedItem, if provided; else injectedIndex will be 'undefined'.
   const listRef = React.useRef();
-  // determine the index where the ad should be injected
   const injectedIndex = useLastVisibleItem(injectedItem, listRef);
 
   // Exclude prefix uris in these results variables. We don't want to show
@@ -149,7 +148,6 @@ export default function ClaimList(props: Props) {
   }, []);
 
   // @if process.env.NODE_ENV!='production'
-  // code to enable replacing of a claim tile isn't available here yet
   if (injectedItem && injectedItem.replace) {
     throw new Error('claimList: "injectedItem.replace" is not implemented yet');
   }
@@ -201,7 +199,6 @@ export default function ClaimList(props: Props) {
     />
   );
 
-  // returns injected ad DOM when indexes match
   const getInjectedItem = (index) => {
     if (injectedItem && injectedItem.node && injectedIndex === index) {
       return injectedItem.node;
@@ -210,26 +207,31 @@ export default function ClaimList(props: Props) {
   };
 
   return tileLayout && !header ? (
-    <section ref={listRef} className={classnames('claim-grid', { 'swipe-list': swipeLayout })}>
-      {urisLength > 0 &&
-        tileUris.map((uri, index) => (
-          <React.Fragment key={uri}>
-            {getInjectedItem(index)}
-            {/* inject ad node */}
-            <ClaimPreviewTile
-              uri={uri}
-              showHiddenByUser={showHiddenByUser}
-              properties={renderProperties}
-              collectionId={collectionId}
-              showNoSourceClaims={showNoSourceClaims}
-              swipeLayout={swipeLayout}
-            />
-          </React.Fragment>
-        ))}
-      {loading && useLoadingSpinner && <ClaimPreviewTile placeholder="loading" swipeLayout={swipeLayout} />}
-      {!timedOut && urisLength === 0 && !loading && <div className="empty main--empty">{empty || noResultMsg}</div>}
-      {timedOut && timedOutMessage && <div className="empty main--empty">{timedOutMessage}</div>}
-    </section>
+    <>
+      <section ref={listRef} className={classnames('claim-grid', { 'swipe-list': swipeLayout })}>
+        {urisLength > 0 &&
+          tileUris.map((uri, index) => (
+            <React.Fragment key={uri}>
+              {getInjectedItem(index)}
+              <ClaimPreviewTile
+                uri={uri}
+                showHiddenByUser={showHiddenByUser}
+                properties={renderProperties}
+                collectionId={collectionId}
+                showNoSourceClaims={showNoSourceClaims}
+                swipeLayout={swipeLayout}
+              />
+            </React.Fragment>
+          ))}
+        {!timedOut && urisLength === 0 && !loading && <div className="empty main--empty">{empty || noResultMsg}</div>}
+        {timedOut && timedOutMessage && <div className="empty main--empty">{timedOutMessage}</div>}
+      </section>
+      {loading && useLoadingSpinner && (
+        <div className="spinnerArea--centered">
+          <Spinner type="small" />
+        </div>
+      )}
+    </>
   ) : (
     <section
       className={classnames('claim-list', {


### PR DESCRIPTION
Closes [#605 Add pagination support to channel search](https://github.com/OdyseeTeam/odysee-frontend/issues/605)
Test: the usual place.

## Previous Attempt
The previous attempt (https://github.com/OdyseeTeam/odysee-frontend/commit/69de63c436a3511756684de62cfbe49b6950db41) didn't work because the wunderbar is part of the list component, so it is unmounted when we switch between the Normal and Filtered list, causing it to lose focus while typing.

Also, creating another full-blown ClaimList* component was probably redundant (we should be consolidating instead).

## Approach
ClaimListDiscover recently added a new `subSection`, so we can place the filtered `ClaimList` here without causing the wunderbar to unmount.

Wrapped the "lighthouse search with channel_id" into `searchResults.jsx` for now as a quick and isolated solution. When we refactor ClaimList*, we can then consider incorporating into `doSearch`.