### PR TITLE
List Page: use swipe layout for mobile

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2122,6 +2122,7 @@
   "Enter the full channel name or URL to search.\n\nExamples:\n - @channel\n - @channel#3\n - https://odysee.com/@Odysee:8\n - lbry://@Odysee#8": "Enter the full channel name or URL to search.\n\nExamples:\n - @channel\n - @channel#3\n - https://odysee.com/@Odysee:8\n - lbry://@Odysee#8",
   "Choose %asset%": "Choose %asset%",
   "Showing %filtered% results of %total%": "Showing %filtered% results of %total%",
+  "filtered": "filtered",
   "Failed to synchronize settings. Wait a while before retrying.": "Failed to synchronize settings. Wait a while before retrying.",
   "You are offline. Check your internet connection.": "You are offline. Check your internet connection.",
   "A new version of Odysee is available.": "A new version of Odysee is available.",

--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -152,7 +152,11 @@ function ClaimPreviewTile(props: Props) {
 
   if (placeholder || (!claim && isResolvingUri)) {
     return (
-      <li className={classnames('placeholder claim-preview--tile', {})}>
+      <li
+        className={classnames('placeholder claim-preview--tile', {
+          'swipe-list__item claim-preview--horizontal-tile': swipeLayout,
+        })}
+      >
         <div className="media__thumb">
           <img src={PlaceholderTx} alt="Placeholder" />
         </div>

--- a/ui/component/collectionPreviewOverlay/view.jsx
+++ b/ui/component/collectionPreviewOverlay/view.jsx
@@ -33,8 +33,8 @@ function CollectionPreviewOverlay(props: Props) {
             collectionItemUrls.map((item, index) => {
               if (index < 2) {
                 return (
-                  <div className="collection-preview__overlay-grid-items">
-                    <FileThumbnail uri={item} key={item} />
+                  <div className="collection-preview__overlay-grid-items" key={item}>
+                    <FileThumbnail uri={item} />
                   </div>
                 );
               }

--- a/ui/component/collectionPreviewTile/view.jsx
+++ b/ui/component/collectionPreviewTile/view.jsx
@@ -25,18 +25,12 @@ type Props = {
   thumbnail?: string,
   title?: string,
   placeholder: boolean,
-  blackListedOutpoints: Array<{
-    txid: string,
-    nout: number,
-  }>,
-  filteredOutpoints: Array<{
-    txid: string,
-    nout: number,
-  }>,
+  swipeLayout?: boolean,
+  blackListedOutpoints: Array<{ txid: string, nout: number }>,
+  filteredOutpoints: Array<{ txid: string, nout: number }>,
   blockedChannelUris: Array<string>,
   isMature?: boolean,
   showMature: boolean,
-  collectionId: string,
   deleteCollection: (string) => void,
   resolveCollectionItems: (any) => void,
   isResolvingCollectionClaims: boolean,
@@ -53,6 +47,7 @@ function CollectionPreviewTile(props: Props) {
     collectionItemUrls,
     claim,
     resolveCollectionItems,
+    swipeLayout = false,
   } = props;
 
   const { push } = useHistory();
@@ -120,7 +115,11 @@ function CollectionPreviewTile(props: Props) {
 
   if (isResolvingUri || isResolvingCollectionClaims) {
     return (
-      <li className={classnames('claim-preview--tile', {})}>
+      <li
+        className={classnames('claim-preview--tile', {
+          'swipe-list__item claim-preview--horizontal-tile': swipeLayout,
+        })}
+      >
         <div className="placeholder media__thumb" />
         <div className="placeholder__wrapper">
           <div className="placeholder claim-tile__title" />
@@ -129,12 +128,19 @@ function CollectionPreviewTile(props: Props) {
       </li>
     );
   }
+
   if (uri) {
-    return <ClaimPreviewTile uri={uri} />;
+    return <ClaimPreviewTile swipeLayout={swipeLayout} uri={uri} />;
   }
 
   return (
-    <li role="link" onClick={handleClick} className={'card claim-preview--tile'}>
+    <li
+      role="link"
+      onClick={handleClick}
+      className={classnames('card claim-preview--tile', {
+        'swipe-list__item claim-preview--horizontal-tile': swipeLayout,
+      })}
+    >
       <NavLink {...navLinkProps}>
         <FileThumbnail uri={collectionItemUrls && collectionItemUrls.length && collectionItemUrls[0]}>
           <React.Fragment>


### PR DESCRIPTION
#950 
> _playlists page - right now we show watch later on top, and if you have stuff here, you have to scroll down to other playlists. Show a selector on top? Whatever other improvements we can make here to improve UX._

## Approach
Use swipe layout for mobile.