### PR TITLE
Playlist tile optimizations

### DIFF
--- a/ui/component/collectionPreviewOverlay/view.jsx
+++ b/ui/component/collectionPreviewOverlay/view.jsx
@@ -25,20 +25,17 @@ function CollectionPreviewOverlay(props: Props) {
   }, [collectionId, collectionItemUrls, fetchCollectionItems]);
 
   if (collectionItemUrls && collectionItemUrls.length > 0) {
+    const displayed = collectionItemUrls.slice(0, 2);
+
     return (
       <div className="collection-preview__overlay-thumbs">
         <div className="collection-preview__overlay-side" />
         <div className="collection-preview__overlay-grid">
-          {collectionItemUrls &&
-            collectionItemUrls.map((item, index) => {
-              if (index < 2) {
-                return (
-                  <div className="collection-preview__overlay-grid-items" key={item}>
-                    <FileThumbnail uri={item} />
-                  </div>
-                );
-              }
-            })}
+          {displayed.map((uri) => (
+            <div className="collection-preview__overlay-grid-items" key={uri}>
+              <FileThumbnail uri={uri} />
+            </div>
+          ))}
         </div>
       </div>
     );

--- a/ui/component/collectionsListMine/view.jsx
+++ b/ui/component/collectionsListMine/view.jsx
@@ -23,7 +23,7 @@ type Props = {
 
 const LIST_TYPE = Object.freeze({ ALL: 'All', PRIVATE: 'Private', PUBLIC: 'Public' });
 const COLLECTION_FILTERS = [LIST_TYPE.ALL, LIST_TYPE.PRIVATE, LIST_TYPE.PUBLIC];
-const COLLECTION_SHOW_COUNT = 12;
+const PLAYLIST_SHOW_COUNT = Object.freeze({ DEFAULT: 12, MOBILE: 6 });
 
 export default function CollectionsListMine(props: Props) {
   const {
@@ -41,6 +41,7 @@ export default function CollectionsListMine(props: Props) {
   const [filterType, setFilterType] = React.useState(LIST_TYPE.ALL);
   const [searchText, setSearchText] = React.useState('');
   const isMobileScreen = useIsMobile();
+  const playlistShowCount = isMobileScreen ? PLAYLIST_SHOW_COUNT.MOBILE : PLAYLIST_SHOW_COUNT.DEFAULT;
 
   const playlistPageUrl = `/$/${PAGES.PLAYLISTS}?type=${filterType}`;
   let collectionsToShow = [];
@@ -63,9 +64,9 @@ export default function CollectionsListMine(props: Props) {
             publishedCollections[id].name.toLocaleLowerCase().includes(searchText.toLocaleLowerCase()))
         );
       })
-      .slice(0, COLLECTION_SHOW_COUNT);
+      .slice(0, playlistShowCount);
   } else {
-    filteredCollections = collectionsToShow.slice(0, COLLECTION_SHOW_COUNT) || [];
+    filteredCollections = collectionsToShow.slice(0, playlistShowCount) || [];
   }
 
   const totalLength = collectionsToShow ? collectionsToShow.length : 0;


### PR DESCRIPTION
Closes [#1071 Limit tiles shown in horizontal mode, option to show all ](https://github.com/OdyseeTeam/odysee-frontend/issues/1071)

- ListOverlay: don't loop through all items if we just want 2. `map` doesn't short-circuit.
- Playlist: reduce show count from 12 to 6 on mobile.
