### PR TITLE
Handle case of missing `effective_amount`

### DIFF
--- a/ui/component/fileValues/view.jsx
+++ b/ui/component/fileValues/view.jsx
@@ -84,7 +84,7 @@ class FileValues extends PureComponent<Props> {
               </div>
             </td>
             <td>
-              <CreditAmount amount={Number(claim.meta.effective_amount)} precision={2} />
+              <CreditAmount amount={Number(claim.meta.effective_amount) || 0} precision={2} />
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Closes [#916 "NaN in Total Staked Amount"](https://github.com/OdyseeTeam/odysee-frontend/issues/916)

Contemplated putting the fallback into `<CreditAmount>` itself, but decided to minimize testing. Not sure if there are clients that would rely on NaN being used.

### Test
<img width="129" alt="image" src="https://user-images.githubusercontent.com/64950861/157999883-6c648d3e-326d-4011-b445-9a7a3233cb54.png">
