### PR TITLE
Notification bubble: add border since it's the same color as an active button

### DIFF
--- a/ui/scss/component/_notification.scss
+++ b/ui/scss/component/_notification.scss
@@ -295,6 +295,7 @@ $contentMaxWidth: 60rem;
   height: 1.4rem;
   width: 1.4rem;
   border-radius: 50%;
+  border: 1.5px solid var(--color-background);
   background-color: var(--color-notification);
   position: absolute;
   top: -0.4rem;


### PR DESCRIPTION
#950 
> _notifications count clashes with color of the expand button in top right_

----

Before and after:
![image](https://user-images.githubusercontent.com/64950861/158002084-73fb7604-bb2d-464d-aced-a3caaae5e4a7.png)


I think both the button and bubble should retain their colors (used to it + makes sense), so just add a border.


