### PR TITLE
Fix #798: fix action dispatch order in doFetchItemsInCollections

### DIFF
--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -273,16 +273,16 @@ export const doFetchItemsInCollections = (
   });
 
   dispatch({
+    type: ACTIONS.RESOLVE_URIS_COMPLETED,
+    data: { resolveInfo },
+  });
+
+  dispatch({
     type: ACTIONS.COLLECTION_ITEMS_RESOLVE_COMPLETED,
     data: {
       resolvedCollections: newCollectionObjectsById,
       failedCollectionIds: invalidCollectionIds,
     },
-  });
-
-  dispatch({
-    type: ACTIONS.RESOLVE_URIS_COMPLETED,
-    data: { resolveInfo },
   });
 };
 


### PR DESCRIPTION
We need to store the resolved claims first before marking `COLLECTION_ITEMS_RESOLVE_COMPLETED`, otherwise the GUI still sees undefined claims and tries to resolve again.

798 just accidentally flipped the order due to refactoring, I believe. It's now back to original.
