### PR TITLE
Go Live: fix missing channel selector

### DIFF
--- a/ui/page/livestreamSetup/view.jsx
+++ b/ui/page/livestreamSetup/view.jsx
@@ -65,15 +65,6 @@ export default function LivestreamSetupPage(props: Props) {
     ENABLE_NO_SOURCE_CLAIMS && user && !liveDisabled && (liveEnabled || odyseeMembership || hasEnoughLBCToStream)
   );
 
-  let reasonAllowedToStream = '';
-  if (odyseeMembership) {
-    reasonAllowedToStream = 'you purchased Odysee Premium';
-  } else if (liveEnabled) {
-    reasonAllowedToStream = 'your livestreaming was turned on manually';
-  } else if (hasEnoughLBCToStream) {
-    reasonAllowedToStream = 'you have enough staked LBC';
-  }
-
   function createStreamKey() {
     if (!channelId || !channelName || !sigData.signature || !sigData.signing_ts) return null;
     return `${channelId}?d=${toHex(channelName)}&s=${sigData.signature}&t=${sigData.signing_ts}`;
@@ -260,9 +251,7 @@ export default function LivestreamSetupPage(props: Props) {
                   />
                 }
                 title={__('Go Live on Odysee')}
-                subtitle={
-                  <>{__(`Congratulations, you have access to livestreaming because ${reasonAllowedToStream}!`)} </>
-                }
+                subtitle={<>{__(`Expand to learn more about setting up a livestream.`)} </>}
                 actions={showHelp && helpText}
               />
               {streamKey && totalLivestreamClaims.length > 0 && (

--- a/ui/page/livestreamSetup/view.jsx
+++ b/ui/page/livestreamSetup/view.jsx
@@ -192,6 +192,15 @@ export default function LivestreamSetupPage(props: Props) {
 
   return (
     <Page>
+      {/* channel selector */}
+      {!fetchingChannels && (
+        <>
+          <div className="section__actions--between">
+            <ChannelSelector hideAnon />
+          </div>
+        </>
+      )}
+
       {/* no livestreaming privs because no premium membership */}
       {!livestreamEnabled && !odyseeMembership && (
         <div style={{ marginTop: '11px' }}>
@@ -231,15 +240,6 @@ export default function LivestreamSetupPage(props: Props) {
                 </div>
               }
             />
-          )}
-
-          {/* channel selector */}
-          {!fetchingChannels && (
-            <>
-              <div className="section__actions--between">
-                <ChannelSelector hideAnon />
-              </div>
-            </>
           )}
 
           {/* getting livestreams */}


### PR DESCRIPTION
If the active channel doesn't have 50 LBC support, we are stuck in the "you can't stream" state. But I have other channels that are eligible.

## Also
The "congratulations" string is done in a non-localizable way.  It tries to explain why this channel can stream.
Before I fix the i18n, do we need such a string?  

- Can the subtitle be just "Expand to learn more about setting up a livestream."?  That seems to make more sense given what appears after the expansion.

<img width="644" alt="image" src="https://user-images.githubusercontent.com/64950861/158830379-04daa876-dc79-4389-860e-04c1ae8f2c0b.png">

