### PR TITLE
Better handling of SDK errors

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1090,6 +1090,8 @@
   "Channel to show support as": "Channel to show support as",
   "This refundable boost will improve the discoverability of this %claimTypeText% while active. ": "This refundable boost will improve the discoverability of this %claimTypeText% while active. ",
   "Show this channel your appreciation by sending a donation in USD. ": "Show this channel your appreciation by sending a donation in USD. ",
+  "Boost transaction failed.": "Boost transaction failed.",
+  "Tip transaction failed.": "Tip transaction failed.",
   "Add a Card": "Add a Card",
   "To Tip Creators": "To Tip Creators",
   "Show this channel your appreciation by sending a donation of Credits. ": "Show this channel your appreciation by sending a donation of Credits. ",

--- a/ui/lbry.js
+++ b/ui/lbry.js
@@ -1,4 +1,5 @@
 // @flow
+import analytics from 'analytics';
 import { NO_AUTH, X_LBRY_AUTH_TOKEN } from 'constants/token';
 
 require('proxy-polyfill');
@@ -246,7 +247,12 @@ export function apiCall(method: string, params: ?{}, resolve: Function, reject: 
       const error = response.error || (response.result && response.result.error);
       return error ? reject(error) : resolve(response.result);
     })
-    .catch(reject);
+    .catch((err) => {
+      if (err.message === 'Failed to fetch') {
+        analytics.error(`\`${method}\`: Failed to fetch`);
+      }
+      return reject(err);
+    });
 }
 
 function daemonCallWithResult(

--- a/ui/redux/actions/wallet.js
+++ b/ui/redux/actions/wallet.js
@@ -388,10 +388,19 @@ export function doSendTip(params, isSupport, successCallback, errorCallback, sho
     };
 
     const error = (err) => {
+      const baseMsg = isSupport ? __('Boost transaction failed.') : __('Tip transaction failed.');
+      const errMsg = typeof err === 'object' ? err.message : err;
+
+      // For now, spew to console for persistence until the Status Log component is ready.
+      // eslint-disable-next-line no-console
+      console.log(`${baseMsg}\n • ${errMsg}`);
+
       dispatch(
         doToast({
-          message: __(`There was an error sending support funds.`),
+          message: baseMsg,
+          subMessage: errMsg,
           isError: true,
+          duration: 'long',
         })
       );
 

--- a/ui/scss/component/_snack-bar.scss
+++ b/ui/scss/component/_snack-bar.scss
@@ -79,7 +79,7 @@
 }
 
 .snack-bar__messageText--sub {
-  font-size: var(--font-small);
+  font-size: var(--font-xsmall);
   color: var(--color-text-subtitle);
 }
 


### PR DESCRIPTION
_Putting this up in `kp` for experimenting. Not being able to reproduce the SDK timeout makes it hard to confirm things.
Also, my initial design to make long pending calls visible in the GUI didn't work well, so back to drawing board for now (but that's just an enhancement)._

## Details
- Errors like "unexpected token at..." and "failed to fetch" are being logged, rather than the actual call error.
- Attempt to make the logs more helpful, and the error message more meaningful to the user.
- Starting off with `publish` SDK call as an experiment. Can add others if this method works.

Inline with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_that_the_fetch_was_successful.