### PR TITLE
Don't run filters unless necessary

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -114,14 +114,18 @@ export default function ClaimList(props: Props) {
   const urisLength = (uris && uris.length) || 0;
 
   let tileUris = (prefixUris || []).concat(uris || []);
-  tileUris = tileUris.filter((uri) => !excludeUris.includes(uri));
+
+  if (excludeUris && excludeUris.length) {
+    tileUris = tileUris.filter((uri) => !excludeUris.includes(uri));
+  }
+
   if (prefixUris && prefixUris.length) tileUris.splice(prefixUris.length * -1, prefixUris.length);
 
   const totalLength = tileUris.length;
 
   if (maxClaimRender) tileUris = tileUris.slice(0, maxClaimRender);
 
-  let sortedUris = (urisLength > 0 && (currentSort === SORT_NEW ? tileUris : tileUris.slice().reverse())) || [];
+  const sortedUris = (urisLength > 0 && (currentSort === SORT_NEW ? tileUris : tileUris.slice().reverse())) || [];
 
   React.useEffect(() => {
     if (typeof loadedCallback === 'function') loadedCallback(totalLength);


### PR DESCRIPTION
The loop was executed over the entire `tileUris` regardless of whether `excludeUris` existed.
