### PR TITLE
Following Page: fix redundant livestream data passed in

### DIFF
--- a/ui/page/channelsFollowing/view.jsx
+++ b/ui/page/channelsFollowing/view.jsx
@@ -56,7 +56,6 @@ function ChannelsFollowingPage(props: Props) {
           )}
 
           <ClaimListDiscover
-            prefixUris={getLivestreamUris(activeLivestreams, channelIds)}
             hideAdvancedFilter={SIMPLE_SITE}
             streamType={SIMPLE_SITE ? CS.CONTENT_ALL : undefined}
             tileLayout={tileLayout}


### PR DESCRIPTION
Clean up for 17a9b84d

We are now using `subSection` for livestreams, so no point passing in `prefixUris`, which causes additional processing.

(It wasn't visible because `showNoSourceClaims` was removed, but processing still happens).
