### PR TITLE
Sidebar: handle stray separator on empty section

### DIFF
--- a/ui/scss/component/_navigation.scss
+++ b/ui/scss/component/_navigation.scss
@@ -89,6 +89,10 @@
   ul {
     padding-bottom: var(--spacing-s);
   }
+
+  ul:empty {
+    display: none;
+  }
 }
 
 .navigation-touch {


### PR DESCRIPTION
"Lists" section is only for authenticated, and causes stray separator line and padding
