### PR TITLE
Fix sidebar active subs not batch-resolving

### DIFF
--- a/ui/redux/actions/subscriptions.js
+++ b/ui/redux/actions/subscriptions.js
@@ -1,9 +1,9 @@
 // @flow
-import Lbry from 'lbry';
 import * as ACTIONS from 'constants/action_types';
 import { SIDEBAR_SUBS_DISPLAYED } from 'constants/subscriptions';
 import REWARDS from 'rewards';
 import { Lbryio } from 'lbryinc';
+import { doClaimSearch } from 'redux/actions/claims';
 import { doClaimRewardType } from 'redux/actions/rewards';
 import { getChannelFromClaim } from 'util/claim';
 import { parseURI } from 'util/lbryURI';
@@ -128,11 +128,13 @@ export function doFetchLastActiveSubs(forceFetch: boolean = false, count: number
       order_by: ['release_time'],
     };
 
-    Lbry.claim_search(searchOptions)
-      .then((result) => {
+    dispatch(doClaimSearch(searchOptions))
+      .then((results) => {
+        const values = Object.values(results || {});
         dispatch({
           type: ACTIONS.FETCH_LAST_ACTIVE_SUBS_DONE,
-          data: result.items.map((claim) => getChannelFromClaim(claim)),
+          // $FlowFixMe https://github.com/facebook/flow/issues/2221
+          data: values.map((v) => getChannelFromClaim(v.stream)),
         });
       })
       .catch(() => {

--- a/ui/redux/reducers/subscriptions.js
+++ b/ui/redux/reducers/subscriptions.js
@@ -82,7 +82,7 @@ export default handleActions(
       if (activeChannelClaims && activeChannelClaims.length > 0) {
         const subs = [];
         activeChannelClaims.forEach((claim) => {
-          const index = state.subscriptions.findIndex((sub) => isURIEqual(sub.uri, claim.permanent_url));
+          const index = state.subscriptions.findIndex((sub) => isURIEqual(sub.uri, claim?.permanent_url));
           if (index !== -1) {
             subs.push(state.subscriptions[index]);
           }


### PR DESCRIPTION
`Lbry.claim_search` was used, so it doesn't save the resolved results to redux. Use `doClaimSearch`.
