### PR TITLE
More sidebar optimizations

### DIFF
--- a/ui/component/app/index.js
+++ b/ui/component/app/index.js
@@ -10,9 +10,8 @@ import {
   selectHomepageFetched,
 } from 'redux/selectors/user';
 import { selectUnclaimedRewards } from 'redux/selectors/rewards';
-import { doFetchChannelListMine, doFetchCollectionListMine, doResolveUris } from 'redux/actions/claims';
+import { doFetchChannelListMine, doFetchCollectionListMine } from 'redux/actions/claims';
 import { selectMyChannelClaimIds } from 'redux/selectors/claims';
-import { selectSubscriptions } from 'redux/selectors/subscriptions';
 import { selectLanguage, selectLoadedLanguages, selectThemePath } from 'redux/selectors/settings';
 import {
   selectIsUpgradeAvailable,
@@ -46,7 +45,6 @@ const select = (state) => ({
   syncFatalError: selectSyncFatalError(state),
   activeChannelClaim: selectActiveChannelClaim(state),
   myChannelClaimIds: selectMyChannelClaimIds(state),
-  subscriptions: selectSubscriptions(state),
   hasPremiumPlus: selectOdyseeMembershipIsPremiumPlus(state),
   homepageFetched: selectHomepageFetched(state),
 });
@@ -62,7 +60,6 @@ const perform = (dispatch) => ({
   setActiveChannelIfNotSet: () => dispatch(doSetActiveChannel()),
   setIncognito: () => dispatch(doSetIncognito()),
   fetchModBlockedList: () => dispatch(doFetchModBlockedList()),
-  resolveUris: (uris) => dispatch(doResolveUris(uris)),
   fetchModAmIList: () => dispatch(doFetchCommentModAmIList()),
 });
 

--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -336,6 +336,10 @@ function SideNavigation(props: Props) {
           lastActiveSubs && lastActiveSubs.length > 0 ? lastActiveSubs : subscriptions.slice(0, SIDEBAR_SUBS_DISPLAYED);
       }
 
+      if (lastActiveSubs === undefined) {
+        return null; // Don't show yet, just wait to save some renders
+      }
+
       return (
         <ul className="navigation__secondary navigation-links">
           {subscriptions.length > SIDEBAR_SUBS_DISPLAYED && (

--- a/ui/redux/actions/subscriptions.js
+++ b/ui/redux/actions/subscriptions.js
@@ -118,6 +118,14 @@ export function doFetchLastActiveSubs(forceFetch: boolean = false, count: number
     const channelIds = subscriptions.map((sub) => parseIdFromUri(sub.uri));
     activeSubsLastFetchedTime = now;
 
+    if (channelIds.length === 0) {
+      dispatch({
+        type: ACTIONS.FETCH_LAST_ACTIVE_SUBS_DONE,
+        data: [],
+      });
+      return;
+    }
+
     const searchOptions = {
       limit_claims_per_channel: 1,
       channel_ids: channelIds,


### PR DESCRIPTION
- Remove the odd resolve call that's lingering in `App`. Feels out of place, plus we don't need it now since the "active subs" claim_search would contain resolved results.
- Don't search for active subs if Following count is zero.
