### PR TITLE
Outbrain: remove visibility delay

### DIFF
--- a/ui/effects/use-ad-outbrain.js
+++ b/ui/effects/use-ad-outbrain.js
@@ -20,32 +20,12 @@ export default function useAdOutbrain(hasPremiumPlus: boolean, isAuthenticated: 
   // when returned as false
   const isNotAuthenticated = isAuthenticated === false;
 
-  function loadListener() {
-    const container = window[OUTBRAIN_CONTAINER_KEY];
-    if (container) {
-      // Hide it immediately while we wait for ads to be filled. This prevents
-      // the invisible container from blocking our content.
-      container.style.visibility = 'hidden';
-      container.style.zIndex = '800'; // any value below $nag-z-index
-
-      // Restore visibility after confirming the ad is filled. If it is filled
-      // after the stipulated time, well, no soup for you.
-      setTimeout(() => {
-        const filledAd = document.querySelector('.ob-widget-items-container');
-        if (filledAd && isNotAuthenticated) {
-          container.style.visibility = 'visible';
-        }
-      }, 5000); // 3s is sufficient for Chrome, but Firefox seems to take ~5s
-    }
-  }
-
   React.useEffect(() => {
     if (!inIFrame() && isNotAuthenticated && !script) {
       const loadTimer = setTimeout(() => {
         script = document.createElement('script');
         script.src = 'https://adncdnend.azureedge.net/adtags/odysee.adn.js';
         script.async = true;
-        script.addEventListener('load', loadListener); // not using 'script.onload'; seem unreliable with async.
 
         // $FlowFixMe
         document.body.appendChild(script);


### PR DESCRIPTION
They have removed the blocking transparent container when ads are not (or not yet) filled.

Test: `kp` (soon)
