### PR TITLE
Batch resolve with claim_search | [Recommended, Comments]

### DIFF
--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -48,7 +48,7 @@ export function doResolveUris(
     });
 
     if (urisToResolve.length === 0) {
-      return;
+      return Promise.resolve();
     }
 
     dispatch({
@@ -157,7 +157,7 @@ export function doResolveClaimIds(claimIds: Array<string>) {
     const idsToResolve = claimIds.filter((x) => !resolvedIds.includes(x));
 
     if (idsToResolve.length === 0) {
-      return;
+      return Promise.resolve();
     }
 
     return dispatch(


### PR DESCRIPTION
Ticket: #1189
Test: `kp`

## Issue
There is a bug in a batched `resolve` that returns jumbled data. Temporarily switch to `claim_search` until that is fixed.

## Notable differences:
- `resolve` will tell us directly that a claim has been removed or filtered, so redux will mark the ID as such. `claim_search` simply returns nothing, so we will still end up with an extra `resolve` for these items when the component tries to display it.

- The new function currently does not handle Collections (i.e. resolving individual items in the Collection) and Reposts. Given that this is temporarily, I'd like to leave `doClaimSearch` as is, instead of trying to replicate what's in `doResolveUris`.

## Code Notes:
- Since we don't care if the resolve fails (and we weren't doing anything in the `catch` anyways), use `finally` instead.
- There is some DRY violation in `doSearch`, but it's written that way to allow easy removal later without changing the owner of the original line in git.

----

@saltrafael, can help take a look, especially on comments?  Wasn't sure how the original double `doResolveUris` work.
