### PR TITLE
tus: retry only after 2-minute wait

### DIFF
--- a/ui/component/webUploadList/internal/web-upload-item.jsx
+++ b/ui/component/webUploadList/internal/web-upload-item.jsx
@@ -82,7 +82,7 @@ export default function WebUploadItem(props: Props) {
       if (status) {
         switch (status) {
           case 'retry':
-            return __('Retrying...');
+            return __('Uploading...');
           case 'error':
             return __('Failed.');
           case 'conflict':

--- a/web/setup/publish-v2.js
+++ b/web/setup/publish-v2.js
@@ -70,7 +70,7 @@ export function makeResumableUploadRequest(
     const uploader = new tus.Upload(file, {
       ...urlOptions,
       chunkSize: UPLOAD_CHUNK_SIZE_BYTE,
-      retryDelays: [40000, 60000],
+      retryDelays: [122000],
       parallelUploads: 1,
       storeFingerprintForResuming: false,
       urlStorage: new NoopUrlStorage(),


### PR DESCRIPTION
There is anecdote that we need to wait up to 2 minutes to preven the locking scenario.
`https://github.com/tus/tusd/pull/667#issuecomment-1079647640`

## Change
Instead of multiple retries at short intervals, do a one-time retry after a 2-minute wait. We'll do this until the fix is available in tusd v2.

Not showing that we are retrying in the GUI, since 2 minutes could be long. Just retain the "Uploading..." text.

Added 2 extra seconds for good measure.