### PR TITLE
Fix outbrain not removed after auth'd

### DIFF
--- a/ui/effects/use-ad-outbrain.js
+++ b/ui/effects/use-ad-outbrain.js
@@ -10,7 +10,7 @@ function inIFrame() {
 }
 
 const LOAD_AD_DELAY_MS = 3000; // Wait past boot-up and core-vitals period.
-const OUTBRAIN_CONTAINER_KEY = 'outbrainStickyParent';
+const OUTBRAIN_CONTAINER_KEY = 'outbrainSizeDiv';
 
 let script;
 


### PR DESCRIPTION
https://discord.com/channels/362322208485277697/363087331475062785/958695965798301716

The variable name changed. This seems to be the only one left.

Perhaps we need a formal method from Outbrain for removal?
