### PR TITLE
Fix failing video position reset

### DIFF
--- a/flow-typed/content.js
+++ b/flow-typed/content.js
@@ -1,5 +1,21 @@
 // @flow
 
+declare type ContentState = {
+  primaryUri: ?string,
+  playingUri: {}, // Someone please fill in.
+  positions: { [string]: { [string]: number } }, // claimId: { outpoint: position }
+  history: Array<WatchHistory>,
+  recommendationId: { [string]: string }, // claimId: recommendationId
+  recommendationParentId: { [string]: string}, // claimId: referrerId
+  recommendationUrls: { [string]: Array<string>}, // claimId: [lbryUrls...]
+  recommendationClicks: { [string]: Array<number>}, // "claimId": [clicked indices...]
+};
+
+declare type WatchHistory = {
+  uri: string,
+  lastViewed: number,
+};
+
 declare type PlayingUri = {
   uri?: ?string,
   primaryUri?: string,

--- a/ui/component/socialShare/index.js
+++ b/ui/component/socialShare/index.js
@@ -3,7 +3,7 @@ import { doFetchInviteStatus } from 'redux/actions/user';
 import { makeSelectClaimForUri, selectTitleForUri } from 'redux/selectors/claims';
 import SocialShare from './view';
 import { selectUserInviteReferralCode, selectUser, selectUserInviteStatusFetched } from 'redux/selectors/user';
-import { makeSelectContentPositionForUri } from 'redux/selectors/content';
+import { selectContentPositionForUri } from 'redux/selectors/content';
 
 const select = (state, props) => ({
   claim: makeSelectClaimForUri(props.uri)(state),
@@ -11,7 +11,7 @@ const select = (state, props) => ({
   referralCode: selectUserInviteReferralCode(state),
   user: selectUser(state),
   title: selectTitleForUri(state, props.uri),
-  position: makeSelectContentPositionForUri(props.uri)(state),
+  position: selectContentPositionForUri(state, props.uri),
 });
 
 const perform = {

--- a/ui/component/viewers/videoViewer/index.js
+++ b/ui/component/viewers/videoViewer/index.js
@@ -17,7 +17,7 @@ import {
 } from 'redux/actions/app';
 import { selectVolume, selectMute } from 'redux/selectors/app';
 import { savePosition, clearPosition, doPlayUri, doSetPlayingUri } from 'redux/actions/content';
-import { makeSelectContentPositionForUri, makeSelectIsPlayerFloating, selectPlayingUri } from 'redux/selectors/content';
+import { makeSelectIsPlayerFloating, selectContentPositionForUri, selectPlayingUri } from 'redux/selectors/content';
 import { selectRecommendedContentForUri } from 'redux/selectors/search';
 import VideoViewer from './view';
 import { withRouter } from 'react-router';
@@ -35,7 +35,7 @@ const select = (state, props) => {
   const claim = selectClaimForUri(state, uri);
 
   // TODO: eventually this should be received from DB and not local state (https://github.com/lbryio/lbry-desktop/issues/6796)
-  const position = urlParams.get('t') !== null ? urlParams.get('t') : makeSelectContentPositionForUri(uri)(state);
+  const position = urlParams.get('t') !== null ? urlParams.get('t') : selectContentPositionForUri(state, uri);
   const userId = selectUser(state) && selectUser(state).id;
   const internalFeature = selectUser(state) && selectUser(state).internal_feature;
   const playingUri = selectPlayingUri(state);

--- a/ui/page/file/index.js
+++ b/ui/page/file/index.js
@@ -13,7 +13,7 @@ import * as COLLECTIONS_CONSTS from 'constants/collections';
 import * as SETTINGS from 'constants/settings';
 import { selectCostInfoForUri, doFetchCostInfoForUri } from 'lbryinc';
 import { selectShowMatureContent, selectClientSetting } from 'redux/selectors/settings';
-import { makeSelectFileRenderModeForUri, makeSelectContentPositionForUri } from 'redux/selectors/content';
+import { makeSelectFileRenderModeForUri, selectContentPositionForUri } from 'redux/selectors/content';
 import { selectCommentsListTitleForUri, selectSettingsByChannelId } from 'redux/selectors/comments';
 import { DISABLE_COMMENTS_TAG } from 'constants/tags';
 import { getChannelIdFromClaim } from 'util/claim';
@@ -42,7 +42,7 @@ const select = (state, props) => {
     isLivestream: selectIsStreamPlaceholderForUri(state, uri),
     hasCollectionById: Boolean(makeSelectCollectionForId(collectionId)(state)),
     collectionId,
-    position: makeSelectContentPositionForUri(uri)(state),
+    position: selectContentPositionForUri(state, uri),
     commentsListTitle: selectCommentsListTitleForUri(state, uri),
   };
 };

--- a/ui/page/file/index.js
+++ b/ui/page/file/index.js
@@ -43,6 +43,7 @@ const select = (state, props) => {
     hasCollectionById: Boolean(makeSelectCollectionForId(collectionId)(state)),
     collectionId,
     position: selectContentPositionForUri(state, uri),
+    audioVideoDuration: claim?.value?.video?.duration || claim?.value?.audio?.duration,
     commentsListTitle: selectCommentsListTitleForUri(state, uri),
   };
 };

--- a/ui/page/file/view.jsx
+++ b/ui/page/file/view.jsx
@@ -40,6 +40,7 @@ type Props = {
   contentCommentsDisabled: boolean,
   isLivestream: boolean,
   position: number,
+  audioVideoDuration: ?number,
   commentsListTitle: string,
   settingsByChannelId: { [channelId: string]: PerChannelSettings },
   isPlaying?: boolean,
@@ -68,6 +69,7 @@ export default function FilePage(props: Props) {
     collectionId,
     isLivestream,
     position,
+    audioVideoDuration,
     commentsListTitle,
     settingsByChannelId,
     doFetchCostInfoForUri,
@@ -87,13 +89,15 @@ export default function FilePage(props: Props) {
   const hasFileInfo = fileInfo !== undefined;
   const isMarkdown = renderMode === RENDER_MODES.MARKDOWN;
   const videoPlayedEnoughToResetPosition = React.useMemo(() => {
+    // I've never seen 'fileInfo' contain metadata lately, but retaining as historical fallback.
     const durationInSecs =
-      fileInfo && fileInfo.metadata && fileInfo.metadata.video ? fileInfo.metadata.video.duration : 0;
+      audioVideoDuration ||
+      (fileInfo && fileInfo.metadata && fileInfo.metadata.video ? fileInfo.metadata.video.duration : 0);
     const isVideoTooShort = durationInSecs <= 45;
     const almostFinishedPlaying = position / durationInSecs >= VIDEO_ALMOST_FINISHED_THRESHOLD;
 
     return durationInSecs ? isVideoTooShort || almostFinishedPlaying : false;
-  }, [fileInfo, position]);
+  }, [audioVideoDuration, fileInfo, position]);
 
   React.useEffect(() => {
     // always refresh file info when entering file page to see if we have the file

--- a/ui/redux/reducers/content.js
+++ b/ui/redux/reducers/content.js
@@ -1,16 +1,17 @@
+// @flow
 import * as ACTIONS from 'constants/action_types';
 
 const reducers = {};
-const defaultState = {
+const defaultState: ContentState = {
   primaryUri: null, // Top level content uri triggered from the file page
   playingUri: {},
   channelClaimCounts: {},
   positions: {},
   history: [],
-  recommendationId: {}, // { "claimId": "recommendationId" }
-  recommendationParentId: {}, // { "claimId": "referrerId" }
-  recommendationUrls: {}, // { "claimId": [lbryUrls...] }
-  recommendationClicks: {}, // { "claimId": [clicked indices...] }
+  recommendationId: {},
+  recommendationParentId: {},
+  recommendationUrls: {},
+  recommendationClicks: {},
 };
 
 reducers[ACTIONS.SET_PRIMARY_URI] = (state, action) =>
@@ -123,7 +124,7 @@ reducers[ACTIONS.CLEAR_CONTENT_HISTORY_ALL] = (state) => ({ ...state, history: [
 //   };
 // };
 
-export default function reducer(state = defaultState, action) {
+export default function reducer(state: ContentState = defaultState, action: any) {
   const handler = reducers[action.type];
   if (handler) return handler(state, action);
   return state;

--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -1,11 +1,11 @@
 // @flow
 import { createSelector } from 'reselect';
 import {
-  makeSelectClaimForUri,
   selectClaimsByUri,
   selectClaimIsNsfwForUri,
   selectClaimIsMineForUri,
   makeSelectContentTypeForUri,
+  selectClaimForUri,
 } from 'redux/selectors/claims';
 import { makeSelectMediaTypeForUri, makeSelectFileNameForUri } from 'redux/selectors/file_info';
 import { selectBalance } from 'redux/selectors/wallet';
@@ -55,15 +55,16 @@ export const makeSelectIsPlayerFloating = (location: UrlLocation) =>
     return true;
   });
 
-export const makeSelectContentPositionForUri = (uri: string) =>
-  createSelector(selectState, makeSelectClaimForUri(uri), (state, claim) => {
-    if (!claim) {
-      return null;
-    }
+export const selectContentPositionForUri = (state: State, uri: string) => {
+  const claim = selectClaimForUri(state, uri);
+  if (claim) {
     const outpoint = `${claim.txid}:${claim.nout}`;
     const id = claim.claim_id;
-    return state.positions[id] ? state.positions[id][outpoint] : null;
-  });
+    const positions = selectState(state).positions;
+    return positions[id] ? positions[id][outpoint] : null;
+  }
+  return null;
+};
 
 export const selectHistory = createSelector(selectState, (state) => state.history || []);
 


### PR DESCRIPTION
## Issue
Maybe related to https://github.com/OdyseeTeam/odysee-frontend/issues/99#issuecomment-1042384649

## Notes
`fileInfo` does not contain `metadata` anymore -- not sure what happened. With zero duration, `videoPlayedEnoughToResetPosition` was never true.

But the claim usually contains the duration already, so we can use that. There are some audio/video claims that don't, but those are a minority.

## Comments
First 2 comments are just cleanup work.