### PR TITLE
Swap pinnedUrls vs. pinnedClaimIds precedence

### DIFF
--- a/flow-typed/homepage.js
+++ b/flow-typed/homepage.js
@@ -19,7 +19,7 @@ declare type RowDataItem = {
   icon?: string,
   extra?: any,
   pinnedUrls?: Array<string>,
-  pinnedClaimIds?: Array<string>, // pinnedUrls takes precedence
+  pinnedClaimIds?: Array<string>, // takes precedence over pinnedUrls
   options?: {
     channelIds?: Array<string>,
     limitClaimsPerChannel?: number,

--- a/ui/effects/use-resolve-pins.js
+++ b/ui/effects/use-resolve-pins.js
@@ -18,9 +18,7 @@ export default function useResolvePins(props: Props) {
 
   React.useEffect(() => {
     if (resolvedPinUris === undefined && pins && !resolvingPinUris) {
-      if (pins.urls) {
-        doResolveUris(pins.urls, true).finally(() => setResolvedPinUris(pins.urls));
-      } else if (pins.claimIds) {
+      if (pins.claimIds) {
         // setResolvingPinUris is only needed for claim_search.
         // doResolveUris uses selectResolvingUris internally to prevent double call.
         setResolvingPinUris(true);
@@ -31,6 +29,8 @@ export default function useResolvePins(props: Props) {
         // next render cycle (redux would be updated by then). Pretty dumb.
         // $FlowFixMe: already checked for null `pins`, but flow can't see it when there's code above it? Wow.
         doResolveClaimIds(pins.claimIds).finally(() => setResolvingPinUris(false));
+      } else if (pins.urls) {
+        doResolveUris(pins.urls, true).finally(() => setResolvedPinUris(pins.urls));
       } else {
         setResolvedPinUris(null);
       }

--- a/ui/util/buildHomepage.js
+++ b/ui/util/buildHomepage.js
@@ -19,7 +19,7 @@ export type HomepageCat = {
   order?: string,
   tags?: Array<string>,
   pinnedUrls?: Array<string>,
-  pinnedClaimIds?: Array<string>, // pinnedUrls takes precedence
+  pinnedClaimIds?: Array<string>, // takes precedence over pinnedUrls
   mixIn?: Array<string>,
 };
 


### PR DESCRIPTION
pinnedUrls = resolve
pinnedClaimIds = claim_search

Make `pinnedClaimIds` take precedence for now, since the homepage is defining both to support Android.

For some reason, I previously made `pinnedUrls` the priority, thinking this should be the "correct" one to use when the SDK is fixed.
