### PR TITLE
Publish: handle failed 'notify' at the server

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 **/plugins/inline-attachment/**
+**/ui/constants/errors.js

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2230,5 +2230,6 @@
   "Active channel": "Active channel",
   "This account has livestreaming disabled, please reach out to hello@odysee.com for assistance.": "This account has livestreaming disabled, please reach out to hello@odysee.com for assistance.",
   "Attach images by pasting or drag-and-drop.": "Attach images by pasting or drag-and-drop.",
+  "There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.": "There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.",
   "--end--": "--end--"
 }

--- a/ui/constants/errors.js
+++ b/ui/constants/errors.js
@@ -1,2 +1,3 @@
 export const ALREADY_CLAIMED = 'once the invite reward has been claimed the referrer cannot be changed';
 export const REFERRER_NOT_FOUND = 'A odysee account could not be found for the referrer you provided.';
+export const PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL = 'There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.';

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -1,4 +1,5 @@
 // @flow
+import { PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL } from 'constants/errors';
 import * as MODALS from 'constants/modal_types';
 import * as ACTIONS from 'constants/action_types';
 import * as PAGES from 'constants/pages';
@@ -14,7 +15,7 @@ import {
   selectReflectingById,
 } from 'redux/selectors/claims';
 import { makeSelectPublishFormValue, selectPublishFormValues, selectMyClaimForUri } from 'redux/selectors/publish';
-import { doError } from 'redux/actions/notifications';
+import { doError, doToast } from 'redux/actions/notifications';
 import { push } from 'connected-react-router';
 import analytics from 'analytics';
 import { doOpenModal, doSetIncognito, doSetActiveChannel } from 'redux/actions/app';
@@ -282,7 +283,13 @@ export const doPublishDesktop = (filePath: string, preview?: boolean) => (dispat
     actions.push({
       type: ACTIONS.PUBLISH_FAIL,
     });
-    actions.push(doError({ message: error.message, cause: error.cause }));
+
+    if (error.message === PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL) {
+      actions.push(doToast({ message: error.message, duration: 'long' }));
+    } else {
+      actions.push(doError({ message: error.message, cause: error.cause }));
+    }
+
     dispatch(batchActions(...actions));
   };
 


### PR DESCRIPTION
Closes #1256

For `notify`, "file is currently locked" and "no such file or directory" is indication that the previous "failed" SDK call actually worked. Tell the user to check the transactions.

<img width="216" alt="image" src="https://user-images.githubusercontent.com/64950861/161484040-ed32ec6a-ed8a-41c8-8c99-843a45bf990f.png">

This is the band aid until odysee-api/401 is addressed.
