### PR TITLE
Remove abandoned claim from Uploads Page

### DIFF
--- a/ui/redux/reducers/claims.js
+++ b/ui/redux/reducers/claims.js
@@ -632,16 +632,24 @@ reducers[ACTIONS.ABANDON_CLAIM_SUCCEEDED] = (state: State, action: any): State =
   const { claimId }: { claimId: string } = action.data;
   const byId = Object.assign({}, state.byId);
   const newMyClaims = state.myClaims ? state.myClaims.slice() : [];
+  let myClaimsPageResults = null;
   const newMyChannelClaims = state.myChannelClaims ? state.myChannelClaims.slice() : [];
   const claimsByUri = Object.assign({}, state.claimsByUri);
   const abandoningById = Object.assign({}, state.abandoningById);
   const newMyCollectionClaims = state.myCollectionClaims ? state.myCollectionClaims.slice() : [];
 
+  let abandonedUris = [];
+
   Object.keys(claimsByUri).forEach((uri) => {
     if (claimsByUri[uri] === claimId) {
+      abandonedUris.push(uri);
       delete claimsByUri[uri];
     }
   });
+
+  if (abandonedUris.length > 0 && state.myClaimsPageResults) {
+    myClaimsPageResults = state.myClaimsPageResults.filter((uri) => !abandonedUris.includes(uri));
+  }
 
   if (abandoningById[claimId]) {
     delete abandoningById[claimId];
@@ -660,6 +668,7 @@ reducers[ACTIONS.ABANDON_CLAIM_SUCCEEDED] = (state: State, action: any): State =
     byId,
     claimsByUri,
     abandoningById,
+    myClaimsPageResults: myClaimsPageResults || state.myClaimsPageResults,
   });
 };
 


### PR DESCRIPTION
## Issue
Ticket: #108

## Interesting
Uploads Page uses `claim_list`
Channel Page uses `claim_search`

A second `claim_list` would instantly show updated results, but `claim_search` takes a long while to reflect the deletion.  If both are waiting for a transaction, why did `claim_list` work as expected?

## Change
This PR only handles the `claim_list` (Uploads Page).

## Aside
The `claim_search` version would be troublesome to handle. If a refresh would bring back the results (due to the `claim_search` slow update behavior), we would need to store the deleted claim persistently. Then ...
  - Store where? rehydrate?
  - When to clear?
  - How to make each `ClaimList` filter this out without polluting the code? etc.

...will be messy. Feels easier to "fix" at the `claim_search` to make it update faster like `claim_list`.
