### PR TITLE
Fix `Paginate` click area

### DIFF
--- a/ui/page/fileListPublished/view.jsx
+++ b/ui/page/fileListPublished/view.jsx
@@ -4,6 +4,7 @@ import * as ICONS from 'constants/icons';
 import React, { useEffect } from 'react';
 import Button from 'component/button';
 import ClaimList from 'component/claimList';
+import ClaimPreview from 'component/claimPreview';
 import Page from 'component/page';
 import Paginate from 'component/common/paginate';
 import { PAGE_PARAM, PAGE_SIZE_PARAM } from 'constants/claim';
@@ -106,7 +107,6 @@ function FileListPublished(props: Props) {
               }
               headerAltControls={
                 <div className="card__actions--inline">
-                  {fetching && <Spinner type="small" />}
                   {!fetching && (
                     <Button
                       button="alt"
@@ -125,8 +125,11 @@ function FileListPublished(props: Props) {
                 </div>
               }
               persistedStorageKey="claim-list-published"
-              uris={urls}
+              uris={fetching ? [] : urls}
+              loading={fetching}
             />
+            {fetching &&
+              new Array(Number(pageSize)).fill(1).map((x, i) => <ClaimPreview key={i} placeholder="loading" />)}
             <Paginate totalPages={urlTotal > 0 ? Math.ceil(urlTotal / Number(pageSize)) : 1} />
           </>
         )}

--- a/ui/scss/component/_pagination.scss
+++ b/ui/scss/component/_pagination.scss
@@ -42,7 +42,7 @@
   }
 
   > a {
-    display: inline-block;
+    display: block;
     height: 100%;
     margin-top: 1px;
   }


### PR DESCRIPTION
## Issue
Closes #1257

The hit-area is just extremely small (just the text) and apparently due to an accessibility issue.
```
https://github.com/AdeleD/react-paginate/issues/125#issuecomment-276625181
```
_<sup>(Not creating a link to avoid unnecessary mention)</sup>_

## Change
Changed the css as suggested by the maintainer.

Rave, any potential side effects (e.g. accesibility?).  Seems to work with keyboard.
