### PR TITLE
VerifyPage: better handling of errors

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2231,5 +2231,8 @@
   "This account has livestreaming disabled, please reach out to hello@odysee.com for assistance.": "This account has livestreaming disabled, please reach out to hello@odysee.com for assistance.",
   "Attach images by pasting or drag-and-drop.": "Attach images by pasting or drag-and-drop.",
   "There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.": "There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.",
+  "Invalid email or verification token.": "Invalid email or verification token.",
+  "Invalid Recaptcha.": "Invalid Recaptcha.",
+  "Verification token expired.": "Verification token expired.",
   "--end--": "--end--"
 }

--- a/ui/page/signInVerify/index.js
+++ b/ui/page/signInVerify/index.js
@@ -1,10 +1,3 @@
-import { connect } from 'react-redux';
-import { doToast } from 'redux/actions/notifications';
 import SignInVerifyPage from './view';
 
-const select = () => ({});
-const perform = {
-  doToast,
-};
-
-export default connect(select, perform)(SignInVerifyPage);
+export default SignInVerifyPage;

--- a/ui/util/api-message.js
+++ b/ui/util/api-message.js
@@ -51,6 +51,18 @@ const MESSAGE_MAP: Array<ApiMsgConfig> = Object.freeze([
   //   originalMsg: /^Earn a random reward of at least 0.1 LBC for watching cool stuff at least 3 days during the week. You last claimed it (.*) ago!$/,
   //   replacement: 'Earn a random reward of at least 0.1 LBC for watching cool stuff at least 3 days during the week. You last claimed it %1% ago!',
   // },
+  {
+    originalMsg: 'invalid email or verification token',
+    replacement: 'Invalid email or verification token.',
+  },
+  {
+    originalMsg: 'invalid Recaptcha',
+    replacement: 'Invalid Recaptcha.',
+  },
+  {
+    originalMsg: 'verification token expired. Check your email for a new token',
+    replacement: 'Verification token expired.',
+  },
 ]);
 
 /**


### PR DESCRIPTION
1. Don't navigate to Sign Up page on error, because that causes the Sign Up Flow to start.
2. Relay the API's actual error, instead of a vague catch-all + Fix i18n
3. Toast is probably not a good choice since it is auto-dismissed. Show the error in the main card.
4. Fixed dependency: I think `push` shouldn't cause the error useEffect to run.
5. Avoid flashing of several messages through a delayed spinner.

Test: `kp`