### PR TITLE
Comments: don't show Expand button if no comments

### DIFF
--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -302,7 +302,7 @@ export default function CommentList(props: Props) {
 
           {!hasDefaultExpansion && (
             <div className="card__bottom-actions--comments">
-              {(!expandedComments || moreBelow) && (
+              {(!expandedComments || moreBelow) && totalComments > 0 && (
                 <Button
                   button="link"
                   title={!expandedComments ? __('Expand') : __('More')}
@@ -310,7 +310,7 @@ export default function CommentList(props: Props) {
                   onClick={() => (!expandedComments ? setExpandedComments(true) : setPage(page + 1))}
                 />
               )}
-              {expandedComments && (
+              {expandedComments && totalComments > 0 && (
                 <Button
                   button="link"
                   title={__('Collapse')}


### PR DESCRIPTION
## Issue
In Medium layout, the Expand/Collapse button would still appear even for 0 comments.

## Approach
Hide the button when comments = 0, but didn't hide the section because the separator line feels useful as a visual guide to mark the sections.


@saltrafael, take a look just in case I broke the logic for other scenarios?