### PR TITLE
Skip 'include_is_my_output' for Incognito

### DIFF
--- a/ui/page/show/index.js
+++ b/ui/page/show/index.js
@@ -13,6 +13,7 @@ import {
   makeSelectUrlsForCollectionId,
   makeSelectIsResolvingCollectionForId,
 } from 'redux/selectors/collections';
+import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { doResolveUri } from 'redux/actions/claims';
 import { doBeginPublish } from 'redux/actions/publish';
 import { doFetchItemsInCollection } from 'redux/actions/collections';
@@ -81,6 +82,7 @@ const select = (state, props) => {
     collectionId,
     collectionUrls: makeSelectUrlsForCollectionId(collectionId)(state),
     isResolvingCollection: makeSelectIsResolvingCollectionForId(collectionId)(state),
+    isAuthenticated: selectUserVerifiedEmail(state),
     geoRestriction: selectGeoRestrictionForUri(state, uri),
   };
 };

--- a/ui/page/show/view.jsx
+++ b/ui/page/show/view.jsx
@@ -35,6 +35,7 @@ type Props = {
   collection: Collection,
   collectionUrls: Array<string>,
   isResolvingCollection: boolean,
+  isAuthenticated: boolean,
   geoRestriction: ?GeoRestriction,
   doResolveUri: (uri: string, returnCached: boolean, resolveReposts: boolean, options: any) => void,
   doBeginPublish: (name: ?string) => void,
@@ -56,6 +57,7 @@ export default function ShowPage(props: Props) {
     collection,
     collectionUrls,
     isResolvingCollection,
+    isAuthenticated,
     geoRestriction,
     doResolveUri,
     doBeginPublish,
@@ -122,16 +124,27 @@ export default function ShowPage(props: Props) {
 
     if (
       (doResolveUri && !isResolvingUri && uri && haventFetchedYet) ||
-      (claimExists && !claimIsPending && (!canonicalUrl || isMine === undefined))
+      (claimExists && !claimIsPending && (!canonicalUrl || (isMine === undefined && isAuthenticated)))
     ) {
       doResolveUri(
         uri,
         false,
         true,
-        isMine === undefined ? { include_is_my_output: true, include_purchase_receipt: true } : {}
+        isMine === undefined && isAuthenticated ? { include_is_my_output: true, include_purchase_receipt: true } : {}
       );
     }
-  }, [doResolveUri, isResolvingUri, canonicalUrl, uri, claimExists, haventFetchedYet, isMine, claimIsPending, search]);
+  }, [
+    doResolveUri,
+    isResolvingUri,
+    canonicalUrl,
+    uri,
+    claimExists,
+    haventFetchedYet,
+    isMine,
+    claimIsPending,
+    search,
+    isAuthenticated,
+  ]);
 
   // Don't navigate directly to repost urls
   // Always redirect to the actual content


### PR DESCRIPTION
Ticket: #1180
Test: `kp` (after build)

I believe the original intention was "if a claim was previously resolved, but without authentication (no `is_my_output` data), then resolve again with `include_is_my_output`"

Update to exclude that logic for Incognito.

## Aside
The check for `!canonicalUrl` is interesting:
- Are there claims that really don't have `canonical_url`?  If yes, would that end up in an infinite `resolve` loop?

## Aside 2
For the duplicate call, it'll come in another PR after a solution is found (see comment in ticket)