### PR TITLE
Fix signout sequence not cleaning up correctly

### DIFF
--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -550,15 +550,13 @@ export function doSignOut() {
         .then(doSignOutCleanup)
         .then(() => {
           // @if TARGET='web'
-          window.persistor.purge();
+          return window.persistor.purge();
           // @endif
         })
-        .then(() => {
-          setTimeout(() => {
-            location.reload();
-          });
+        .catch((err) => {
+          analytics.error(`\`doSignOut\`: ${err.message || err}`);
         })
-        .catch(() => location.reload());
+        .finally(() => location.reload());
     }
   };
 }


### PR DESCRIPTION
Potentially closes #1319

## Note
- `persistor.purge` returns a promise, we should wait for the resolved results before reloading, instead of just adding an arbitrary `setTimeout`.
  - Perhaps the `setTimeout` method is to ignore a super-long or hanged purge (not sure), but it wouldn't be right since it would end up in a limbo state.
- Log errors to get clues for future.
- Reduced code by moving the reload to `finally`.
