### PR TITLE
Fix broken Search Page OG

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -321,7 +321,9 @@ async function getHtml(ctx) {
     html = fs.readFileSync(path.join(__dirname, '/../dist/index.html'), 'utf8');
   }
 
+  const query = ctx.query;
   const requestPath = unscapeHtmlProperty(decodeURIComponent(ctx.path));
+
   if (requestPath.length === 0) {
     const ogMetadata = buildBasicOgMetadata();
     return insertToHead(html, ogMetadata);
@@ -371,7 +373,7 @@ async function getHtml(ctx) {
 
   const categoryMetaFn = getCategoryMetaRenderFn(requestPath);
   if (categoryMetaFn) {
-    const categoryMeta = categoryMetaFn(ctx.request.query);
+    const categoryMeta = categoryMetaFn(query);
     const categoryPageMetadata = buildOgMetadata({
       ...categoryMeta,
       path: requestPath,


### PR DESCRIPTION
The changes to escape characters caused `ctx.query` to be nulled.

As a quick fix, stash that value early on.

Results (back to working state):
<img width="601" alt="image" src="https://user-images.githubusercontent.com/64950861/163175868-790392f6-8ad1-4b60-b096-cee571f26c5e.png">

Not sure if need to escape/un-escape the query string for this case.
<img width="400" alt="image" src="https://user-images.githubusercontent.com/64950861/163176151-9821d4d0-dd44-4985-8aaa-6f3a0dea15a6.png">
