### PR TITLE
Homepage API v2 -- includes 'meme'

### DIFF
--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -310,17 +310,31 @@ export function doFetchLanguage(language) {
 
 export function doFetchHomepages() {
   return (dispatch) => {
-    // -- Use this env flag to use local homepage data. Otherwise, it will grab from `/$/api/content/v1/get`.
+    // -- Use this env flag to use local homepage data. Otherwise, it will grab from `/$/api/content/v*/get`.
     // @if USE_LOCAL_HOMEPAGE_DATA='true'
     const homepages = require('homepages');
     if (homepages) {
-      window.homepages = homepages;
+      const v2 = {};
+      const homepageKeys = Object.keys(homepages);
+
+      homepageKeys.forEach((hp) => {
+        v2[hp] = {
+          categories: homepages[hp],
+        };
+      });
+
+      const meme = require('memes');
+      if (meme && v2['en']) {
+        v2['en'].meme = meme;
+      }
+
+      window.homepages = v2;
       dispatch({ type: ACTIONS.FETCH_HOMEPAGES_DONE });
       return;
     }
     // @endif
 
-    fetch('https://odysee.com/$/api/content/v1/get')
+    fetch('https://odysee.com/$/api/content/v2/get')
       .then((response) => response.json())
       .then((json) => {
         if (json?.status === 'success' && json?.data) {

--- a/ui/redux/selectors/settings.js
+++ b/ui/redux/selectors/settings.js
@@ -66,7 +66,7 @@ export const selectLanguage = (state) => {
 export const selectHomepageData = (state) => {
   const homepageCode = selectHomepageCode(state);
   const homepages = window.homepages;
-  return homepages ? homepages[homepageCode] || homepages['en'] || {} : {};
+  return homepages ? homepages[homepageCode].categories || homepages['en'].categories || {} : {};
 };
 
 export const selectInRegionByCode = (state, code) => {

--- a/web/component/meme.jsx
+++ b/web/component/meme.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import Button from 'component/button';
-const memes = require('memes');
 
 export default function Meme() {
+  const meme = window?.homepages?.en?.meme;
+  if (!meme) {
+    return null;
+  }
+
   return (
     <h1 className="home__meme">
-      <Button button="link" navigate={memes.url}>
-        {memes.text}
+      <Button button="link" navigate={meme.url}>
+        {meme.text}
       </Button>
     </h1>
   );

--- a/web/src/getHomepageJSON.js
+++ b/web/src/getHomepageJSON.js
@@ -1,13 +1,39 @@
 const memo = {};
+
 // this didn't seem to help.
 if (!memo.homepageData) {
   try {
     memo.homepageData = require('../../custom/homepages/v2');
+    memo.meme = require('../../custom/homepages/meme');
   } catch (err) {
-    console.log('homepage data failed');
+    console.log('getHomepageJSON:', err);
   }
 }
-const getHomepageJSON = () => {
+
+const getHomepageJsonV1 = () => {
   return memo.homepageData || {};
 };
-module.exports = { getHomepageJSON };
+
+const getHomepageJsonV2 = () => {
+  if (!memo.homepageData) {
+    return {};
+  }
+
+  const v2 = {};
+  const homepageKeys = Object.keys(memo.homepageData);
+
+  homepageKeys.forEach((hp) => {
+    v2[hp] = {
+      categories: memo.homepageData[hp],
+    };
+  });
+
+  if (memo.meme && v2['en']) {
+    // Only supporting English memes for now, but one-per-homepage is possible.
+    v2['en'].meme = memo.meme;
+  }
+
+  return v2;
+};
+
+module.exports = { getHomepageJsonV1, getHomepageJsonV2 };

--- a/web/src/homepageApi.js
+++ b/web/src/homepageApi.js
@@ -1,0 +1,27 @@
+const { CUSTOM_HOMEPAGE } = require('../../config');
+const { getHomepageJsonV1, getHomepageJsonV2 } = require('./getHomepageJSON');
+
+async function getHomepage(ctx, version) {
+  if (!CUSTOM_HOMEPAGE) {
+    ctx.status = 404;
+    ctx.body = { message: 'Not Found' };
+    return;
+  }
+
+  try {
+    const content = version === 1 ? getHomepageJsonV1() : getHomepageJsonV2();
+    ctx.set('Content-Type', 'application/json');
+    ctx.set('Access-Control-Allow-Origin', '*');
+    ctx.body = {
+      status: 'success',
+      data: content,
+    };
+  } catch (err) {
+    ctx.status = err.statusCode || err.status || 500;
+    ctx.body = {
+      message: err.message,
+    };
+  }
+}
+
+module.exports = { getHomepage };

--- a/web/src/html.js
+++ b/web/src/html.js
@@ -22,7 +22,7 @@ const {
 } = require('../../ui/util/web');
 const { getJsBundleId } = require('../bundle-id.js');
 const { lbryProxy: Lbry } = require('../lbry');
-const { getHomepageJSON } = require('./getHomepageJSON');
+const { getHomepageJsonV1 } = require('./getHomepageJSON');
 const { buildURI, parseURI, normalizeClaimUrl } = require('./lbryURI');
 const fs = require('fs');
 const moment = require('moment');
@@ -61,7 +61,7 @@ function truncateDescription(description, maxChars = 200) {
 }
 
 function getCategoryMeta(path) {
-  const homepage = getHomepageJSON();
+  const homepage = getHomepageJsonV1();
 
   if (path === `/$/${PAGES.WILD_WEST}` || path === `/$/${PAGES.WILD_WEST}/`) {
     return {

--- a/web/src/routes.js
+++ b/web/src/routes.js
@@ -1,6 +1,4 @@
-const { CUSTOM_HOMEPAGE } = require('../../config.js');
 const { generateStreamUrl } = require('../../ui/util/web');
-const { getHomepageJSON } = require('./getHomepageJSON');
 const { getHtml } = require('./html');
 const { getOEmbed } = require('./oEmbed');
 const { getRss } = require('./rss');
@@ -8,6 +6,7 @@ const { getTempFile } = require('./tempfile');
 
 const fetch = require('node-fetch');
 const Router = require('@koa/router');
+const { getHomepage } = require('./homepageApi');
 
 // So any code from 'lbry-redux'/'lbryinc' that uses `fetch` can be run on the server
 global.fetch = fetch;
@@ -39,30 +38,9 @@ const tempfileMiddleware = async (ctx) => {
   ctx.body = temp;
 };
 
-router.get(`/$/api/content/v1/get`, async (ctx) => {
-  if (!CUSTOM_HOMEPAGE) {
-    ctx.status = 404;
-    ctx.body = {
-      message: 'Not Found',
-    };
-  } else {
-    let content;
-    try {
-      content = getHomepageJSON();
-      ctx.set('Content-Type', 'application/json');
-      ctx.set('Access-Control-Allow-Origin', '*');
-      ctx.body = {
-        status: 'success',
-        data: content,
-      };
-    } catch (err) {
-      ctx.status = err.statusCode || err.status || 500;
-      ctx.body = {
-        message: err.message,
-      };
-    }
-  }
-});
+router.get(`/$/api/content/v1/get`, async (ctx) => getHomepage(ctx, 1));
+
+router.get(`/$/api/content/v2/get`, async (ctx) => getHomepage(ctx, 2));
 
 router.get(`/$/download/:claimName/:claimId`, async (ctx) => {
   const streamUrl = getStreamUrl(ctx);


### PR DESCRIPTION
## Ticket
Item 2 of [#1318](https://github.com/OdyseeTeam/odysee-homepages/issues/1318)

## Changes
- Had to create v2 as there is no backward-compatible location in the v1 json to place it.
- v2 allows any future expansion beyond 'categories' and 'meme'.
- One-meme-per-homepage is also supported, but not enabled for now.

Format:
<img width="342" alt="image" src="https://user-images.githubusercontent.com/64950861/163574016-fd9f70d2-a787-4962-82dc-908638ed5050.png">


