### PR TITLE
doCheckPublishNameAvailability: case-insensitive version

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1056,6 +1056,7 @@
   "Edit existing claim instead": "Edit existing claim instead",
   "You already have a claim at %existing_uri%. Publishing will update (overwrite) your existing claim.": "You already have a claim at %existing_uri%. Publishing will update (overwrite) your existing claim.",
   "You already have a pending upload at %existing_uri%.": "You already have a pending upload at %existing_uri%.",
+  "You already have an upload with that name.": "You already have an upload with that name.",
   "Save": "Save",
   "Saved": "Saved",
   "Saving...": "Saving...",

--- a/ui/component/publishName/index.js
+++ b/ui/component/publishName/index.js
@@ -16,6 +16,7 @@ const select = (state) => ({
   uri: makeSelectPublishFormValue('uri')(state),
   isStillEditing: selectIsStillEditing(state),
   myClaimForUri: selectMyClaimForUri(state),
+  myClaimForUriCaseInsensitive: selectMyClaimForUri(state, false),
   currentUploads: selectCurrentUploads(state),
   activeChannelClaim: selectActiveChannelClaim(state),
   incognito: selectIncognito(state),

--- a/ui/component/publishName/name-help-text.jsx
+++ b/ui/component/publishName/name-help-text.jsx
@@ -13,13 +13,14 @@ function isUriPendingUpload(uri: ?string, currentUploadNames: Array<string>) {
 type Props = {
   uri: ?string,
   myClaimForUri: ?StreamClaim,
+  myClaimForUriCaseInsensitive: ?StreamClaim,
   currentUploads: { [key: string]: FileUploadItem },
   isStillEditing: boolean,
   onEditMyClaim: (any, string) => void,
 };
 
 function NameHelpText(props: Props) {
-  const { uri, myClaimForUri, currentUploads, onEditMyClaim, isStillEditing } = props;
+  const { uri, myClaimForUri, myClaimForUriCaseInsensitive, currentUploads, onEditMyClaim, isStillEditing } = props;
 
   const currentUploadNames: Array<string> = React.useMemo(() => {
     // $FlowFixMe - unable to resolve mixed
@@ -67,6 +68,8 @@ function NameHelpText(props: Props) {
         />
       </React.Fragment>
     );
+  } else if (uri && myClaimForUriCaseInsensitive) {
+    nameHelpText = <div className="error__text">{__('You already have an upload with that name.')}</div>;
   }
 
   return (

--- a/ui/component/publishName/view.jsx
+++ b/ui/component/publishName/view.jsx
@@ -11,6 +11,7 @@ type Props = {
   uri: string,
   isStillEditing: boolean,
   myClaimForUri: ?StreamClaim,
+  myClaimForUriCaseInsensitive: ?StreamClaim,
   amountNeededForTakeover: number,
   prepareEdit: ({}, string) => void,
   updatePublishForm: ({}) => void,
@@ -25,6 +26,7 @@ function PublishName(props: Props) {
     uri,
     isStillEditing,
     myClaimForUri,
+    myClaimForUriCaseInsensitive,
     prepareEdit,
     updatePublishForm,
     activeChannelClaim,
@@ -86,6 +88,7 @@ function PublishName(props: Props) {
           uri={uri}
           isStillEditing={isStillEditing}
           myClaimForUri={myClaimForUri}
+          myClaimForUriCaseInsensitive={myClaimForUriCaseInsensitive}
           currentUploads={currentUploads}
           onEditMyClaim={editExistingClaim}
         />


### PR DESCRIPTION
## Issue
??

## Ticket
https://odysee-workspace.slack.com/archives/D02EKAWJ8EB/p1650218769018309?thread_ts=1649984883.723529&cid=D02EKAWJ8EB

## Test
`kp`

## Behavioral Changes
- Use "`claim_search` + all own channel IDs" instead of `claim_list` to retrieve all all own claims with the same name (case-insensitive).
  - Caveat: annonymous claims will be excluded.
- When a clash occurs, there is a possibility that we have multiple existing entries (e.g. "xxX", "xXx"). Since we don't know which one is best to fall back, I removed the "edit" button for this case and replaced with a simpler text

## Code Note
- If not mistaken, the rest of the code still needs `selectMyClaimForUri` to be case-sensitive, so augment the selector to support both through an optional parameter.