### PR TITLE
Fix hidden purchases through embeds

### DIFF
--- a/ui/page/embedWrapper/view.jsx
+++ b/ui/page/embedWrapper/view.jsx
@@ -142,10 +142,10 @@ export default function EmbedWrapperPage(props: Props) {
       doResolveUri(uri);
     }
 
-    if (uri && haveClaim && !hasCost) {
+    if (uri && haveClaim && costInfo && costInfo.cost === 0) {
       doPlayUri(uri);
     }
-  }, [doPlayUri, doResolveUri, hasCost, haveClaim, uri]);
+  }, [doPlayUri, doResolveUri, haveClaim, costInfo, uri]);
 
   React.useEffect(() => {
     if (haveClaim && uri && doFetchCostInfoForUri) {


### PR DESCRIPTION
## Issue
Closes #1345

## Change
The refactor in  [04c5ac46](https://github.com/OdyseeTeam/odysee-frontend/commit/04c5ac460bd3c3e391b26d32f61a3bc9fa7eac4c#diff-7cad9126bc5596b95beaee0e28af64ea74e73ab38d583fbdb3907c0abc2e0856R158) broke the logic, because `!hasCost` would incorrectly include an undefined `costInfo` (haven't fetched) as free content.
