### PR TITLE
Ad: change to 'insert' mode in Mobile layout.

### DIFF
--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -169,7 +169,7 @@ function HomePage(props: Props) {
         injectedItem={
           index === 0 && {
             node: <Ads small type="video" tileLayout />,
-            replace: adBlockerFound === false,
+            replace: adBlockerFound === false && isLargeScreen,
           }
         }
         forceShowReposts={id !== 'FOLLOWING'}


### PR DESCRIPTION
## Ticket
Closes #1074 (band-aid)
In mobile, the second livestream tile in Following gets missing because of the Ad being in 'replace' mode.

## Change
Switch from 'replace' to 'insert' mode in Mobile layout.

If missing (replaced) tiles is a problem, the true fix would be to always use 'insert' mode, and either live with the uneven tiles, or wait for our design master's solution.
