### PR TITLE
ClaimPreviewTiles: hide abandoned tiles by default

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -231,6 +231,7 @@ export default function ClaimList(props: Props) {
               <ClaimPreviewTile
                 uri={uri}
                 showHiddenByUser={showHiddenByUser}
+                showUnresolvedClaims={showUnresolvedClaims}
                 properties={renderProperties}
                 collectionId={collectionId}
                 fypId={fypId}

--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -45,10 +45,11 @@ type Props = {
   isMature: boolean,
   showMature: boolean,
   showHiddenByUser?: boolean,
+  showNoSourceClaims?: boolean,
+  showUnresolvedClaims?: boolean,
   properties?: (Claim) => void,
   collectionId?: string,
   fypId?: string,
-  showNoSourceClaims?: boolean,
   isLivestream: boolean,
   viewCount: string,
   isLivestreamActive: boolean,
@@ -76,6 +77,7 @@ function ClaimPreviewTile(props: Props) {
     showHiddenByUser,
     properties,
     showNoSourceClaims,
+    showUnresolvedClaims,
     isLivestream,
     isLivestreamActive,
     livestreamViewerCount,
@@ -88,6 +90,7 @@ function ClaimPreviewTile(props: Props) {
   const isRepost = claim && claim.repost_channel_url;
   const isCollection = claim && claim.value_type === 'collection';
   const isStream = claim && claim.value_type === 'stream';
+  const isAbandoned = !isResolvingUri && !claim;
   // $FlowFixMe
   const isPlayable =
     claim &&
@@ -150,7 +153,10 @@ function ClaimPreviewTile(props: Props) {
     shouldHide = true;
   } else {
     shouldHide =
-      banState.blacklisted || banState.filtered || (!showHiddenByUser && (banState.muted || banState.blocked));
+      banState.blacklisted ||
+      banState.filtered ||
+      (!showHiddenByUser && (banState.muted || banState.blocked)) ||
+      (isAbandoned && !showUnresolvedClaims);
   }
 
   if (shouldHide || (isLivestream && !showNoSourceClaims)) {

--- a/ui/component/collectionsListMine/view.jsx
+++ b/ui/component/collectionsListMine/view.jsx
@@ -129,6 +129,7 @@ export default function CollectionsListMine(props: Props) {
                     key={list.name}
                     uris={itemUrls.slice(0, 6)}
                     collectionId={list.id}
+                    showUnresolvedClaims
                   />
                 </>
               )}


### PR DESCRIPTION
## Ticket
Closes #1308, Closes #1363

## Change
Ported the `isAbandoned` handling from the list-layout to the tile-layout (yet another grumble on why tile vs. list is not just a css difference but an entire different component).

## Misc
Because "ClaimList + tileLayout" was showing abandoned claims by default all this while, searched around to see if it was still needed. I think only `collectionsListMine` would require that (or maybe not, can remove later).
