### PR TITLE
LivestreamLink: fix flicker when a child updates

### DIFF
--- a/ui/component/livestreamLink/view.jsx
+++ b/ui/component/livestreamLink/view.jsx
@@ -15,7 +15,11 @@ export default function LivestreamLink(props: Props) {
   const { claimUri, title = null } = props;
   const { push } = useHistory();
 
-  const element = (props: { children: any }) => (
+  if (!claimUri) {
+    return null;
+  }
+
+  return (
     <Card
       className="livestream__channel-link claim-preview__live"
       title={title || __('Live stream in progress')}
@@ -23,9 +27,7 @@ export default function LivestreamLink(props: Props) {
         push(formatLbryUrlForWeb(claimUri));
       }}
     >
-      {props.children}
+      <ClaimPreview uri={claimUri} type="inline" hideMenu />
     </Card>
   );
-
-  return claimUri ? <ClaimPreview uri={claimUri} wrapperElement={element} type="inline" /> : null;
 }


### PR DESCRIPTION
| Ticket | Closes [#1358 - flicker on livestream tile when viewers updates](https://github.com/OdyseeTeam/odysee-frontend/issues/1358) |
| ------------- | ------------- |
| Test    | `inf` |

## Change
Defining the component that way results in unique Card wrapper on each resolve, so everything gets torn down and re-mounted, causing the flicker.

There is a css side-effect with the fix though: the tags changed from red to black. But tags are inconsistent through the app ... sometimes black, sometimes red (I think it should always be red + smaller font from the body).
