### PR TITLE
SearchInLanguage: honor user's setting before category's setting.

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -215,15 +215,9 @@ function ClaimListDiscover(props: Props) {
     new Set(mutedUris.concat(blockedUris).map((uri) => splitBySeparator(uri)[1]))
   );
 
-  // Precedence:
-  // - searchLanguages (per instance attribute)
-  // - urlParams
-  // - languageSetting (redux setting)
-  const language = searchLanguages ? searchLanguages.join(',') : languageSetting;
   const langParam = urlParams.get(CS.LANGUAGE_KEY) || null;
-  const forcedSearchInLanguage = Boolean(searchLanguages);
-  const userSearchInLanguage = searchInLanguage && !ignoreSearchInLanguage;
-  const languageParams = resolveLangForClaimSearch(language, forcedSearchInLanguage || userSearchInLanguage, langParam);
+  const searchInSelectedLang = searchInLanguage && !ignoreSearchInLanguage;
+  const languageParams = resolveLangForClaimSearch(languageSetting, searchInSelectedLang, searchLanguages, langParam);
 
   let claimTypeParam = claimType || defaultClaimType || null;
   let streamTypeParam = streamType || defaultStreamType || null;
@@ -709,7 +703,7 @@ function ClaimListDiscover(props: Props) {
             <div className="section__header--actions">
               <div className="section__actions">
                 {headerToUse}
-                {userSearchInLanguage && <LangFilterIndicator />}
+                {searchInSelectedLang && <LangFilterIndicator />}
               </div>
               {meta && <div className="section__actions--no-margin">{meta}</div>}
             </div>
@@ -749,7 +743,7 @@ function ClaimListDiscover(props: Props) {
             <div className="section__header--actions">
               <div className="section__actions">
                 {headerToUse}
-                {userSearchInLanguage && <LangFilterIndicator />}
+                {searchInSelectedLang && <LangFilterIndicator />}
               </div>
               {meta && <div className="section__actions--no-margin">{meta}</div>}
             </div>

--- a/ui/page/discover/livestreamSection.jsx
+++ b/ui/page/discover/livestreamSection.jsx
@@ -70,9 +70,7 @@ export default function LivestreamSection(props: Props) {
 
   React.useEffect(() => {
     // Fetch active livestreams on mount
-    const language = searchLanguages ? searchLanguages.join(',') : languageSetting;
-    const searchInSelectedLangOnly = Boolean(searchLanguages) || searchInLanguage;
-    const langCsv = resolveLangForClaimSearch(language, searchInSelectedLangOnly, langParam);
+    const langCsv = resolveLangForClaimSearch(languageSetting, searchInLanguage, searchLanguages, langParam);
     const lang = langCsv ? langCsv.split(',') : null;
     doFetchActiveLivestreams(CS.ORDER_BY_NEW_VALUE, lang);
     // eslint-disable-next-line react-hooks/exhaustive-deps, (on mount only)

--- a/ui/util/default-languages.js
+++ b/ui/util/default-languages.js
@@ -44,24 +44,42 @@ export function sortLanguageMap(languages) {
 }
 
 /**
- * Resolves the language parameter for a claim_search based on various settings.
+ * Resolves the claim_search 'any_language' parameter based on various language settings.
  *
- * @param langSetting The user's language setting.
- * @param searchInSelectedLangOnly Return results in the given language only.
- * @param langParam Language override for specific use-cases, typically from urlParam.
+ * @param languageSetting The user (redux) language setting.
+ * @param searchInLanguageSetting By default, the user (redux) setting, but some components may override to false (e.g. 'ignoreSearchInLanguage' prop).
+ * @param searchLanguages Per-instance default language list (e.g. different Categories having different filters).
+ * @param languageUrlParams Language override via URLSearchParams.
  * @returns {string|null} Comma-separated string of language codes, or null.
  */
-export function resolveLangForClaimSearch(langSetting, searchInSelectedLangOnly, langParam = null) {
-  // TODO: expand ternary for easier maintenance.
-  return searchInSelectedLangOnly
-    ? langParam === null
-      ? langSetting.concat(langSetting === 'en' ? ',none' : '')
-      : langParam === 'any'
-      ? null
-      : langParam.concat(langParam === 'en' ? ',none' : '')
-    : langParam === null
-    ? null
-    : langParam === 'any'
-    ? null
-    : langParam.concat(langParam === 'en' ? ',none' : '');
+export function resolveLangForClaimSearch(
+  languageSetting, // : string,
+  searchInLanguageSetting, // : boolean,
+  searchLanguages, // : ?Array<string>,
+  languageUrlParams = null // : ?string
+) {
+  const langParam = languageUrlParams;
+
+  let lang;
+  if (searchInLanguageSetting) {
+    lang = languageSetting;
+  } else if (searchLanguages) {
+    lang = searchLanguages.join(',');
+  }
+
+  if (lang) {
+    if (langParam === null) {
+      return lang === 'en' ? 'en,none' : lang;
+    } else if (langParam === 'any') {
+      return null;
+    } else {
+      return langParam === 'en' ? 'en,none' : langParam;
+    }
+  } else if (langParam === null) {
+    return null;
+  } else if (langParam === 'any') {
+    return null;
+  } else {
+    return langParam === 'en' ? 'en,none' : langParam;
+  }
 }


### PR DESCRIPTION
|  |  |
| --- | --- |
| Test: | `inf` |
| Ticket: | Part of #1368 (_"if user overrides the category homepage language with a different language setting + use 'search this language' option, use that instead. It's not typical this will happen, but probably expected."_)| |

## Change
- Refactored to move more logic into `resolveLangForClaimSearch`
- Replaced the ternary version to make it more readable (hopefully).
- Inverted the language filter precedence by honoring the user's setting first.
  - Note: for both User and Category filters, URLSearchParams will always take precedence.