### PR TITLE
Discover: fix release_time for Tag and Wild West

### DIFF
--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -176,10 +176,13 @@ function DiscoverPage(props: Props) {
       </span>
     );
   }
-  let releaseTime =
-    dynamicRouteProps && dynamicRouteProps.options && dynamicRouteProps.options.releaseTime
-      ? dynamicRouteProps.options.releaseTime
-      : !isWildWest && `>${Math.floor(moment().subtract(0, 'hour').startOf('week').unix())}`;
+
+  let releaseTime = dynamicRouteProps?.options?.releaseTime;
+  if (isWildWest) {
+    // The homepage definition currently does not support 'start-of-week', so
+    // continue to hardcode here for now.
+    releaseTime = `>${Math.floor(moment().subtract(0, 'hour').startOf('week').unix())}`;
+  }
 
   return (
     <Page


### PR DESCRIPTION
- I got the previous logic completely wrong.
- Wild West's release time now comes from the homepage definition, but since the definition currently does not support "start of week", continue to hardcode the customization here.
- This logic also fixes the release_time for Tags.
