### PR TITLE
Fix 'content=any' not producing Channels in result

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { ENABLE_NO_SOURCE_CLAIMS, SIMPLE_SITE } from 'config';
+import { ENABLE_NO_SOURCE_CLAIMS } from 'config';
 import type { Node } from 'react';
 import * as CS from 'constants/claim_search';
 import React from 'react';
@@ -148,7 +148,7 @@ function ClaimListDiscover(props: Props) {
     // pageSize,
     defaultClaimType,
     streamType,
-    defaultStreamType = SIMPLE_SITE ? [CS.FILE_VIDEO, CS.FILE_AUDIO] : undefined, // add param for DEFAULT_STREAM_TYPE
+    defaultStreamType,
     freshness,
     defaultFreshness = CS.FRESH_WEEK,
     renderProperties,

--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -207,6 +207,7 @@ function DiscoverPage(props: Props) {
           tileLayout={repostedUri ? false : tileLayout}
           defaultOrderBy={isWildWest || tags ? CS.ORDER_BY_TRENDING : undefined}
           claimType={claimType ? [claimType] : undefined}
+          defaultStreamType={isCategory ? [CS.FILE_VIDEO, CS.FILE_AUDIO] : undefined}
           headerLabel={headerLabel}
           tags={tags}
           hiddenNsfwMessage={<HiddenNsfw type="page" />}


### PR DESCRIPTION
Test: `inf`

## Issue
Closes #1378
> "Content Type: Any" uses `claim_type: [streams, reposts, channels]`,  with `stream_types: ["video", "audio"]`, so channels aren't returned, and not any types of streams either.  Probably shouldn't have `stream_type` filter there.
(This also happens in categories, but maybe wanted in there?)

This one is probably a legacy issue since Odysee.

## Root
Due to this line in `ClaimListDiscover`:
`defaultStreamType = SIMPLE_SITE ? [CS.FILE_VIDEO, CS.FILE_AUDIO] : undefined, // add param for DEFAULT_STREAM_TYPE`

Wanted to check if this fallback was meant for Categories only or any list, but the git history is not preserved because Odysee was a squashed single-commit back in the `SIMPLE_SITE` days.

## Change
Will assume it was meant for Category Page only and moved that line from the component and into the client-side.

This also means that clients of `ClaimListDiscover` without `streamTypes` and `defaultStreamTypes` defined will no longer have `stream_types: ['video', 'audio']` as the automatic fallback (they must define `defaultStreamTypes` themselves). I think this modal is clearer -- it doesn't make sense to have filters like "content=any" but overridden quietly to `video|audio`.

## For reviewer
These are the remaining clients of `ClaimListDiscover`.  I think they won't be affected by the removal, but please check.
<img width="260" alt="image" src="https://user-images.githubusercontent.com/64950861/165016957-4304d775-8458-43e5-b918-509c3cf9e5bd.png">

