### PR TITLE
Use `videojs::http-streaming` for all except iPhones

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -160,18 +160,16 @@ export default React.memo<Props>(function VideoJs(props: Props) {
 
   const isMobile = useIsMobile();
 
-  // will later store the videojs player
   const playerRef = useRef();
   const containerRef = useRef();
-
   const tapToUnmuteRef = useRef();
   const tapToRetryRef = useRef();
-
   const playerServerRef = useRef();
 
   const { url: livestreamVideoUrl } = activeLivestreamForChannel || {};
+  const overrideNativeVhs = !platform.isIPhone();
   const showQualitySelector =
-    !isLivestreamClaim ||
+    (!isLivestreamClaim && overrideNativeVhs) ||
     (livestreamVideoUrl && (livestreamVideoUrl.includes('/transcode/') || livestreamVideoUrl.includes('cloud.odysee')));
 
   // initiate keyboard shortcuts
@@ -214,7 +212,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     controls: true,
     html5: {
       vhs: {
-        overrideNative: !videojs.browser.IS_ANY_SAFARI,
+        overrideNative: overrideNativeVhs, // !videojs.browser.IS_ANY_SAFARI,
         enableLowInitialPlaylist: false,
         fastQualityChange: true,
         useDtsForTimestampOffset: true,

--- a/ui/util/platform.js
+++ b/ui/util/platform.js
@@ -203,9 +203,9 @@ export const platform = {
   //   return (/ipad/gi).test(navigator.platform);
   // },
 
-  // isIPhone: function() { << untested
-  //   return (/iphone/gi).test(navigator.platform);
-  // },
+  isIPhone: function () {
+    return /iphone/gi.test(navigator.platform);
+  },
 
   // isLandscape: function() {  << I think window.orientation makes more sense
   //   return window.innerHeight < window.innerWidth;


### PR DESCRIPTION
## Ticket
Fixes [#31: quality selector not available on safari browsers](https://github.com/OdyseeTeam/odysee-frontend/issues/31)

## Notes
The quality selector isn't populated in some Apple products -- a known issue in videojs as the platform doesn't relay the info.
But it seems like only iPhone is affected, so let's enable the override for all platforms except iPhone.

## Test: `inf`
<table>
  <tr>
    <td>iPad Mini 6</td>
    <td>:heavy_check_mark: </td>
  </tr><tr></tr>
  <tr>
    <td> macOS 15.3</td>
    <td>:heavy_check_mark:, but transition to original not smooth</td>
  </tr><tr></tr>
  <tr>
    <td>iPhone 13</td>
    <td>:white_check_mark: (disable) </td>
  </tr>
</table>



