### PR TITLE
Fix blank homepage when livestream API fails

### DIFF
--- a/ui/page/channelsFollowing/view.jsx
+++ b/ui/page/channelsFollowing/view.jsx
@@ -54,47 +54,46 @@ function ChannelsFollowingPage(props: Props) {
               limitClaimsPerChannel={2}
             />
           )}
-
-          <ClaimListDiscover
-            hideAdvancedFilter={SIMPLE_SITE}
-            streamType={SIMPLE_SITE ? CS.CONTENT_ALL : undefined}
-            tileLayout={tileLayout}
-            headerLabel={
-              <span>
-                <Icon icon={ICONS.SUBSCRIBE} size={10} />
-                {__('Following')}
-              </span>
-            }
-            defaultOrderBy={CS.ORDER_BY_NEW}
-            channelIds={channelIds}
-            meta={
-              <>
-                <Button
-                  icon={ICONS.SEARCH}
-                  button="secondary"
-                  label={__('Discover Channels')}
-                  navigate={`/$/${PAGES.CHANNELS_FOLLOWING_DISCOVER}`}
-                />
-                <Button
-                  icon={ICONS.SETTINGS}
-                  button="secondary"
-                  label={__('Manage')}
-                  navigate={`/$/${PAGES.CHANNELS_FOLLOWING_MANAGE}`}
-                />
-              </>
-            }
-            subSection={
-              <LivestreamSection
-                tileLayout={tileLayout}
-                channelIds={channelIds}
-                activeLivestreams={activeLivestreams}
-                doFetchActiveLivestreams={doFetchActiveLivestreams}
-              />
-            }
-            hasSource
-          />
         </>
       )}
+      <ClaimListDiscover
+        hideAdvancedFilter={SIMPLE_SITE}
+        streamType={SIMPLE_SITE ? CS.CONTENT_ALL : undefined}
+        tileLayout={tileLayout}
+        headerLabel={
+          <span>
+            <Icon icon={ICONS.SUBSCRIBE} size={10} />
+            {__('Following')}
+          </span>
+        }
+        defaultOrderBy={CS.ORDER_BY_NEW}
+        channelIds={channelIds}
+        meta={
+          <>
+            <Button
+              icon={ICONS.SEARCH}
+              button="secondary"
+              label={__('Discover Channels')}
+              navigate={`/$/${PAGES.CHANNELS_FOLLOWING_DISCOVER}`}
+            />
+            <Button
+              icon={ICONS.SETTINGS}
+              button="secondary"
+              label={__('Manage')}
+              navigate={`/$/${PAGES.CHANNELS_FOLLOWING_MANAGE}`}
+            />
+          </>
+        }
+        subSection={
+          <LivestreamSection
+            tileLayout={tileLayout}
+            channelIds={channelIds}
+            activeLivestreams={activeLivestreams}
+            doFetchActiveLivestreams={doFetchActiveLivestreams}
+          />
+        }
+        hasSource
+      />
     </Page>
   );
 }


### PR DESCRIPTION
Closes #1397

Similar to the homepage before this, the intention was to wait for the livestream data first to avoid layout shifts when livestream data comes late.

While the shift sucks (especially when you have scrolled), it has a lesser impact than a blank page, so removing that behavior for now.
