### PR TITLE
Fix broken player rect state when app is updated and resize failed

### DIFF
--- a/ui/component/fileRenderFloating/view.jsx
+++ b/ui/component/fileRenderFloating/view.jsx
@@ -139,6 +139,7 @@ export default function FileRenderFloating(props: Props) {
     y: window.innerHeight - 400,
   });
   const relativePosRef = React.useRef({ x: 0, y: 0 });
+  const noPlayerHeight = fileViewerRect?.height === 0;
 
   const navigateUrl =
     (playingPrimaryUri || playingUrl || '') + (collectionId ? generateListSearchUrlParams(collectionId) : '');
@@ -244,10 +245,10 @@ export default function FileRenderFloating(props: Props) {
   }, [channelUrl, claimId, doCommentSocketConnect, doCommentSocketDisconnect, isCurrentClaimLive, uri]);
 
   React.useEffect(() => {
-    if (playingPrimaryUri || playingUrl) {
+    if (playingPrimaryUri || playingUrl || noPlayerHeight) {
       handleResize();
     }
-  }, [handleResize, playingPrimaryUri, theaterMode, playingUrl]);
+  }, [handleResize, playingPrimaryUri, theaterMode, playingUrl, noPlayerHeight]);
 
   // Listen to main-window resizing and adjust the floating player position accordingly:
   React.useEffect(() => {
@@ -587,7 +588,8 @@ const PlayerGlobalStyles = (props: GlobalStylesProps) => {
     <Global
       styles={{
         [`.${PRIMARY_PLAYER_WRAPPER_CLASS}`]: {
-          height: !theaterMode && mainFilePlaying ? `${heightResult} !important` : undefined,
+          height:
+            !theaterMode && mainFilePlaying && fileViewerRect?.height > 0 ? `${heightResult} !important` : undefined,
           opacity: !theaterMode && mainFilePlaying ? '0 !important' : undefined,
         },
 


### PR DESCRIPTION
## Fixes

Issue Number: n/a

this is mainly a fix for development, since it's really annoying when the page hot-reloads and the video disappears, maybe there are edge cases this could fix also, but easy to revert if breaks anything else

to test simply change anything like type `console.log(1)` anywhere in the code while a video is playing