### PR TITLE
Allow only 1 comment reaction per account

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1355,7 +1355,7 @@
   "Unable to edit this comment, please try again later.": "Unable to edit this comment, please try again later.",
   "No active channel selected.": "No active channel selected.",
   "Unable to verify your channel. Please try again.": "Unable to verify your channel. Please try again.",
-  "Unable to verify signature for %channel%.": "Unable to verify signature for %channel%.",
+  "Unable to verify signature.": "Unable to verify signature.",
   "Channel cannot be anonymous, please select a channel and try again.": "Channel cannot be anonymous, please select a channel and try again.",
   "Change to list layout": "Change to list layout",
   "Change to tile layout": "Change to tile layout",
@@ -2254,5 +2254,7 @@
   "This account has livestreaming disabled, please reach out to hello@odysee.com for assistance.": "This account has livestreaming disabled, please reach out to hello@odysee.com for assistance.",
   "Attach images by pasting or drag-and-drop.": "Attach images by pasting or drag-and-drop.",
   "There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.": "There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.",
+  "Already reacted to this comment from another channel.": "Already reacted to this comment from another channel.",
+  "Unable to react. Please try again later.": "Unable to react. Please try again later.",
   "--end--": "--end--"
 }

--- a/ui/util/toast-wrappers.js
+++ b/ui/util/toast-wrappers.js
@@ -4,7 +4,8 @@ import { doToast } from 'redux/actions/notifications';
 export function doFailedSignatureToast(dispatch: Dispatch, channelName: string) {
   dispatch(
     doToast({
-      message: __('Unable to verify signature for %channel%.', { channel: channelName }),
+      message: __('Unable to verify signature.'),
+      subMessage: channelName,
       isError: true,
     })
   );


### PR DESCRIPTION
Test:  `inf`
Ticket:  Part of #1705

<strike>## Concerns</strike>
<strike>In order to know if we have already reacted from another comment, we need to fetch reactions for all of our channels.  This increases the `reaction.List` call by N_OWN_CHANNELS per comment page.

If this is fine, then great.  Else, we can try to only fetch-all when a reaction is being done, rather than when a reaction count is normally being fetched.</strike>

## Note
- This PR doesn't cover comments (but the test instance covers both)