### PR TITLE
Fix tempFileMiddleware serving a cached .well-known file

### DIFF
--- a/web/src/tempfile.js
+++ b/web/src/tempfile.js
@@ -1,13 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
-let tempFile;
 async function getTempFile(ctx) {
   const filename = ctx.params.filename;
-  if (!tempFile) {
-    tempFile = fs.readFileSync(path.join(__dirname, `/../dist/${filename}`), 'utf8');
-  }
-  return tempFile;
+  return fs.readFileSync(path.join(__dirname, `/../dist/${filename}`), 'utf8');
 }
 
 module.exports = { getTempFile };


### PR DESCRIPTION
Related: #1386

The code was caching the first result and returning that.

We would expand the cache for multiple files, that that also require checking if the file has changed, so just read the content every time -- I think the file is small enough?
