### PR TITLE
Auto-populate category page titles

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1265,6 +1265,7 @@
   "Game": "Game",
   "Gaming": "Gaming",
   "Lab": "Lab",
+  "Lifestyle": "Lifestyle",
   "Movies": "Movies",
   "Music": "Music",
   "News & Politics": "News & Politics",

--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -226,8 +226,16 @@ function AppRouter(props: Props) {
 
   useEffect(() => {
     const getDefaultTitle = (pathname: string) => {
-      const title = pathname.startsWith('/$/') ? PAGE_TITLE[pathname.substring(3)] : '';
-      return __(title) || (IS_WEB ? SITE_TITLE : 'Odysee');
+      let title = '';
+      if (pathname.startsWith('/$/')) {
+        const name = pathname.substring(3);
+        if (window.CATEGORY_PAGE_TITLE && window.CATEGORY_PAGE_TITLE[name]) {
+          title = window.CATEGORY_PAGE_TITLE[name];
+        } else {
+          title = PAGE_TITLE[name];
+        }
+      }
+      return __(title) || SITE_TITLE || 'Odysee';
     };
 
     if (uri) {

--- a/ui/constants/pageTitles.js
+++ b/ui/constants/pageTitles.js
@@ -7,24 +7,7 @@ import * as PAGES from 'constants/pages';
 
 export const PAGE_TITLE = {
   // --- Categories ---
-  [PAGES.ARTISTS]: 'Artists',
-  [PAGES.CREATIVE_ARTS]: 'The Arts',
-  [PAGES.DISCOVER]: 'Wild West',
-  [PAGES.EDUCATION]: 'Education',
-  [PAGES.ENLIGHTENMENT]: 'Enlightenment',
-  [PAGES.FEATURED]: 'Featured',
-  [PAGES.FINANCE]: 'Finance 2.0',
-  [PAGES.GAMING]: 'Gaming',
-  [PAGES.GENERAL]: 'Cheese',
-  [PAGES.LAB]: 'Lab',
-  [PAGES.MOVIES]: 'Movies',
-  [PAGES.MUSIC]: 'Music',
-  [PAGES.NEWS]: 'News & Politics',
-  [PAGES.POP_CULTURE]: 'Pop Culture',
-  [PAGES.SPORTS]: 'Sports',
-  [PAGES.TECH]: 'Tech',
-  [PAGES.UNIVERSE]: 'Universe',
-  [PAGES.WILD_WEST]: 'Wild West',
+  // Dynamically populated in 'window.CATEGORY_PAGE_TITLE'.
 
   // --- Everything else in alphabetical order ---
   [PAGES.BUY]: 'Buy or Swap',

--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -308,6 +308,15 @@ export function doFetchLanguage(language) {
   };
 }
 
+function populateCategoryTitles(categories) {
+  if (categories) {
+    window.CATEGORY_PAGE_TITLE = {};
+    Object.values(categories).forEach((x) => {
+      window.CATEGORY_PAGE_TITLE[x.name] = x.label;
+    });
+  }
+}
+
 export function doFetchHomepages() {
   return (dispatch) => {
     // -- Use this env flag to use local homepage data. Otherwise, it will grab from `/$/api/content/v*/get`.
@@ -329,6 +338,7 @@ export function doFetchHomepages() {
       }
 
       window.homepages = v2;
+      populateCategoryTitles(window.homepages?.en?.categories);
       dispatch({ type: ACTIONS.FETCH_HOMEPAGES_DONE });
       return;
     }
@@ -339,6 +349,7 @@ export function doFetchHomepages() {
       .then((json) => {
         if (json?.status === 'success' && json?.data) {
           window.homepages = json.data;
+          populateCategoryTitles(window.homepages?.en?.categories);
           dispatch({ type: ACTIONS.FETCH_HOMEPAGES_DONE });
         } else {
           dispatch({ type: ACTIONS.FETCH_HOMEPAGES_FAILED });


### PR DESCRIPTION
Completely remove any need to update things on our side when a Category is added or changed.

<strike>Will need to inform homepage owners to directly translate the `label` field, so we don't need to use our translation system.  But can push first (doesn't impact existing translations).</strike> _Update:_ scratch that ... Chinese homepage is shared between 2 languages, and translating that way wouldn't work.  Continue with existing method, I guess.
