### PR TITLE
Add a timeout on SDK calls to allow specific error messages.

### DIFF
--- a/ui/constants/errors.js
+++ b/ui/constants/errors.js
@@ -1,3 +1,4 @@
 export const ALREADY_CLAIMED = 'once the invite reward has been claimed the referrer cannot be changed';
 export const REFERRER_NOT_FOUND = 'A odysee account could not be found for the referrer you provided.';
 export const PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL = 'There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.';
+export const FETCH_TIMEOUT = 'promise timeout';

--- a/ui/util/fetch.js
+++ b/ui/util/fetch.js
@@ -1,14 +1,16 @@
+import { FETCH_TIMEOUT } from 'constants/errors';
+
 export default function fetchWithTimeout(ms, promise) {
   return new Promise((resolve, reject) => {
     const timeoutId = setTimeout(() => {
-      reject(new Error('promise timeout'));
+      reject(new Error(FETCH_TIMEOUT));
     }, ms);
     promise.then(
-      res => {
+      (res) => {
         clearTimeout(timeoutId);
         resolve(res);
       },
-      err => {
+      (err) => {
         clearTimeout(timeoutId);
         reject(err);
       }

--- a/web/setup/publish-v1.js
+++ b/web/setup/publish-v1.js
@@ -5,12 +5,15 @@
 //   - 'file' binary
 //   - 'json_payload' publish params to be passed to the server's sdk.
 
+import { PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL } from '../../ui/constants/errors';
 import { X_LBRY_AUTH_TOKEN } from '../../ui/constants/token';
 import { doUpdateUploadAdd, doUpdateUploadProgress, doUpdateUploadRemove } from '../../ui/redux/actions/publish';
 import { LBRY_WEB_PUBLISH_API } from 'config';
 
 const ENDPOINT = LBRY_WEB_PUBLISH_API;
 const ENDPOINT_METHOD = 'publish';
+
+const PUBLISH_FETCH_TIMEOUT_MS = 60000;
 
 export function makeUploadRequest(
   token: string,
@@ -46,6 +49,7 @@ export function makeUploadRequest(
     let xhr = new XMLHttpRequest();
     xhr.open('POST', ENDPOINT);
     xhr.setRequestHeader(X_LBRY_AUTH_TOKEN, token);
+    xhr.timeout = PUBLISH_FETCH_TIMEOUT_MS;
     xhr.responseType = 'json';
     xhr.upload.onprogress = (e) => {
       const percentage = ((e.loaded / e.total) * 100).toFixed(2);
@@ -58,6 +62,10 @@ export function makeUploadRequest(
     xhr.onerror = () => {
       window.store.dispatch(doUpdateUploadProgress({ guid, status: 'error' }));
       reject(new Error(__('There was a problem with your upload. Please try again.')));
+    };
+    xhr.ontimeout = () => {
+      window.store.dispatch(doUpdateUploadProgress({ guid, status: 'error' }));
+      reject(new Error(PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL));
     };
     xhr.onabort = () => {
       window.store.dispatch(doUpdateUploadRemove(guid));


### PR DESCRIPTION
## Issue #1263
Previously, we tried to inform the user that when an SDK call such as `support_create` and `publish` fails (specifically, timed out), the operation could be successful -- please check the transactions later.

However, we only covered the case of `fetch` actually getting a response that indicated a timeout, e.g. "status = 524". For our SDK case, the timeout scenario is an error that goes into the `catch` block. In the `catch` block, we can't differentiate whether it is a timeout because it only returns a generic "failed to fetch" message.

## New Approach
Since `fetch` does not support a timeout value, the usual solution is to wrap it with a `setTimeout`. This already exists in our code as `fetchWithTimeout` (yay).

By setting a timeout that is lower than the browser's default and also lower than the SDK operation (90s for most commands, 5m for `publish`), we would now have a way to detect a timeout and inform the user.

Firefox's 90s seems to be the lowest common denominator ... so 60s was chosen as the default.

For the case of `publish`, it is actually called in the backend, so wrap the xhr call with a timeout as well.

## How I tested
- SDK: Added temp code to change `SDK_FETCH_TIMEOUT_MS` to `500` for `support_create`, and then tried to tip.
- Publish:  tweaked `PUBLISH_FETCH_TIMEOUT_MS` to `500` and publish a Post which uses v1.