### PR TITLE
Sort livestreams per viewCount, descending

### DIFF
--- a/ui/util/livestream.js
+++ b/ui/util/livestream.js
@@ -52,6 +52,14 @@ export function getLivestreamUris(
     values = values.filter((v) => !excludedChannelIds.includes(v.creatorId));
   }
 
+  values = values.sort((a, b) => {
+    // $FlowFixMe
+    if (a.viewCount < b.viewCount) return 1;
+    // $FlowFixMe
+    else if (a.viewCount > b.viewCount) return -1;
+    else return 0;
+  });
+
   // $FlowFixMe
   return values.map((v) => v.claimUri);
 }


### PR DESCRIPTION
I assume `viewCount` always exists;  if not, probably need to handle.