### PR TITLE
Stacking toasts

### DIFF
--- a/ui/component/snackBar/index.js
+++ b/ui/component/snackBar/index.js
@@ -1,14 +1,15 @@
 import { connect } from 'react-redux';
 import { doDismissToast } from 'redux/actions/notifications';
-import { selectToast } from 'redux/selectors/notifications';
+import { selectToast, selectToastCount } from 'redux/selectors/notifications';
 import SnackBar from './view';
 
-const perform = dispatch => ({
+const perform = (dispatch) => ({
   removeSnack: () => dispatch(doDismissToast()),
 });
 
-const select = state => ({
+const select = (state) => ({
   snack: selectToast(state),
+  snackCount: selectToastCount(state),
 });
 
 export default connect(select, perform)(SnackBar);

--- a/ui/component/snackBar/view.jsx
+++ b/ui/component/snackBar/view.jsx
@@ -9,40 +9,46 @@ import LbcMessage from 'component/common/lbc-message';
 type Props = {
   removeSnack: (any) => void,
   snack: ?ToastParams,
+  snackCount: number,
 };
 
 class SnackBar extends React.PureComponent<Props> {
   constructor(props: Props) {
     super(props);
-    this.hideTimeout = null;
+    this.intervalId = null;
   }
 
-  hideTimeout: ?TimeoutID;
+  intervalId: ?IntervalID;
 
   render() {
-    const { snack, removeSnack } = this.props;
+    const { snack, snackCount, removeSnack } = this.props;
 
     if (!snack) {
-      this.hideTimeout = null; // should be unmounting anyway, but be safe?
+      clearInterval(this.intervalId);
+      this.intervalId = null; // should be unmounting anyway, but be safe?
       return null;
     }
 
     const { message, subMessage, duration, linkText, linkTarget, isError } = snack;
 
-    if (this.hideTimeout === null) {
-      this.hideTimeout = setTimeout(
-        () => {
-          this.hideTimeout = null;
-          removeSnack();
-        },
-        duration === 'long' ? 15000 : 5000
-      );
+    if (this.intervalId) {
+      // TODO: render should be pure
+      clearInterval(this.intervalId);
     }
+
+    this.intervalId = setInterval(
+      () => {
+        removeSnack();
+      },
+      duration === 'long' ? 10000 : 5000
+    );
 
     return (
       <div
         className={classnames('snack-bar', {
           'snack-bar--error': isError,
+          'snack-bar--stacked-error': snackCount > 1 && isError,
+          'snack-bar--stacked-non-error': snackCount > 1 && !isError,
         })}
       >
         <div className="snack-bar__message">

--- a/ui/redux/reducers/notifications.js
+++ b/ui/redux/reducers/notifications.js
@@ -26,7 +26,7 @@ export default handleActions(
     },
     [ACTIONS.DISMISS_TOAST]: (state: NotificationState) => {
       const newToasts: Array<Toast> = state.toasts.slice();
-      newToasts.shift();
+      newToasts.pop();
 
       return {
         ...state,

--- a/ui/redux/selectors/notifications.js
+++ b/ui/redux/selectors/notifications.js
@@ -41,6 +41,8 @@ export const selectToast = createSelector(selectState, (state) => {
   return null;
 });
 
+export const selectToastCount = (state) => selectState(state).toasts.length;
+
 export const selectError = createSelector(selectState, (state) => {
   if (state.errors.length) {
     const { error } = state.errors[0];

--- a/ui/redux/selectors/notifications.js
+++ b/ui/redux/selectors/notifications.js
@@ -31,7 +31,7 @@ export const selectUnseenNotificationCount = createSelector(selectNotifications,
 
 export const selectToast = createSelector(selectState, (state) => {
   if (state.toasts.length) {
-    const { id, params } = state.toasts[0];
+    const { id, params } = state.toasts[state.toasts.length - 1];
     return {
       id,
       ...params,

--- a/ui/scss/component/_snack-bar.scss
+++ b/ui/scss/component/_snack-bar.scss
@@ -37,6 +37,32 @@
   background-color: var(--color-snack-bg-error);
 }
 
+.snack-bar--stacked-non-error {
+  box-shadow: // The top layer shadow
+    0 1px 1px var(--color-border),
+    // The second layer
+    0 10px 0 -5px var(--color-primary),
+    // The second layer shadow
+    0 10px 1px -4px var(--color-border);
+  //// The third layer
+  //0 20px 0 -10px var(--color-primary),
+  //// The third layer shadow
+  //0 20px 1px -9px var(--color-border);
+}
+
+.snack-bar--stacked-error {
+  box-shadow: // The top layer shadow
+    0 1px 1px var(--color-border),
+    // The second layer
+    0 10px 0 -5px var(--color-snack-bg-error),
+    // The second layer shadow
+    0 10px 1px -4px var(--color-border);
+  //// The third layer
+  //0 20px 0 -10px var(--color-snack-bg-error),
+  //// The third layer shadow
+  //0 20px 1px -9px var(--color-border);
+}
+
 .snack-bar--notification {
   @extend .card;
   background-color: var(--color-card-background);


### PR DESCRIPTION
Part of #1412

<img width="214" alt="image" src="https://user-images.githubusercontent.com/64950861/167113984-8484246b-d28c-45a2-b832-33ac83285714.png">

## Issue
New toasts/warnings could be buried by existing ones, or unclear that there is a stack of them queued up.
This is getting more apparent with the commenting restrictions, as we need to inform the user immediately after a button is pressed.

## Changes
- Reverse the toast display order to show the latest first
- Add GUI to indicate the stacking scenario.



@saltrafael, I think the Wallet Send is the only non-toast GUI that need to look at `selectToast`.  I think the change in behavior on the selector shouldn't affect the component, but can you help double confirm?

