### PR TITLE
Recsys: send `totalPlayingTime` instead of `events`

### DIFF
--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -204,7 +204,7 @@ const recsys = {
         if (isEmbedded) {
           recsys.entries[claimId]['isEmbed'] = true;
         }
-        recsys.entries[claimId]['totalPlayingTime'] = totalPlayingTime;
+        recsys.entries[claimId]['totalPlayTime'] = totalPlayingTime;
         recsys.sendRecsysEntry(claimId);
       }
     }

--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -138,7 +138,8 @@ const recsys = {
       IS_WEB || (window && window.store && selectDaemonSettings(window.store.getState()).share_usage_data);
 
     if (recsys.entries[claimId] && shareTelemetry) {
-      const data = JSON.stringify(recsys.entries[claimId]);
+      const { events, ...entryData } = recsys.entries[claimId];
+      const data = JSON.stringify(entryData);
 
       if (!isTentative) {
         delete recsys.entries[claimId];
@@ -184,6 +185,7 @@ const recsys = {
     recsys.entries[claimId].events.push(event);
     recsys.log('onRecsysPlayerEvent', claimId);
   },
+
   log: function (callName, claimId) {
     if (recsys.debug) {
       console.log(`Call: ***${callName}***, ClaimId: ${claimId}, Recsys Entries`, Object.assign({}, recsys.entries));

--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -9,6 +9,7 @@ import { X_LBRY_AUTH_TOKEN } from 'constants/token';
 import { makeSelectClaimForUri } from 'redux/selectors/claims';
 import { selectPlayingUri, selectPrimaryUri } from 'redux/selectors/content';
 import { selectClientSetting, selectDaemonSettings } from 'redux/selectors/settings';
+import { selectIsSubscribedForClaimId } from 'redux/selectors/subscriptions';
 import { history } from 'ui/store';
 
 const recsysEndpoint = RECSYS_ENDPOINT;
@@ -101,28 +102,25 @@ const recsys = {
       const state = window.store.getState();
       const user = selectUser(state);
       const userId = user ? user.id : null;
+
+      // Make a stub entry that will be filled out on page load
+      recsys.entries[claimId] = {
+        uuid: uuid || Uuidv4(),
+        claimId: claimId,
+        recClickedVideoIdx: [],
+        pageLoadedAt: Date.now(),
+        events: [],
+        incognito: !(user && user.has_verified_email),
+        isFollowing: selectIsSubscribedForClaimId(state, claimId),
+      };
+
       if (parentUuid) {
-        // Make a stub entry that will be filled out on page load
-        recsys.entries[claimId] = {
-          uuid: uuid || Uuidv4(),
-          parentUuid: parentUuid,
-          uid: userId || null, // selectUser
-          claimId: claimId,
-          recClickedVideoIdx: [],
-          pageLoadedAt: Date.now(),
-          events: [],
-        };
+        recsys.entries[claimId].uid = userId || null;
+        recsys.entries[claimId].parentUuid = parentUuid;
       } else {
-        recsys.entries[claimId] = {
-          uuid: uuid || Uuidv4(),
-          uid: userId, // selectUser
-          claimId: claimId,
-          pageLoadedAt: Date.now(),
-          recsysId: null,
-          recClaimIds: [],
-          recClickedVideoIdx: [],
-          events: [],
-        };
+        recsys.entries[claimId].uid = userId;
+        recsys.entries[claimId].recsysId = null;
+        recsys.entries[claimId].recClaimIds = [];
       }
     }
     recsys.log('createRecsysEntry', claimId);

--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -196,7 +196,7 @@ const recsys = {
    * Player closed. Check to see if primaryUri = playingUri
    * if so, send the Entry.
    */
-  onPlayerDispose: function (claimId, isEmbedded) {
+  onPlayerDispose: function (claimId, isEmbedded, totalPlayingTime) {
     if (window && window.store) {
       const state = window.store.getState();
       const playingUri = selectPlayingUri(state);
@@ -206,6 +206,7 @@ const recsys = {
         if (isEmbedded) {
           recsys.entries[claimId]['isEmbed'] = true;
         }
+        recsys.entries[claimId]['totalPlayingTime'] = totalPlayingTime;
         recsys.sendRecsysEntry(claimId);
       }
     }

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -93,7 +93,10 @@ export const selectClaimIdForUri = (state: State, uri: string) => selectClaimIds
 
 export const selectReflectingById = (state: State) => selectState(state).reflectingById;
 
+// OBSOLETE: use selectClaimForClaimId instead
 export const makeSelectClaimForClaimId = (claimId: string) => createSelector(selectClaimsById, (byId) => byId[claimId]);
+
+export const selectClaimForClaimId = (state: State, claimId: string) => selectClaimsById(state)[claimId];
 
 export const selectClaimForUri = createCachedSelector(
   selectClaimIdsByUri,

--- a/ui/redux/selectors/subscriptions.js
+++ b/ui/redux/selectors/subscriptions.js
@@ -7,6 +7,7 @@ import {
   makeSelectChannelForClaimUri,
   makeSelectClaimForUri,
   selectClaimForUri,
+  selectClaimForClaimId,
 } from 'redux/selectors/claims';
 import { swapKeyAndValue } from 'util/swap-json';
 import { getChannelFromClaim, isChannelClaim } from 'util/claim';
@@ -134,6 +135,23 @@ export const selectIsSubscribedForUri = createCachedSelector(
     return false;
   }
 )((state, uri) => String(uri));
+
+/**
+ * Unlike its 'selectIsSubscribedForUri' counterpart, this does not try to use
+ * parseURI as a fallback (since it only has claimId and not the uri).
+ */
+export const selectIsSubscribedForClaimId = createCachedSelector(
+  selectClaimForClaimId, // (state, claimId)
+  selectSubscriptions, // (state)
+  (claim, subscriptions) => {
+    const channelClaim = getChannelFromClaim(claim);
+    if (channelClaim) {
+      const permanentUrl = channelClaim.permanent_url;
+      return subscriptions.some((sub) => isURIEqual(sub.uri, permanentUrl));
+    }
+    return false;
+  }
+)((state, claimId) => String(claimId));
 
 export const makeSelectNotificationsDisabled = (uri) =>
   createSelector(


### PR DESCRIPTION
Closes #1317

Behavior is as described in the ticket (thanks, jbn for the details :+1:)

Depending on the outcome of https://odysee-workspace.slack.com/archives/C02FQBM00Q0/p1652175686742469, some rework might be needed.  This version follows suggestion (a) in the chat, so the initial frame and any subsequent seeked frames all count as 1s.