### PR TITLE
Meta: escape chars when generating `keywords` from `tags`

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -217,7 +217,7 @@ function buildClaimOgMetadata(uri, claim, overrideOptions = {}, referrerQuery) {
   head += `<meta name="description" content="${cleanDescription}"/>`;
 
   if (tags && tags.length > 0) {
-    head += `<meta name="keywords" content="${tags.toString()}"/>`;
+    head += `<meta name="keywords" content="${escapeHtmlProperty(tags.toString())}"/>`;
   }
 
   head += `<meta name="twitter:image" content="${claimThumbnail}"/>`;


### PR DESCRIPTION
A content page contained `"` as a tag, and that caused the meta generator to produce a malformed page.

`@Ads:e`