### PR TITLE
Use `get` instead of generating the stream url

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -9,7 +9,6 @@ WEB_SERVER_PORT=1337
 
 # -- APIs ---
 LBRY_WEB_API=https://api.na-backend.odysee.com
-LBRY_WEB_STREAMING_API=https://player.odycdn.com
 LBRY_WEB_BUFFER_API=https://collector-service.api.lbry.tv/api/v1/events/video
 COMMENT_SERVER_API=https://comments.odysee.tv/api/v2
 SEARCH_SERVER_API_ALT=https://recsys.odysee.tv/search

--- a/config.js
+++ b/config.js
@@ -10,7 +10,6 @@ const config = {
   LBRY_WEB_PUBLISH_API: process.env.LBRY_WEB_PUBLISH_API,
   LBRY_WEB_PUBLISH_API_V2: process.env.LBRY_WEB_PUBLISH_API_V2,
   LBRY_API_URL: process.env.LBRY_API_URL, // api.odysee.com',
-  LBRY_WEB_STREAMING_API: process.env.LBRY_WEB_STREAMING_API, // player.odycdn.com
   LBRY_WEB_BUFFER_API: process.env.LBRY_WEB_BUFFER_API,
   SEARCH_SERVER_API: process.env.SEARCH_SERVER_API,
   SEARCH_SERVER_API_ALT: process.env.SEARCH_SERVER_API_ALT,

--- a/ui/effects/use-get-thumbnail.js
+++ b/ui/effects/use-get-thumbnail.js
@@ -19,7 +19,6 @@ export default function useGetThumbnail(
   const isCollection = claim && claim.value_type === 'collection';
   const thumbnailInClaim = claim && claim.value && claim.value.thumbnail && claim.value.thumbnail.url;
 
-  // @if TARGET='web'
   if (thumbnailInClaim) {
     thumbnailToUse = thumbnailInClaim;
   } else if (claim && isImage && isFree) {
@@ -27,24 +26,6 @@ export default function useGetThumbnail(
   } else if (isCollection) {
     thumbnailToUse = MISSING_THUMB_DEFAULT;
   }
-  // @endif
-
-  // @if TARGET='app'
-  thumbnailToUse = thumbnailInClaim;
-
-  //
-  // Temporarily disabled until we can call get with "save_blobs: off"
-  //
-  // React.useEffect(() => {
-  //   if (hasClaim && isImage && isFree) {
-  //     if (streamingUrl) {
-  //       setThumbnail(streamingUrl);
-  //     } else if (!shouldHide) {
-  //       getFile(uri);
-  //     }
-  //   }
-  // }, [hasClaim, isFree, isImage, streamingUrl, uri, shouldHide]);
-  // @endif
 
   const [thumbnail, setThumbnail] = React.useState(thumbnailToUse);
   React.useEffect(() => {

--- a/ui/effects/use-get-thumbnail.js
+++ b/ui/effects/use-get-thumbnail.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import { generateStreamUrl } from 'util/web';
 import { MISSING_THUMB_DEFAULT } from 'config';
 
 export default function useGetThumbnail(
@@ -18,16 +17,28 @@ export default function useGetThumbnail(
   const isFree = claim && claim.value && (!claim.value.fee || Number(claim.value.fee.amount) <= 0);
   const isCollection = claim && claim.value_type === 'collection';
   const thumbnailInClaim = claim && claim.value && claim.value.thumbnail && claim.value.thumbnail.url;
+  let shouldFetchFileInfo = false;
 
   if (thumbnailInClaim) {
     thumbnailToUse = thumbnailInClaim;
   } else if (claim && isImage && isFree) {
-    thumbnailToUse = generateStreamUrl(claim.name, claim.claim_id);
+    if (streamingUrl) {
+      thumbnailToUse = streamingUrl;
+    } else if (!shouldHide) {
+      shouldFetchFileInfo = true;
+    }
   } else if (isCollection) {
     thumbnailToUse = MISSING_THUMB_DEFAULT;
   }
 
   const [thumbnail, setThumbnail] = React.useState(thumbnailToUse);
+
+  React.useEffect(() => {
+    if (shouldFetchFileInfo) {
+      getFile(uri);
+    }
+  }, [shouldFetchFileInfo, uri]);
+
   React.useEffect(() => {
     setThumbnail(thumbnailToUse);
   }, [thumbnailToUse]);

--- a/ui/util/web.js
+++ b/ui/util/web.js
@@ -1,13 +1,6 @@
-const { URL, LBRY_WEB_STREAMING_API, THUMBNAIL_CARDS_CDN_URL } = require('../../config');
+const { URL, THUMBNAIL_CARDS_CDN_URL } = require('../../config');
 
 const CONTINENT_COOKIE = 'continent';
-
-function generateStreamUrl(claimName, claimId) {
-  return `${LBRY_WEB_STREAMING_API}/content/claims/${encodeURIComponent(claimName)
-    .replace(/'/g, '%27')
-    .replace(/\(/g, '%28')
-    .replace(/\)/g, '%29')}/${claimId}/${encodeURIComponent(claimName)}`;
-}
 
 function generateEmbedUrl(claimName, claimId, startTime, referralLink) {
   let urlParams = new URLSearchParams();
@@ -98,7 +91,6 @@ module.exports = {
   generateEmbedIframeData,
   generateEmbedUrl,
   generateEmbedUrlEncoded,
-  generateStreamUrl,
   getParameterByName,
   getThumbnailCdnUrl,
   escapeHtmlProperty,

--- a/web/src/fetchStreamUrl.js
+++ b/web/src/fetchStreamUrl.js
@@ -1,0 +1,15 @@
+const { lbryProxy: Lbry } = require('../lbry');
+const { buildURI } = require('./lbryURI');
+
+async function fetchStreamUrl(claimName, claimId) {
+  const uri = buildURI({ claimName, claimId });
+  return await Lbry.get({ uri })
+    .then(({ streaming_url }) => streaming_url)
+    .catch((error) => {
+      return '';
+    });
+}
+
+module.exports = {
+  fetchStreamUrl,
+};

--- a/web/src/routes.js
+++ b/web/src/routes.js
@@ -1,4 +1,4 @@
-const { generateStreamUrl } = require('../../ui/util/web');
+const { fetchStreamUrl } = require('./fetchStreamUrl');
 const { getHtml } = require('./html');
 const { getOEmbed } = require('./oEmbed');
 const { getRss } = require('./rss');
@@ -13,11 +13,9 @@ global.fetch = fetch;
 
 const router = new Router();
 
-function getStreamUrl(ctx) {
+async function getStreamUrl(ctx) {
   const { claimName, claimId } = ctx.params;
-
-  const streamUrl = generateStreamUrl(claimName, claimId);
-  return streamUrl;
+  return await fetchStreamUrl(claimName, claimId);
 }
 
 const rssMiddleware = async (ctx) => {
@@ -43,7 +41,7 @@ router.get(`/$/api/content/v1/get`, async (ctx) => getHomepage(ctx, 1));
 router.get(`/$/api/content/v2/get`, async (ctx) => getHomepage(ctx, 2));
 
 router.get(`/$/download/:claimName/:claimId`, async (ctx) => {
-  const streamUrl = getStreamUrl(ctx);
+  const streamUrl = await getStreamUrl(ctx);
   const downloadUrl = `${streamUrl}?download=1`;
   ctx.redirect(downloadUrl);
 });


### PR DESCRIPTION
## Issues from the initial attempt
- There are 2 versions of `Lbry` and `buildURI` -- the app and web-server version.  There are subtle differences between them, and for the app case, importing the web-server version results in a query into an invalid URL.
- Function was changed from returning a string to returning a promise.

## Changes
- The app only needs it in `use-get-thumbnail`.  Use the existing `doFileGet` framework, which indirectly caches results.
- Since `generateStreamUrl` (renamed to `fetchStreamUrl` for clarity) is currently only needed for web-server, I moved it into the `web` folder to avoid misuse in app.
- Await on the promise. Unfortunately, this also means the entire chain of function calls need to be adjusted to be `async`.

## Future :warning: 
- [ ] Should we cache the web-server calls?  Probably troublesome, though -- need to know how many to cache, and when to invalidate.