### PR TITLE
Temporarily prevent invalid `get` calls until we figure it out

### DIFF
--- a/ui/lbry.js
+++ b/ui/lbry.js
@@ -80,7 +80,18 @@ const Lbry = {
 
   // Claim fetching and manipulation
   resolve: (params) => daemonCallWithResult('resolve', params, searchRequiresAuth),
-  get: (params) => daemonCallWithResult('get', params),
+  // get: (params) => daemonCallWithResult('get', params),
+  get: (params) => {
+    // $FlowFixMe
+    const uri = params?.uri;
+    if (uri && uri.endsWith('[object Promise]')) {
+      try {
+        analytics.error(`get: Invalid url (${uri})\n\`\`\`${new Error().stack}\`\`\``);
+      } catch {}
+      return Promise.reject(new Error(`get: Invalid url (${uri})`));
+    }
+    return daemonCallWithResult('get', params);
+  },
   claim_search: (params) => daemonCallWithResult('claim_search', params, searchRequiresAuth),
   claim_list: (params) => daemonCallWithResult('claim_list', params),
   channel_create: (params) => daemonCallWithResult('channel_create', params),

--- a/web/lbry.js
+++ b/web/lbry.js
@@ -76,7 +76,15 @@ const Lbry = {
 
   // Claim fetching and manipulation
   resolve: (params) => daemonCallWithResult('resolve', params),
-  get: (params) => daemonCallWithResult('get', params),
+  // get: (params) => daemonCallWithResult('get', params),
+  get: (params) => {
+    // $FlowFixMe
+    const uri = params?.uri;
+    if (uri && uri.endsWith('[object Promise]')) {
+      return Promise.reject(new Error(`get: Invalid url (${uri})`));
+    }
+    return daemonCallWithResult('get', params);
+  },
   claim_search: (params) => daemonCallWithResult('claim_search', params),
   claim_list: (params) => daemonCallWithResult('claim_list', params),
   channel_create: (params) => daemonCallWithResult('channel_create', params),


### PR DESCRIPTION
No analytics for the server side 
