### PR TITLE
Watch History: infinite scroll and batch-resolve

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2263,5 +2263,8 @@
   "Unable to react. Please try again later.": "Unable to react. Please try again later.",
   "Username (cannot be changed)": "Username (cannot be changed)",
   "Display Name": "Display Name",
+  "Watch History": "Watch History",
+  "Currently, your watch history is only saved locally.": "Currently, your watch history is only saved locally.",
+  "Clear History": "Clear History",
   "--end--": "--end--"
 }

--- a/ui/effects/use-claimList-infinite-scroll.js
+++ b/ui/effects/use-claimList-infinite-scroll.js
@@ -1,0 +1,62 @@
+// @flow
+/**
+ * Infinite-scroll and batch-resolving handling for `claimList` instances.
+ *
+ * By default, the list is "locked" during initial mount to have a stable
+ * pagination, but can be disabled through the `disableListLock` parameter.
+ */
+
+import React from 'react';
+
+export default function useClaimListInfiniteScroll(
+  allUris: Array<string>,
+  doResolveUris: (uris: Array<string>, returnCachedClaims: boolean, resolveReposts: boolean) => void,
+  pageSize: number = 30,
+  disableListLock: boolean = false
+) {
+  // Lock the full set of uris on mount, so we have a stable list for pagination.
+  const [uris, setUris] = React.useState([]);
+
+  // Infinite-scroll handling. 'page' is 0-indexed.
+  const [page, setPage] = React.useState(-1);
+  const lastPage = Math.max(0, Math.ceil(allUris.length / pageSize) - 1);
+  const [isLoadingPage, setIsLoadingPage] = React.useState(true);
+
+  async function resolveUris(uris) {
+    return doResolveUris(uris, true, false);
+  }
+
+  async function resolveNextPage(uris, currPage, pageSize) {
+    const nextPage = currPage + 1;
+    const nextUriBatch = uris.slice(nextPage * pageSize, (nextPage + 1) * pageSize);
+    return resolveUris(nextUriBatch);
+  }
+
+  function bumpPage() {
+    if (page < lastPage) {
+      setIsLoadingPage(true);
+      resolveNextPage(uris, page, pageSize).finally(() => {
+        setIsLoadingPage(false);
+        setPage(page + 1);
+      });
+    }
+  }
+
+  // -- Initial mount: lock list and resolve first batch:
+  React.useEffect(() => {
+    setUris(allUris);
+    resolveNextPage(allUris, -1, pageSize).finally(() => {
+      setIsLoadingPage(false);
+      setPage(0);
+    });
+  }, []);
+
+  // -- Optional: remove the locking behavior for whatever reason:
+  React.useEffect(() => {
+    if (disableListLock) {
+      setUris(allUris);
+    }
+  }, [allUris]);
+
+  return { uris, page, isLoadingPage, bumpPage };
+}

--- a/ui/page/watchHistory/index.js
+++ b/ui/page/watchHistory/index.js
@@ -1,17 +1,17 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import WatchHistoryPage from './view';
-import { selectHistory } from 'redux/selectors/content';
+import { selectWatchHistoryUris } from 'redux/selectors/content';
 import { doClearContentHistoryAll } from 'redux/actions/content';
+import { doResolveUris } from 'redux/actions/claims';
 
-const select = (state) => {
-  return {
-    history: selectHistory(state),
-  };
-};
-
-const perform = (dispatch) => ({
-  doClearContentHistoryAll: () => dispatch(doClearContentHistoryAll()),
+const select = (state) => ({
+  historyUris: selectWatchHistoryUris(state),
 });
+
+const perform = {
+  doClearContentHistoryAll,
+  doResolveUris,
+};
 
 export default withRouter(connect(select, perform)(WatchHistoryPage));

--- a/ui/page/watchHistory/view.jsx
+++ b/ui/page/watchHistory/view.jsx
@@ -8,23 +8,24 @@ import Icon from 'component/common/icon';
 import * as ICONS from 'constants/icons';
 import { YRBL_SAD_IMG_URL } from 'config';
 import Tooltip from 'component/common/tooltip';
+import useClaimListInfiniteScroll from 'effects/use-claimList-infinite-scroll';
 
-export const PAGE_VIEW_QUERY = 'view';
+export const PAGE_SIZE = 30;
 
 type Props = {
-  history: Array<any>,
+  historyUris: Array<string>,
   doClearContentHistoryAll: () => void,
+  doResolveUris: (uris: Array<string>, returnCachedClaims: boolean, resolveReposts: boolean) => void,
 };
 
 export default function WatchHistoryPage(props: Props) {
-  const { history, doClearContentHistoryAll } = props;
-  const [unavailableUris] = React.useState([]);
-  const watchHistory = [];
-  for (let entry of history) {
-    if (entry.uri.indexOf('@') !== -1) {
-      watchHistory.push(entry.uri);
-    }
-  }
+  const { historyUris, doClearContentHistoryAll, doResolveUris } = props;
+  const { uris, page, isLoadingPage, bumpPage } = useClaimListInfiniteScroll(
+    historyUris,
+    doResolveUris,
+    PAGE_SIZE,
+    true
+  );
 
   function clearHistory() {
     doClearContentHistoryAll();
@@ -43,7 +44,7 @@ export default function WatchHistoryPage(props: Props) {
           </h1>
 
           <div className="claim-list__alt-controls--wrap">
-            {watchHistory.length > 0 && (
+            {uris.length > 0 && (
               <Button
                 title={__('Clear History')}
                 button="primary"
@@ -53,8 +54,18 @@ export default function WatchHistoryPage(props: Props) {
             )}
           </div>
         </div>
-        {watchHistory.length > 0 && <ClaimList uris={watchHistory} unavailableUris={unavailableUris} inWatchHistory />}
-        {watchHistory.length === 0 && (
+        {uris.length > 0 && (
+          <ClaimList
+            uris={uris.slice(0, (page + 1) * PAGE_SIZE)}
+            onScrollBottom={bumpPage}
+            page={page + 1}
+            pageSize={PAGE_SIZE}
+            loading={isLoadingPage}
+            useLoadingSpinner
+            inWatchHistory
+          />
+        )}
+        {uris.length === 0 && (
           <div style={{ textAlign: 'center' }}>
             <img src={YRBL_SAD_IMG_URL} />
             <h2 className="main--empty empty" style={{ marginTop: '0' }}>

--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -69,7 +69,7 @@ export const selectContentPositionForUri = (state: State, uri: string) => {
   return null;
 };
 
-export const selectHistory = createSelector(selectState, (state) => state.history || []);
+export const selectHistory = (state: State) => selectState(state).history || [];
 
 export const selectHistoryPageCount = createSelector(selectHistory, (history) =>
   Math.ceil(history.length / HISTORY_ITEMS_PER_PAGE)
@@ -90,6 +90,16 @@ export const makeSelectHasVisitedUri = (uri: string) =>
 
 export const selectRecentHistory = createSelector(selectHistory, (history) => {
   return history.slice(0, RECENT_HISTORY_AMOUNT);
+});
+
+export const selectWatchHistoryUris = createSelector(selectHistory, (history) => {
+  const uris = [];
+  for (let entry of history) {
+    if (entry.uri.indexOf('@') !== -1) {
+      uris.push(entry.uri);
+    }
+  }
+  return uris;
 });
 
 export const selectShouldObscurePreviewForUri = (state: State, uri: string) => {


### PR DESCRIPTION
Test:  `kp`

## Issue
Doing individual resolves is taxing.

## Change
Add infinite scroll and batch-resolve each page. Factored out the method used in Manage Following.
