### PR TITLE
ClaimList: fix infinite effect loop

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -119,13 +119,15 @@ export default function ClaimList(props: Props) {
   const timedOut = uris === null;
   const urisLength = (uris && uris.length) || 0;
 
-  let tileUris = (prefixUris || []).concat(uris || []);
-
-  if (prefixUris && prefixUris.length) tileUris.splice(prefixUris.length * -1, prefixUris.length);
+  const tileUris = React.useMemo(() => {
+    const x = (prefixUris || []).concat(uris || []);
+    if (prefixUris && prefixUris.length) {
+      x.splice(prefixUris.length * -1, prefixUris.length);
+    }
+    return maxClaimRender ? x.slice(0, maxClaimRender) : x;
+  }, [prefixUris, uris, maxClaimRender]);
 
   const totalLength = tileUris.length;
-
-  if (maxClaimRender) tileUris = tileUris.slice(0, maxClaimRender);
 
   const sortedUris = (urisLength > 0 && (currentSort === SORT_NEW ? tileUris : tileUris.slice().reverse())) || [];
 


### PR DESCRIPTION
_Found this while trying to rebase adnim, where Category Page inject ads every other page.  It's the same problem as the PublishFile.  Gotta be mindful of this in future reviews._

`tileUris` is being used as an effect dependency, but it gets re-created on every render (same content, but different reference), so the `setUriBuffer` effect ended up in a loop.
