### PR TITLE
Revert "Temporarily prevent invalid `get` calls until we figure it out"

### DIFF
--- a/ui/lbry.js
+++ b/ui/lbry.js
@@ -80,18 +80,7 @@ const Lbry = {
 
   // Claim fetching and manipulation
   resolve: (params) => daemonCallWithResult('resolve', params, searchRequiresAuth),
-  // get: (params) => daemonCallWithResult('get', params),
-  get: (params) => {
-    // $FlowFixMe
-    const uri = params?.uri;
-    if (uri && uri.endsWith('[object Promise]')) {
-      try {
-        analytics.error(`get: Invalid url (${uri})\n\`\`\`${new Error().stack}\`\`\``);
-      } catch {}
-      return Promise.reject(new Error(`get: Invalid url (${uri})`));
-    }
-    return daemonCallWithResult('get', params);
-  },
+  get: (params) => daemonCallWithResult('get', params),
   claim_search: (params) => daemonCallWithResult('claim_search', params, searchRequiresAuth),
   claim_list: (params) => daemonCallWithResult('claim_list', params),
   channel_create: (params) => daemonCallWithResult('channel_create', params),

--- a/web/lbry.js
+++ b/web/lbry.js
@@ -76,15 +76,7 @@ const Lbry = {
 
   // Claim fetching and manipulation
   resolve: (params) => daemonCallWithResult('resolve', params),
-  // get: (params) => daemonCallWithResult('get', params),
-  get: (params) => {
-    // $FlowFixMe
-    const uri = params?.uri;
-    if (uri && uri.endsWith('[object Promise]')) {
-      return Promise.reject(new Error(`get: Invalid url (${uri})`));
-    }
-    return daemonCallWithResult('get', params);
-  },
+  get: (params) => daemonCallWithResult('get', params),
   claim_search: (params) => daemonCallWithResult('claim_search', params),
   claim_list: (params) => daemonCallWithResult('claim_list', params),
   channel_create: (params) => daemonCallWithResult('channel_create', params),


### PR DESCRIPTION
This reverts commit f6f15531d48991b554cd65a0ec6759923b9e264f.

The root-cause was known (8dd0982f), and I don't think it worked because:
1. The issue happened at the web side which didn't have logging.
2. The `[object Promise]` came after the `get`, not before.
