### PR TITLE
Fix selector naming convention

### DIFF
--- a/ui/page/embedWrapper/index.js
+++ b/ui/page/embedWrapper/index.js
@@ -5,7 +5,7 @@ import {
   selectClaimForUri,
   selectIsUriResolving,
   selectGeoRestrictionForUri,
-  selectLatestClaimByUri,
+  selectLatestClaimForUri,
 } from 'redux/selectors/claims';
 import { makeSelectStreamingUrlForUri } from 'redux/selectors/file_info';
 import { doResolveUri, doFetchLatestClaimForChannel } from 'redux/actions/claims';
@@ -51,7 +51,7 @@ const select = (state, props) => {
   const latestContentClaim =
     featureParam === PAGES.LIVE_NOW
       ? selectActiveLiveClaimForChannel(state, claimId)
-      : selectLatestClaimByUri(state, canonicalUrl);
+      : selectLatestClaimForUri(state, canonicalUrl);
   const latestClaimUrl = latestContentClaim && latestContentClaim.canonical_url;
   if (latestClaimUrl) uri = latestClaimUrl;
 

--- a/ui/page/show/index.js
+++ b/ui/page/show/index.js
@@ -6,7 +6,7 @@ import {
   selectClaimIsMine,
   makeSelectClaimIsPending,
   selectGeoRestrictionForUri,
-  selectLatestClaimByUri,
+  selectLatestClaimForUri,
 } from 'redux/selectors/claims';
 import {
   makeSelectCollectionForId,
@@ -41,7 +41,7 @@ const select = (state, props) => {
   const { canonical_url: canonicalUrl, claim_id: claimId } = claim || {};
   const latestContentClaim = liveContentPath
     ? selectActiveLiveClaimForChannel(state, claimId)
-    : selectLatestClaimByUri(state, canonicalUrl);
+    : selectLatestClaimForUri(state, canonicalUrl);
   const latestClaimUrl = latestContentClaim && latestContentClaim.canonical_url;
 
   return {

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -35,7 +35,7 @@ export const selectRepostLoading = (state: State) => selectState(state).repostLo
 export const selectRepostError = (state: State) => selectState(state).repostError;
 export const selectLatestByUri = (state: State) => selectState(state).latestByUri;
 
-export const selectLatestClaimByUri = createSelector(
+export const selectLatestClaimForUri = createSelector(
   (state, uri) => uri,
   selectLatestByUri,
   (uri, latestByUri) => {


### PR DESCRIPTION
`ByUri` - returns the storage variable (array or object).  Usually through `selectBlahByUri(state)`
`ForUri` - returns the specific entry in the storage variable.  Usually through `selectBlahForUri(state, uri)`
