### PR TITLE
astronaut_n_friends.png: fix src and caching

### DIFF
--- a/ui/scss/component/_ads.scss
+++ b/ui/scss/component/_ads.scss
@@ -34,7 +34,7 @@
     $minWidth: calc(var(--file-list-thumbnail-width) * 0.8);
     min-width: $minWidth;
     background-color: #283263;
-    background-image: url('https://odysee.com/public/img/astronaut_n_friends.png');
+    background-image: url('../../ui/component/membershipSplash/astronaut_n_friends.png'); // TODO fix relative path for all url('')
     background-size: 100%;
     border-radius: var(--border-radius);
     box-shadow: 0 0 0 1px rgba(var(--color-primary-dynamic), 0.1) inset;

--- a/ui/scss/component/_claim-list.scss
+++ b/ui/scss/component/_claim-list.scss
@@ -450,7 +450,7 @@
 .claim-preview--premium-plus {
   .media__thumb {
     background-color: #283263;
-    background-image: url('https://odysee.com/public/img/astronaut_n_friends.png');
+    background-image: url('../../ui/component/membershipSplash/astronaut_n_friends.png'); // TODO fix relative path for all url('')
     background-size: 100%;
   }
 

--- a/web/middleware/cache-control.js
+++ b/web/middleware/cache-control.js
@@ -10,6 +10,7 @@ const STATIC_ASSET_PATHS = [
   '/public/font/v1/700i.woff',
   '/public/favicon.png', // LBRY icon
   '/public/favicon-spaceman.png',
+  '/public/img/astronaut_n_friends.png',
   '/public/img/busy.gif',
   '/public/img/fileRenderPlaceholder.png',
   '/public/img/gerbil-happy.png',


### PR DESCRIPTION
1. Hardcoding breaks any image changes done on dev instances or locally.
2. The relative path used is bad, and there are few more instances of it. But continue as is for now, will file a ticket to fix all of them.
3. Fix caching.
