### PR TITLE
ClaimPreviewTile: fix render violations and `onHidden` logic

### DIFF
--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -215,6 +215,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
       ? claim.permanent_url || claim.canonical_url
       : undefined;
   const repostedContentUri = claim && (claim.reposted_claim ? claim.reposted_claim.permanent_url : claim.permanent_url);
+  const isPublishSuggestion = placeholder === 'publish' && !claim && uri.startsWith('lbry://@'); // See commit a43d9150.
 
   // Get channel title ( use name as fallback )
   let channelTitle = null;
@@ -227,10 +228,9 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     }
   }
 
-  // Aria-label value for claim preview
-  let ariaLabelData = isChannelUri ? title : formatClaimPreviewTitle(title, channelTitle, date, mediaDuration);
+  const ariaLabelData = isChannelUri ? title : formatClaimPreviewTitle(title, channelTitle, date, mediaDuration);
 
-  let navigateUrl = formatLbryUrlForWeb((claim && claim.canonical_url) || uri || '/');
+  const navigateUrl = formatLbryUrlForWeb((claim && claim.canonical_url) || uri || '/');
   let navigateSearch = new URLSearchParams();
   if (listId) {
     navigateSearch.set(COLLECTIONS_CONSTS.COLLECTION_ID, listId);
@@ -273,11 +273,18 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     shouldHide = true;
   }
 
+  if (!shouldHide && isPublishSuggestion) {
+    shouldHide = true;
+  }
+
   if (!shouldHide && customShouldHide && claim) {
     if (customShouldHide(claim)) {
       shouldHide = true;
     }
   }
+
+  // **************************************************************************
+  // **************************************************************************
 
   // Weird placement warning
   // Make sure this happens after we figure out if this claim needs to be hidden
@@ -306,6 +313,9 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
       resolveUri(uri);
     }
   }, [isValid, uri, isResolvingUri, shouldFetch, resolveUri]);
+
+  // **************************************************************************
+  // **************************************************************************
 
   if ((shouldHide && !showNullPlaceholder) || (isLivestream && !ENABLE_NO_SOURCE_CLAIMS)) {
     return null;
@@ -340,8 +350,9 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
       </React.Suspense>
     );
   }
-  if (placeholder === 'publish' && !claim && uri.startsWith('lbry://@')) {
-    return null;
+
+  if (isPublishSuggestion) {
+    return null; // Ignore 'showNullPlaceholder'
   }
 
   let liveProperty = null;

--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -134,20 +134,10 @@ function ClaimPreviewTile(props: Props) {
   const channelUri = !isChannel ? signingChannel && signingChannel.permanent_url : claim && claim.permanent_url;
   const channelTitle = signingChannel && ((signingChannel.value && signingChannel.value.title) || signingChannel.name);
 
-  // Aria-label value for claim preview
-  let ariaLabelData = isChannel ? title : formatClaimPreviewTitle(title, channelTitle, date, mediaDuration);
+  const isChannelPage = window.location.pathname.startsWith('/@');
+  const shouldShowViewCount = !(!viewCount || (claim && claim.repost_url) || isLivestream || !isChannelPage);
 
-  function handleClick(e) {
-    if (navigateUrl) {
-      history.push(navigateUrl);
-    }
-  }
-
-  React.useEffect(() => {
-    if (isValid && !isResolvingUri && shouldFetch && uri) {
-      resolveUri(uri);
-    }
-  }, [isValid, isResolvingUri, uri, resolveUri, shouldFetch]);
+  const ariaLabelData = isChannel ? title : formatClaimPreviewTitle(title, channelTitle, date, mediaDuration);
 
   let shouldHide = false;
 
@@ -165,13 +155,30 @@ function ClaimPreviewTile(props: Props) {
     if (onHidden && shouldHide) onHidden(props.uri);
   }
 
+  // **************************************************************************
+  // **************************************************************************
+
+  function handleClick(e) {
+    if (navigateUrl) {
+      history.push(navigateUrl);
+    }
+  }
+
+  // **************************************************************************
+  // **************************************************************************
+
+  React.useEffect(() => {
+    if (isValid && !isResolvingUri && shouldFetch && uri) {
+      resolveUri(uri);
+    }
+  }, [isValid, isResolvingUri, uri, resolveUri, shouldFetch]);
+
+  // **************************************************************************
+  // **************************************************************************
+
   if (shouldHide || (isLivestream && !showNoSourceClaims)) {
     return null;
   }
-
-  const isChannelPage = window.location.pathname.startsWith('/@');
-
-  const shouldShowViewCount = !(!viewCount || (claim && claim.repost_url) || isLivestream || !isChannelPage);
 
   if (placeholder || (!claim && isResolvingUri)) {
     return (

--- a/ui/component/claimPreviewTile/view.jsx
+++ b/ui/component/claimPreviewTile/view.jsx
@@ -145,14 +145,18 @@ function ClaimPreviewTile(props: Props) {
     // Unfortunately needed until this is resolved
     // https://github.com/lbryio/lbry-sdk/issues/2785
     shouldHide = true;
-  } else {
+  }
+
+  if (!shouldHide && !placeholder) {
     shouldHide =
-      !placeholder &&
-      (banState.blacklisted ||
-        banState.filtered ||
-        (!showHiddenByUser && (banState.muted || banState.blocked)) ||
-        (isAbandoned && !showUnresolvedClaims));
-    if (onHidden && shouldHide) onHidden(props.uri);
+      banState.blacklisted ||
+      banState.filtered ||
+      (!showHiddenByUser && (banState.muted || banState.blocked)) ||
+      (isAbandoned && !showUnresolvedClaims);
+  }
+
+  if (!shouldHide) {
+    shouldHide = isLivestream && !showNoSourceClaims;
   }
 
   // **************************************************************************
@@ -173,10 +177,16 @@ function ClaimPreviewTile(props: Props) {
     }
   }, [isValid, isResolvingUri, uri, resolveUri, shouldFetch]);
 
+  React.useEffect(() => {
+    if (onHidden && shouldHide) {
+      onHidden(props.uri);
+    }
+  }, [shouldHide, onHidden, props.uri]);
+
   // **************************************************************************
   // **************************************************************************
 
-  if (shouldHide || (isLivestream && !showNoSourceClaims)) {
+  if (shouldHide) {
     return null;
   }
 


### PR DESCRIPTION
## Issue
_See commit messages_

----

@toshokanneko, can you help to review the second commit just in case I messed up?  Behavioral differences:
- `onHidden` would now also be called if the list wants to exclude livestreams (although I think only FYP is using `onHidden` at the moment, and FYP doesn't come with livestreams)