### PR TITLE
Remove clearPosition functions for playlists

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs-events.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs-events.jsx
@@ -36,7 +36,6 @@ const VideoJsEvents = ({
   userId: ?number,
   claimValues: any,
   embedded: boolean,
-  clearPosition: (string) => void,
   uri: string,
   doAnalyticsView: (string, number) => any,
   doAnalyticsBuffer: (string, any) => void,

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -98,7 +98,6 @@ type Props = {
   doAnalyticsBuffer: (string, any) => void,
   uri: string,
   claimValues: any,
-  clearPosition: (string) => void,
   isLivestreamClaim: boolean,
   userClaimId: ?string,
   activeLivestreamForChannel: any,
@@ -157,7 +156,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     doAnalyticsBuffer,
     claimRewards,
     uri,
-    clearPosition,
     userClaimId,
     isLivestreamClaim,
     activeLivestreamForChannel,
@@ -211,7 +209,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     claimRewards,
     uri,
     playerServerRef,
-    clearPosition,
     isLivestreamClaim,
   });
 

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -227,7 +227,6 @@ function VideoViewer(props: Props) {
     if (playNextUrl) {
       if (permanentUrl !== nextRecommendedUri) {
         if (nextRecommendedUri) {
-          if (collectionId) clearPosition(permanentUrl);
           doPlay(nextRecommendedUri);
         }
       } else {
@@ -249,7 +248,6 @@ function VideoViewer(props: Props) {
     setEnded(false);
     setPlayNextUrl(true);
   }, [
-    clearPosition,
     collectionId,
     doNavigate,
     doPlay,
@@ -509,7 +507,6 @@ function VideoViewer(props: Props) {
         doAnalyticsBuffer={doAnalyticsBuffer}
         claimRewards={claimRewards}
         uri={uri}
-        clearPosition={clearPosition}
         userClaimId={claim && claim.signing_channel && claim.signing_channel.claim_id}
         isLivestreamClaim={isLivestreamClaim}
         activeLivestreamForChannel={activeLivestreamForChannel}

--- a/ui/page/file/view.jsx
+++ b/ui/page/file/view.jsx
@@ -117,10 +117,6 @@ export default function FilePage(props: Props) {
   React.useEffect(() => {
     // always refresh file info when entering file page to see if we have the file
     // this could probably be refactored into more direct components now
-    if (collectionId) {
-      clearPosition(uri);
-    }
-
     if (fileInfo && videoPlayedEnoughToResetPosition) {
       clearPosition(uri);
     }


### PR DESCRIPTION
## Fixes

Issue Number: closes #1470 

- Let the position be cleared at the end like regular videos and can come back to it 