### PR TITLE
Fix geoblocked items appearing in wunderbar suggestion popup

### DIFF
--- a/ui/component/wunderbarSuggestion/index.js
+++ b/ui/component/wunderbarSuggestion/index.js
@@ -1,5 +1,10 @@
 import { connect } from 'react-redux';
-import { selectClaimForUri, selectIsUriResolving, selectOdyseeMembershipForUri } from 'redux/selectors/claims';
+import {
+  selectClaimForUri,
+  selectGeoRestrictionForUri,
+  selectIsUriResolving,
+  selectOdyseeMembershipForUri,
+} from 'redux/selectors/claims';
 import WunderbarSuggestion from './view';
 
 const select = (state, props) => {
@@ -8,6 +13,7 @@ const select = (state, props) => {
   return {
     claim: selectClaimForUri(state, uri),
     isResolvingUri: selectIsUriResolving(state, uri),
+    geoRestriction: selectGeoRestrictionForUri(state, props.uri),
     odyseeMembership: selectOdyseeMembershipForUri(state, uri),
   };
 };

--- a/ui/component/wunderbarSuggestion/index.js
+++ b/ui/component/wunderbarSuggestion/index.js
@@ -8,7 +8,7 @@ const select = (state, props) => {
   return {
     claim: selectClaimForUri(state, uri),
     isResolvingUri: selectIsUriResolving(state, uri),
-    odyseeMembershipByUri: selectOdyseeMembershipForUri(state, uri),
+    odyseeMembership: selectOdyseeMembershipForUri(state, uri),
   };
 };
 

--- a/ui/component/wunderbarSuggestion/view.jsx
+++ b/ui/component/wunderbarSuggestion/view.jsx
@@ -12,11 +12,11 @@ type Props = {
   claim: ?Claim,
   uri: string,
   isResolvingUri: boolean,
-  odyseeMembershipByUri: ?string,
+  odyseeMembership: ?string,
 };
 
 export default function WunderbarSuggestion(props: Props) {
-  const { claim, uri, isResolvingUri, odyseeMembershipByUri } = props;
+  const { claim, uri, isResolvingUri, odyseeMembership } = props;
 
   if (isResolvingUri) {
     return (
@@ -63,7 +63,7 @@ export default function WunderbarSuggestion(props: Props) {
           <div className="wunderbar__suggestion-title">{claim.value.title}</div>
           <div className="wunderbar__suggestion-name">
             {isChannel ? claim.name : (claim.signing_channel && claim.signing_channel.name) || __('Anonymous')}
-            <PremiumBadge membership={odyseeMembershipByUri} />
+            <PremiumBadge membership={odyseeMembership} />
           </div>
         </span>
       </div>

--- a/ui/component/wunderbarSuggestion/view.jsx
+++ b/ui/component/wunderbarSuggestion/view.jsx
@@ -12,11 +12,12 @@ type Props = {
   claim: ?Claim,
   uri: string,
   isResolvingUri: boolean,
+  geoRestriction: ?GeoRestriction,
   odyseeMembership: ?string,
 };
 
 export default function WunderbarSuggestion(props: Props) {
-  const { claim, uri, isResolvingUri, odyseeMembership } = props;
+  const { claim, uri, isResolvingUri, odyseeMembership, geoRestriction } = props;
 
   if (isResolvingUri) {
     return (
@@ -29,6 +30,11 @@ export default function WunderbarSuggestion(props: Props) {
   }
 
   if (!claim) {
+    return null;
+  }
+
+  if (geoRestriction) {
+    // Could display something else in the future, but hide completely for now.
     return null;
   }
 


### PR DESCRIPTION


This list is not using ClaimPreview or ClaimPreviewTile, so the filtering was missed.
