### PR TITLE
Geoblock: fix anonymous claims passing through

### DIFF
--- a/ui/util/geoRestriction.js
+++ b/ui/util/geoRestriction.js
@@ -15,19 +15,16 @@ export function getGeoRestrictionForClaim(claim: ?StreamClaim, locale: LocaleInf
     const claimId: ?string = claim.claim_id;
     const channelId: ?string = getChannelIdFromClaim(claim);
 
-    if (!claimId || !channelId) {
-      console.log('Claim with blank data:', claim); // eslint-disable-line no-console
-      return null;
-    }
-
     let geoConfig: ?GeoConfig;
 
     // --- livestreams
     if (isStreamPlaceholderClaim(claim) && geoBlockLists.livestreams) {
+      // $FlowIgnore: null key is fine
       geoConfig = geoBlockLists.livestreams[channelId] || geoBlockLists.livestreams[claimId];
     }
     // --- videos (actually, everything else)
     else if (geoBlockLists.videos) {
+      // $FlowIgnore: null key is fine
       geoConfig = geoBlockLists.videos[channelId] || geoBlockLists.videos[claimId];
     }
 


### PR DESCRIPTION
My bad, added an unnecessary check in the previous change that shorted the logic too early.

Accessing an object using 'null' or 'undefined' as the key won't cause trouble (and is expected in this case), so just suppress flow instead of fixing it using
  `channelId && geoBlockLists.livestreams[channelId]`

https://github.com/OdyseeTeam/odysee-frontend/issues/1100#issuecomment-1138928520
