### PR TITLE
Don't show subs button for iOS and show in correct position for the rest of platforms

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -240,6 +240,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       timeDivider: !isLivestreamClaim,
       durationDisplay: !isLivestreamClaim,
       remainingTimeDisplay: !isLivestreamClaim,
+      subsCapsButton: !IS_IOS,
     },
     techOrder: ['chromecast', 'html5'],
     chromecast: {

--- a/ui/scss/component/_videojs.scss
+++ b/ui/scss/component/_videojs.scss
@@ -325,18 +325,21 @@ button.vjs-big-play-button {
 .vjs-chapters-button {
   order: 10 !important;
 }
+.vjs-subs-caps-button {
+  order: 11 !important;
+}
 .vjs-button--autoplay-next {
-  order: 10 !important;
+  order: 12 !important;
 }
 .vjs-playback-rate {
-  order: 11 !important;
+  order: 13 !important;
 }
 .vjs-chromecast-button,
 .vjs-airplay-button {
-  order: 12 !important;
+  order: 13 !important;
 }
 .vjs-quality-selector {
-  order: 13 !important;
+  order: 14 !important;
   display: flex;
 
   .vjs-icon-placeholder {
@@ -345,10 +348,10 @@ button.vjs-big-play-button {
   }
 }
 .vjs-button--theater-mode {
-  order: 14 !important;
+  order: 15 !important;
 }
 .vjs-fullscreen-control {
-  order: 15 !important;
+  order: 16 !important;
 }
 
 // livestream player


### PR DESCRIPTION
Currently, iOS is showing an errant CC button to the left of the play button due to a misreading of embedded subtitles, however on a video with actual subtitles the CC button doesn't show up, therefore subtitles are turned off for iOS

![Screen Shot 2022-05-30 at 6 54 40 PM](https://user-images.githubusercontent.com/7200471/171035014-32b61674-7f3b-480a-a3f8-2c55a8b8aff5.jpg)

Meanwhile on other platforms, the CC button is in the wrong position

![Screen Shot 2022-05-30 at 6 55 02 PM](https://user-images.githubusercontent.com/7200471/171035133-f8ed2335-47a1-4eab-a868-1281f736dfc7.jpg)

This moves the CC button to a better position (based the choice off YouTube)

![Screen Shot 2022-05-30 at 6 56 38 PM](https://user-images.githubusercontent.com/7200471/171035174-7fe16867-77fe-4c47-89ee-06d8a1e8aeb5.jpg)

The upload with a CC button is at: https://odysee.com/DIRECTONOCTURNODELQUINTACOLUMNA-PROGRAMA301-:7169b6a98141f08018886a136d79b183ca036625




