### PR TITLE
Tip: show modal instead of toast when timeout

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2276,5 +2276,7 @@
   "Clear History": "Clear History",
   "Reset homepage to defaults?": "Reset homepage to defaults?",
   "Homepage restored to default.": "Homepage restored to default.",
+  "The transaction timed out, but may have been completed. Please wait a few minutes, then check your wallet transactions before attempting to retry.": "The transaction timed out, but may have been completed. Please wait a few minutes, then check your wallet transactions before attempting to retry.",
+  "The transaction timed out, but may have been completed. Please wait a few minutes, then check your wallet transactions before attempting to retry. Note that due to current limitations, we are unable to re-link the tip sent to a new comment.": "The transaction timed out, but may have been completed. Please wait a few minutes, then check your wallet transactions before attempting to retry. Note that due to current limitations, we are unable to re-link the tip sent to a new comment.",
   "--end--": "--end--"
 }

--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -72,7 +72,14 @@ type Props = {
     preferredCurrency: string,
     (any) => void
   ) => string,
-  doSendTip: (params: {}, isSupport: boolean, successCb: (any) => void, errorCb: (any) => void, boolean) => void,
+  doSendTip: (
+    params: {},
+    isSupport: boolean,
+    successCb: (any) => void,
+    errorCb: (any) => void,
+    boolean,
+    string
+  ) => void,
   doOpenModal: (id: string, any) => void,
   preferredCurrency: string,
   myChannelClaimIds: ?Array<string>,
@@ -314,7 +321,8 @@ export function CommentCreate(props: Props) {
           // reset the frontend so people can send a new comment
           setSubmitting(false);
         },
-        false
+        false,
+        'comment'
       );
     } else {
       const tipParams: TipParams = { tipAmount: Math.round(tipAmount * 100) / 100, tipChannelName, channelClaimId };

--- a/ui/constants/errors.js
+++ b/ui/constants/errors.js
@@ -1,4 +1,5 @@
 export const ALREADY_CLAIMED = 'once the invite reward has been claimed the referrer cannot be changed';
 export const REFERRER_NOT_FOUND = 'A odysee account could not be found for the referrer you provided.';
 export const PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL = 'There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.';
+export const SDK_FETCH_TIMEOUT = 'Your action timed out, but may have been completed.';
 export const FETCH_TIMEOUT = 'promise timeout';

--- a/ui/lbry.js
+++ b/ui/lbry.js
@@ -1,6 +1,6 @@
 // @flow
 import analytics from 'analytics';
-import { FETCH_TIMEOUT } from 'constants/errors';
+import { FETCH_TIMEOUT, SDK_FETCH_TIMEOUT } from 'constants/errors';
 import { NO_AUTH, X_LBRY_AUTH_TOKEN } from 'constants/token';
 import fetchWithTimeout from 'util/fetch';
 
@@ -245,7 +245,7 @@ function resolveFetchErrorMsg(method: string, response: Response | string) {
         return `${method}: ${response.statusText} (${response.status})`;
     }
   } else if (response === FETCH_TIMEOUT) {
-    return `${method}: Your action timed out, but may have been completed.`;
+    return `${method}: ${SDK_FETCH_TIMEOUT}`; // Don't translate as clients will do a string match.
   } else {
     return `${method}: fetch failed.`;
   }


### PR DESCRIPTION
## Issue
The toast wasn't good enough as the user might miss it and attempt to re-send.

## Change
- Change the tip timeout from Toast to Modal.
- For the case of Comments, add additional info about being unable to re-link the txid to the comment for now. Not really useful to the user, but better than nothing.
