### PR TITLE
Recsys: determine the clicked index based on raw results instead of rendered order

### DIFF
--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -1,7 +1,7 @@
 // @flow
 import { RECSYS_ENDPOINT } from 'config';
 import { selectUser } from 'redux/selectors/user';
-import { makeSelectRecommendedRecsysIdForClaimId } from 'redux/selectors/search';
+import { makeSelectRecommendedRecsysIdForClaimId, selectRecommendedContentRawForUri } from 'redux/selectors/search';
 import { v4 as Uuidv4 } from 'uuid';
 import { parseURI } from 'util/lbryURI';
 import { getAuthToken } from 'util/saved-passwords';
@@ -82,13 +82,17 @@ const recsys: Recsys = {
    * plus recommended content, recsysId, etc.
    * Called from recommendedContent component
    */
-  onRecsLoaded: function (claimId, uris, uuid = '') {
+  onRecsLoaded: function (uri, claimId, uuid = '') {
     if (window && window.store) {
       const state = window.store.getState();
+      const rawRecommendations = selectRecommendedContentRawForUri(state, uri);
+      const rawUris = rawRecommendations ? rawRecommendations.uris : null;
+
       if (!recsys.entries[claimId]) {
         recsys.createRecsysEntry(claimId, null, uuid);
       }
-      const claimIds = getClaimIdsFromUris(uris);
+
+      const claimIds = getClaimIdsFromUris(rawUris);
       recsys.entries[claimId]['recsysId'] = makeSelectRecommendedRecsysIdForClaimId(claimId)(state) || recsysId;
       recsys.entries[claimId]['pageLoadedAt'] = Date.now();
 

--- a/flow-typed/recsys.js
+++ b/flow-typed/recsys.js
@@ -4,7 +4,7 @@ declare type Recsys = {
 
   saveEntries: () => void,
   onClickedRecommended: (parentClaimId: ClaimId, newClaimId: ClaimId) => void,
-  onRecsLoaded: (claimId: ClaimId, uris: Array<string>, uuid: string) => void,
+  onRecsLoaded: (uri: ?string, claimId: ClaimId, uuid: string) => void,
   createRecsysEntry: (claimId: ClaimId, parentUuid?: ?string, uuid?: string) => void,
   sendRecsysEntry: (claimId: ClaimId, isTentative?: boolean) => ?Promise<?Response>,
   sendEntries: (entries: ?{ [ClaimId]: RecsysEntry }, isResumedSend: boolean) => void,

--- a/ui/component/recommendedContent/view.jsx
+++ b/ui/component/recommendedContent/view.jsx
@@ -107,9 +107,9 @@ export default React.memo<Props>(function RecommendedContent(props: Props) {
       nextRecommendedUri &&
       viewMode === VIEW_ALL_RELATED
     ) {
-      onRecommendationsLoaded(claimId, recommendedContentUris, uuid);
+      onRecommendationsLoaded(uri, claimId, uuid);
     }
-  }, [recommendedContentUris, onRecommendationsLoaded, claimId, nextRecommendedUri, viewMode, uuid]);
+  }, [uri, recommendedContentUris, onRecommendationsLoaded, claimId, nextRecommendedUri, viewMode, uuid]);
 
   function handleRecommendationClicked(e, clickedClaim) {
     if (claim) {

--- a/ui/redux/selectors/search.js
+++ b/ui/redux/selectors/search.js
@@ -1,7 +1,5 @@
 // @flow
-import { getSearchQueryString } from 'util/query-params';
 import { selectShowMatureContent } from 'redux/selectors/settings';
-import { SEARCH_OPTIONS } from 'constants/search';
 import {
   selectClaimsByUri,
   makeSelectClaimForUri,
@@ -14,11 +12,10 @@ import { parseURI } from 'util/lbryURI';
 import { isClaimNsfw } from 'util/claim';
 import { createSelector } from 'reselect';
 import { createCachedSelector } from 're-reselect';
-import { createNormalizedSearchKey, getRecommendationSearchOptions } from 'util/search';
+import { createNormalizedSearchKey, getRecommendationSearchKey, getRecommendationSearchOptions } from 'util/search';
 import { selectMutedChannels } from 'redux/selectors/blocked';
 import { selectHistory } from 'redux/selectors/content';
 import { selectAllCostInfoByUri } from 'lbryinc';
-import { SIMPLE_SITE } from 'config';
 
 type State = { claims: any, search: SearchState, user: UserState };
 
@@ -66,7 +63,6 @@ export const selectRecommendedContentForUri = createCachedSelector(
   selectClaimIsNsfwForUri, // (state, uri)
   (uri, history, claimsByUri, matureEnabled, blockedChannels, costInfoByUri, searchUrisByQuery, isMature) => {
     const claim = claimsByUri[uri];
-
     if (!claim) return;
 
     let recommendedContent;
@@ -74,26 +70,10 @@ export const selectRecommendedContentForUri = createCachedSelector(
     const currentClaimId = claim.claim_id;
 
     const { title } = claim.value;
-
     if (!title) return;
 
-    const options: {
-      size: number,
-      nsfw?: boolean,
-      isBackgroundSearch?: boolean,
-    } = { size: 20, nsfw: matureEnabled, isBackgroundSearch: true };
-
-    if (SIMPLE_SITE) {
-      options[SEARCH_OPTIONS.CLAIM_TYPE] = SEARCH_OPTIONS.INCLUDE_FILES;
-      options[SEARCH_OPTIONS.MEDIA_VIDEO] = true;
-      options[SEARCH_OPTIONS.PRICE_FILTER_FREE] = true;
-    }
-    if (matureEnabled || (!matureEnabled && !isMature)) {
-      options[SEARCH_OPTIONS.RELATED_TO] = claim.claim_id;
-    }
-
-    const searchQuery = getSearchQueryString(title.replace(/\//, ' '), options);
-    const normalizedSearchQuery = createNormalizedSearchKey(searchQuery);
+    const options = getRecommendationSearchOptions(matureEnabled, isMature, claim.claim_id);
+    const normalizedSearchQuery = getRecommendationSearchKey(title, options);
 
     let searchResult = searchUrisByQuery[normalizedSearchQuery];
 
@@ -169,8 +149,7 @@ export const makeSelectRecommendedRecsysIdForClaimId = (claimId: string) =>
         }
 
         const options = getRecommendationSearchOptions(matureEnabled, isMature, claimId);
-        const searchQuery = getSearchQueryString(title.replace(/\//, ' '), options);
-        const normalizedSearchQuery = createNormalizedSearchKey(searchQuery);
+        const normalizedSearchQuery = getRecommendationSearchKey(title, options);
 
         const searchResult = searchUrisByQuery[normalizedSearchQuery];
         if (searchResult) {

--- a/ui/util/search.js
+++ b/ui/util/search.js
@@ -3,6 +3,7 @@
 import { isNameValid, isURIValid, normalizeURI, parseURI } from 'util/lbryURI';
 import { URL as SITE_URL, URL_LOCAL, URL_DEV, SIMPLE_SITE } from 'config';
 import { SEARCH_OPTIONS } from 'constants/search';
+import { getSearchQueryString } from 'util/query-params';
 
 export function createNormalizedSearchKey(query: string) {
   const removeParam = (query: string, param: string) => {
@@ -97,6 +98,16 @@ export function getUriForSearchTerm(term: string) {
   }
 }
 
+/**
+ * The 'Recommended' search query is used as the key to store the results. This
+ * function ensures all clients derive the same key by making this the only
+ * place to make tweaks.
+ *
+ * @param matureEnabled
+ * @param claimIsMature
+ * @param claimId
+ * @returns {{size: number, nsfw: boolean, isBackgroundSearch: boolean}}
+ */
 export function getRecommendationSearchOptions(matureEnabled: boolean, claimIsMature: boolean, claimId: string) {
   const options = { size: 20, nsfw: matureEnabled, isBackgroundSearch: true };
 
@@ -111,4 +122,9 @@ export function getRecommendationSearchOptions(matureEnabled: boolean, claimIsMa
   }
 
   return options;
+}
+
+export function getRecommendationSearchKey(title: string, options: {}) {
+  const searchQuery = getSearchQueryString(title.replace(/\//, ' '), options);
+  return createNormalizedSearchKey(searchQuery);
 }


### PR DESCRIPTION
Recsys: determine the clicked index based on raw results instead of rendered order

## Ticket
Closes #1606

## Issue
The displayed order of the recs are often re-adjusted -- viewed content are pushed to the bottom to avoid auto-play-next from picking it up again. This was causing recsys to be confused, because the click order does not correspond the results.

## Change
Refactored the selector we can grab the raw results and use that as the index reference.
