### PR TITLE
Missing yarn.lock commit

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6740,7 +6740,7 @@ esrecurse@^4.1.0, esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
 


### PR DESCRIPTION
This diff came up when building. Probably missed from the eslint update PR.
