### PR TITLE
Homepage API: add `?format=roku` support

### DIFF
--- a/web/src/getHomepageJSON.js
+++ b/web/src/getHomepageJSON.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const memo = {};
 
+const FORMAT = { ROKU: 'roku' };
+
 const loadAnnouncements = (homepageKeys) => {
   const fs = require('fs');
   const announcements = {};
@@ -44,7 +46,15 @@ const getHomepageJsonV1 = () => {
   return v1;
 };
 
-const getHomepageJsonV2 = () => {
+const reformatV2Categories = (categories, format) => {
+  if (format === FORMAT.ROKU) {
+    return categories && Object.entries(categories).map(([key, value]) => value);
+  } else {
+    return categories;
+  }
+};
+
+const getHomepageJsonV2 = (format) => {
   if (!memo.homepageData) {
     return {};
   }
@@ -53,7 +63,8 @@ const getHomepageJsonV2 = () => {
   const homepageKeys = Object.keys(memo.homepageData);
   homepageKeys.forEach((hp) => {
     v2[hp] = {
-      ...memo.homepageData[hp],
+      categories: reformatV2Categories(memo.homepageData[hp].categories, format),
+      meme: memo.homepageData[hp].meme,
       announcement: memo.announcements[hp],
     };
   });

--- a/web/src/homepageApi.js
+++ b/web/src/homepageApi.js
@@ -8,8 +8,10 @@ async function getHomepage(ctx, version) {
     return;
   }
 
+  const format = ctx?.request?.query?.format;
+
   try {
-    const content = version === 1 ? getHomepageJsonV1() : getHomepageJsonV2();
+    const content = version === 1 ? getHomepageJsonV1() : getHomepageJsonV2(format);
     ctx.set('Content-Type', 'application/json');
     ctx.set('Access-Control-Allow-Origin', '*');
     ctx.body = {


### PR DESCRIPTION
Formatting changes for Roku to parse the data properly.
Closes https://github.com/OdyseeTeam/odysee-homepages/issues/1570

Wasn't sure whether to use something generic like `format=cat_array`, but ended up with `format=roku`.

## Test
1. https://odysee.com/$/api/content/v2/get
2. https://kp.odysee.com/$/api/content/v2/get
3. https://kp.odysee.com/$/api/content/v2/get?format=roku

1 should equal 2, and 3 is the new format.  

