### PR TITLE
GoogleVideo: fix `contentUrl` and add more metadata

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -363,7 +363,7 @@ async function getHtml(ctx) {
 
     if (claim) {
       const ogMetadata = await buildClaimOgMetadata(claimUri, claim);
-      const googleVideoMetadata = buildGoogleVideoMetadata(claimUri, claim);
+      const googleVideoMetadata = await buildGoogleVideoMetadata(claimUri, claim);
       return insertToHead(html, ogMetadata.concat('\n', googleVideoMetadata));
     }
 
@@ -387,7 +387,7 @@ async function getHtml(ctx) {
 
     if (claim) {
       const ogMetadata = await buildClaimOgMetadata(claimUri, claim, {}, referrerQuery);
-      const googleVideoMetadata = buildGoogleVideoMetadata(claimUri, claim);
+      const googleVideoMetadata = await buildGoogleVideoMetadata(claimUri, claim);
       return insertToHead(html, ogMetadata.concat('\n', googleVideoMetadata));
     }
   }

--- a/web/src/metadata/googleVideo.js
+++ b/web/src/metadata/googleVideo.js
@@ -6,6 +6,16 @@ const { parseURI } = require('../lbryURI');
 const { OG_IMAGE_URL, SITE_NAME, URL } = require('../../../config.js');
 const { generateDirectUrl, generateEmbedUrl, getThumbnailCdnUrl, escapeHtmlProperty } = require('../../../ui/util/web');
 
+// ****************************************************************************
+// Utils
+// ****************************************************************************
+
+function lbryToOdyseeUrl(claim) {
+  if (claim.canonical_url) {
+    return `${URL}/${claim.canonical_url.replace('lbry://', '').replace(/#/g, ':')}`;
+  }
+}
+
 function truncateDescription(description, maxChars = 200) {
   // Get list of single-codepoint strings
   const chars = [...description];
@@ -14,6 +24,52 @@ function truncateDescription(description, maxChars = 200) {
   // Format truncated string
   return chars.length > maxChars ? truncated + '...' : truncated;
 }
+
+// ****************************************************************************
+// ****************************************************************************
+
+const Generate = {
+  author: (claim) => {
+    const channelName = claim?.signing_channel?.value?.title || claim?.signing_channel?.name;
+    const channelUrl = lbryToOdyseeUrl(claim.signing_channel);
+    if (channelName && channelUrl) {
+      return { '@type': 'Person', name: channelName, url: channelUrl };
+    }
+  },
+
+  height: (claim) => {
+    return claim?.value?.video?.height;
+  },
+
+  keywords: (claim) => {
+    const tags = claim?.value?.tags;
+    if (tags) {
+      // Some claims, probably created from cli, have a crazy amount of tags.
+      // Limit that to 10.
+      return tags.slice(0, 10).join(',');
+    }
+  },
+
+  potentialAction: (claim) => {
+    // https://developers.google.com/search/docs/advanced/structured-data/video?hl=en#seek
+    if ((claim?.value?.video || claim?.value?.audio) && claim.canonical_url) {
+      return {
+        '@type': 'SeekToAction',
+        target: `${lbryToOdyseeUrl(claim)}?t={seek_to_second_number}`,
+        'startOffset-input': 'required name=seek_to_second_number',
+      };
+    }
+  },
+
+  thumbnail: (url) => {
+    // We don't have 'width' and 'height' from the claim :(
+    return { '@type': 'ImageObject', url };
+  },
+
+  width: (claim) => {
+    return claim?.value?.video?.width;
+  },
+};
 
 // ****************************************************************************
 // buildGoogleVideoMetadata
@@ -52,8 +108,16 @@ function buildGoogleVideoMetadata(uri, claim) {
     uploadDate: `${new Date(releaseTime * 1000).toISOString()}`,
     // --- Recommended ---
     duration: mediaDuration ? moment.duration(mediaDuration * 1000).toISOString() : undefined,
+    url: generateDirectUrl(claim.name, claim.claim_id),
     contentUrl: generateDirectUrl(claim.name, claim.claim_id),
     embedUrl: generateEmbedUrl(claim.name, claim.claim_id),
+    // --- Misc ---
+    author: Generate.author(claim),
+    thumbnail: Generate.thumbnail(claimThumbnail),
+    keywords: Generate.keywords(claim),
+    width: Generate.width(claim),
+    height: Generate.height(claim),
+    potentialAction: Generate.potentialAction(claim),
   };
 
   if (


### PR DESCRIPTION
## Issue
The `contentUrl` was a redirect -- it needs to be directly pointing to the file itself instead.

## Change
1. Copied the way the url is generated from the RSS code.
2. Incrementally added more metadata for SEO.
  - <img width="200" alt="image" src="https://user-images.githubusercontent.com/64950861/172863578-87feff68-1374-4a39-a1f1-0ed82307f117.png">

## Concerns
1. I think the video url needs to be crawlable.  Is it?  I assume we blocked all crawlers for `player.odycdn`
    - <img width="437" alt="image" src="https://user-images.githubusercontent.com/64950861/172862804-0911e5fb-9e70-4ed2-9b3a-152e81fee280.png">
    - <sub>https://developers.google.com/search/docs/advanced/crawling/verifying-googlebot</sub>
2. This does incur an additional fetch for the streamURL.  Hopefully it doesn't impact page load.  I didn't notice a difference, though -- but not sure at the global scale.





