### PR TITLE
MediaSession: handle null thumbnail

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs-events.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs-events.jsx
@@ -208,7 +208,7 @@ const VideoJsEvents = ({
       navigator.mediaSession.metadata = new window.MediaMetadata({
         title: claimValues.title,
         artist: channelTitle,
-        artwork: [{ src: claimValues.thumbnail.url }],
+        artwork: claimValues?.thumbnail?.url ? [{ src: claimValues.thumbnail.url }] : undefined,
       });
 
       // $FlowFixMe


### PR DESCRIPTION
The exception thrown was causing the rest of `onInitPlay` to not run, e.g. "Tap to mute" not appearing, etc.

Closes #1663
