### PR TITLE
Handle invalid `/$/download` and `/$/stream` with a 404

### DIFF
--- a/web/src/routes.js
+++ b/web/src/routes.js
@@ -42,13 +42,17 @@ router.get(`/$/api/content/v2/get`, async (ctx) => getHomepage(ctx, 2));
 
 router.get(`/$/download/:claimName/:claimId`, async (ctx) => {
   const streamUrl = await getStreamUrl(ctx);
-  const downloadUrl = `${streamUrl}?download=1`;
-  ctx.redirect(downloadUrl);
+  if (streamUrl) {
+    const downloadUrl = `${streamUrl}?download=1`;
+    ctx.redirect(downloadUrl);
+  }
 });
 
 router.get(`/$/stream/:claimName/:claimId`, async (ctx) => {
   const streamUrl = await getStreamUrl(ctx);
-  ctx.redirect(streamUrl);
+  if (streamUrl) {
+    ctx.redirect(streamUrl);
+  }
 });
 
 router.get(`/$/activate`, async (ctx) => {


### PR DESCRIPTION
## Issue
- When `/$/download/:claimname/:claimId` is invalid<sup>1</sup>, it results in a bad loop that keeps requesting the same thing. Eventually it stops, though.
- When `/$/stream/:claimname/:claimId` is invalid, it results in a 302 page that simply says `Redirecting to .`, and is increasing in count as reported in search console.

## Fix
Return a 404 not found for these.

I'm guessing prior to `get`, it just returns whatever the generated URL's server error was?

----

_<sup>1</sup> This includes deleted claims ... when deleted, `get` returns nothing._

