### PR TITLE
Fix invalid claims ending up with status 500

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -380,8 +380,16 @@ async function getHtml(ctx) {
   }
 
   if (!requestPath.includes('$')) {
-    const parsedUri = parseURI(normalizeClaimUrl(requestPath.slice(1)));
-    const claimUri = buildURI({ ...parsedUri, startTime: undefined });
+    let parsedUri, claimUri;
+
+    try {
+      parsedUri = parseURI(normalizeClaimUrl(requestPath.slice(1)));
+      claimUri = buildURI({ ...parsedUri, startTime: undefined });
+    } catch (err) {
+      ctx.status = 404;
+      return err.message;
+    }
+
     const claim = await resolveClaimOrRedirect(ctx, claimUri);
     const referrerQuery = escapeHtmlProperty(getParameterByName('r', ctx.request.url));
 


### PR DESCRIPTION
## Issue
Due the `parseUri` not being used in a try-catch block, the thrown error surfaces all the way up and the 500 catch-all status was used.

The search console was been complaining about this for a while now. I've always thought "what's the problem here, you entered the wrong claim format", but now I realized it's about the error code.

## Change
`try-catch` the call as normal for that function, and return 404. We will still relay the error message it was.
