### PR TITLE
ChannelThumbnail: remove alt text to prevent from being used as search result

### DIFF
--- a/ui/component/channelThumbnail/view.jsx
+++ b/ui/component/channelThumbnail/view.jsx
@@ -121,7 +121,6 @@ function ChannelThumbnail(props: Props) {
     >
       {/* width: use the same size for all 'small' variants so that caching works better */}
       <OptimizedImage
-        alt={__('Channel profile picture')}
         className={!channelThumbnail ? 'channel-thumbnail__default' : 'channel-thumbnail__custom'}
         src={(!thumbLoadError && channelThumbnail) || defaultAvatar}
         width={xxsmall || xsmall || small ? 64 : 160}


### PR DESCRIPTION
Closes #1684

While Lighthouse suggests adding `alt`, I think it's just a recommendation that does not affect the Core Vitals score directly -- the large css plays a bigger role at the moment.

Also, we could consider these as more "decorative" than "functional", because the channel name string is the primary link to enter a channel page.
