### PR TITLE
Outbrain fixes and updates

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -543,6 +543,7 @@ function App(props: Props) {
         />
       ) : (
         <React.Fragment>
+          <AdsSticky uri={uri} />
           <Router uri={uri} embedLatestPath={embedLatestPath} />
           <ModalRouter />
 
@@ -560,8 +561,6 @@ function App(props: Props) {
             )}
             {getStatusNag()}
           </React.Suspense>
-
-          <AdsSticky uri={uri} />
         </React.Fragment>
       )}
     </div>

--- a/web/component/adsSticky/view.jsx
+++ b/web/component/adsSticky/view.jsx
@@ -49,7 +49,7 @@ export default function AdsSticky(props: Props) {
   function shouldShowAdsForPath(pathname, isContentClaim, isChannelClaim, authenticated) {
     // $FlowIssue: mixed type
     const pathIsCategory = Object.values(homepageData).some((x) => pathname.startsWith(`/$/${x?.name}`));
-    return pathIsCategory || isChannelClaim || (isContentClaim && !authenticated);
+    return pathIsCategory || isChannelClaim || (isContentClaim && !authenticated) || pathname === '/';
   }
 
   React.useEffect(() => {

--- a/web/component/adsSticky/view.jsx
+++ b/web/component/adsSticky/view.jsx
@@ -44,7 +44,7 @@ export default function AdsSticky(props: Props) {
   // Global conditions aside, should the Sticky be shown for this path:
   const inAllowedPath = shouldShowAdsForPath(location.pathname, isContentClaim, isChannelClaim, authenticated);
   // Final answer:
-  const shouldLoadSticky = shouldShowAds && inAllowedPath && !gScript && !inIFrame() && !platform.isMobile();
+  const shouldLoadSticky = shouldShowAds && !gScript && !inIFrame() && !platform.isMobile();
 
   function shouldShowAdsForPath(pathname, isContentClaim, isChannelClaim, authenticated) {
     // $FlowIssue: mixed type


### PR DESCRIPTION
I've tested the various scenarios (Premium+, Incognito, mobile, etc.), but do give it a shot given my bad track record in this area.
Sorry, no test instance since I'm preserving the load-order problem for Adnimation.

## Changes
- Fixes the issue of In-content not loading when going from Homepage -> Category -> Homepage the first time.
  - This was due to the shared `OBR` instance between the Sticky and In-content.
- No longer need to re-load the scripts on every page navigation -- this should improve user performance and reduce DOM clutter.
- Enable sticky for homepage.
- Temporarily address the script load-order problem by moving components around. Not ideal, but works for now.