### PR TITLE
Fix playsinline bug on iOS

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -314,9 +314,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         });
       }
 
-      // set playsinline for mobile
-      player.children_[0].setAttribute('playsinline', '');
-
       // immediately show control bar while video is loading
       player.userActive(true);
 
@@ -431,6 +428,8 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       vjsPlayer.controlBar?.show();
 
       vjsPlayer.poster(poster);
+
+      vjsPlayer.el().childNodes[0].setAttribute('playsinline', '');
 
       let contentUrl;
       // TODO: pull this function into videojs-functions


### PR DESCRIPTION
`playsinline` attribute isn't being persisted after previous bugfix, this fixes it on iOS