### PR TITLE
Show controls if both calls to play() fail

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -511,13 +511,29 @@ export default React.memo<Props>(function VideoJs(props: Props) {
                   // $FlowIssue
                   vjsPlayer?.muted(true);
                   // $FlowIssue
-                  vjsPlayer?.play();
-                  // $FlowIssue
-                  document.querySelector('.video-js--tap-to-unmute')?.style.setProperty('visibility', 'visible');
-                  // $FlowIssue
-                  document
-                    .querySelector('.video-js--tap-to-unmute')
-                    ?.style.setProperty('display', 'inline', 'important');
+                  const mutedPlayPromise = vjsPlayer?.play();
+                  if (mutedPlayPromise !== undefined) {
+                    mutedPlayPromise
+                      .then(() => {
+                        const tapToUnmuteButton = document.querySelector('.video-js--tap-to-unmute');
+
+                        // $FlowIssue
+                        tapToUnmuteButton?.style.setProperty('visibility', 'visible');
+                        // $FlowIssue
+                        tapToUnmuteButton?.style.setProperty('display', 'inline', 'important');
+                      })
+                      .catch((error) => {
+                        // $FlowFixMe
+                        vjsPlayer?.addClass('vjs-paused');
+                        // $FlowFixMe
+                        vjsPlayer?.addClass('vjs-has-started');
+
+                        // $FlowFixMe
+                        document.querySelector('.vjs-touch-overlay')?.classList.add('show-play-toggle');
+                        // $FlowFixMe
+                        document.querySelector('.vjs-play-control')?.classList.add('vjs-paused');
+                      });
+                  }
                 } else {
                   // $FlowIssue
                   vjsPlayer?.bigPlayButton?.show();


### PR DESCRIPTION
Addresses issue: https://github.com/OdyseeTeam/odysee-frontend/issues/1716

Hypothesizing that the state occurs when both calls to `play()` fail (based on my own testing of how to replicate the state), this will catch the second `play` error and show the overlay as if the video has been paused

Hopefully a user who is experiencing this can test it first before a merge to confirm it fixes their issue