### PR TITLE
DRY: recommended selectors

### DIFF
--- a/ui/redux/selectors/search.js
+++ b/ui/redux/selectors/search.js
@@ -1,7 +1,5 @@
 // @flow
-import { getSearchQueryString } from 'util/query-params';
 import { selectShowMatureContent } from 'redux/selectors/settings';
-import { SEARCH_OPTIONS } from 'constants/search';
 import {
   selectClaimsByUri,
   makeSelectClaimForUri,
@@ -14,11 +12,10 @@ import { parseURI } from 'util/lbryURI';
 import { isClaimNsfw } from 'util/claim';
 import { createSelector } from 'reselect';
 import { createCachedSelector } from 're-reselect';
-import { createNormalizedSearchKey, getRecommendationSearchOptions } from 'util/search';
+import { createNormalizedSearchKey, getRecommendationSearchKey, getRecommendationSearchOptions } from 'util/search';
 import { selectMutedChannels } from 'redux/selectors/blocked';
 import { selectHistory } from 'redux/selectors/content';
 import { selectAllCostInfoByUri } from 'lbryinc';
-import { SIMPLE_SITE } from 'config';
 
 type State = { claims: any, search: SearchState, user: UserState };
 
@@ -66,7 +63,6 @@ export const selectRecommendedContentForUri = createCachedSelector(
   selectClaimIsNsfwForUri, // (state, uri)
   (uri, history, claimsByUri, matureEnabled, blockedChannels, costInfoByUri, searchUrisByQuery, isMature) => {
     const claim = claimsByUri[uri];
-
     if (!claim) return;
 
     let recommendedContent;
@@ -74,26 +70,10 @@ export const selectRecommendedContentForUri = createCachedSelector(
     const currentClaimId = claim.claim_id;
 
     const { title } = claim.value;
-
     if (!title) return;
 
-    const options: {
-      size: number,
-      nsfw?: boolean,
-      isBackgroundSearch?: boolean,
-    } = { size: 20, nsfw: matureEnabled, isBackgroundSearch: true };
-
-    if (SIMPLE_SITE) {
-      options[SEARCH_OPTIONS.CLAIM_TYPE] = SEARCH_OPTIONS.INCLUDE_FILES;
-      options[SEARCH_OPTIONS.MEDIA_VIDEO] = true;
-      options[SEARCH_OPTIONS.PRICE_FILTER_FREE] = true;
-    }
-    if (matureEnabled || (!matureEnabled && !isMature)) {
-      options[SEARCH_OPTIONS.RELATED_TO] = claim.claim_id;
-    }
-
-    const searchQuery = getSearchQueryString(title.replace(/\//, ' '), options);
-    const normalizedSearchQuery = createNormalizedSearchKey(searchQuery);
+    const options = getRecommendationSearchOptions(matureEnabled, isMature, claim.claim_id);
+    const normalizedSearchQuery = getRecommendationSearchKey(title, options);
 
     let searchResult = searchUrisByQuery[normalizedSearchQuery];
 
@@ -169,8 +149,7 @@ export const makeSelectRecommendedRecsysIdForClaimId = (claimId: string) =>
         }
 
         const options = getRecommendationSearchOptions(matureEnabled, isMature, claimId);
-        const searchQuery = getSearchQueryString(title.replace(/\//, ' '), options);
-        const normalizedSearchQuery = createNormalizedSearchKey(searchQuery);
+        const normalizedSearchQuery = getRecommendationSearchKey(title, options);
 
         const searchResult = searchUrisByQuery[normalizedSearchQuery];
         if (searchResult) {

--- a/ui/util/search.js
+++ b/ui/util/search.js
@@ -3,6 +3,7 @@
 import { isNameValid, isURIValid, normalizeURI, parseURI } from 'util/lbryURI';
 import { URL as SITE_URL, URL_LOCAL, URL_DEV, SIMPLE_SITE } from 'config';
 import { SEARCH_OPTIONS } from 'constants/search';
+import { getSearchQueryString } from 'util/query-params';
 
 export function createNormalizedSearchKey(query: string) {
   const removeParam = (query: string, param: string) => {
@@ -97,6 +98,16 @@ export function getUriForSearchTerm(term: string) {
   }
 }
 
+/**
+ * The 'Recommended' search query is used as the key to store the results. This
+ * function ensures all clients derive the same key by making this the only
+ * place to make tweaks.
+ *
+ * @param matureEnabled
+ * @param claimIsMature
+ * @param claimId
+ * @returns {{size: number, nsfw: boolean, isBackgroundSearch: boolean}}
+ */
 export function getRecommendationSearchOptions(matureEnabled: boolean, claimIsMature: boolean, claimId: string) {
   const options = { size: 20, nsfw: matureEnabled, isBackgroundSearch: true };
 
@@ -111,4 +122,9 @@ export function getRecommendationSearchOptions(matureEnabled: boolean, claimIsMa
   }
 
   return options;
+}
+
+export function getRecommendationSearchKey(title: string, options: {}) {
+  const searchQuery = getSearchQueryString(title.replace(/\//, ' '), options);
+  return createNormalizedSearchKey(searchQuery);
 }


### PR DESCRIPTION
Bring back the refactoring commits from the reverted #1616.
No functional change -- equivalent code.

Needed to do the same thing for the uuid stuff.