### PR TITLE
Recsys: capture and use `x-uuid` from search results

### DIFF
--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -81,6 +81,11 @@ const recsys: Recsys = {
    * Page was loaded. Get or Create entry and populate it with default data,
    * plus recommended content, recsysId, etc.
    * Called from recommendedContent component
+   *
+   * @param claimId The ID of the content the recommendations are for.
+   * @param uris The recommended uris for `claimId`.
+   * @param uuid Specific uuid to use (e.g. for FYP); randomly generates one
+   *             otherwise.
    */
   onRecsLoaded: function (claimId, uris, uuid = '') {
     if (window && window.store) {
@@ -107,7 +112,8 @@ const recsys: Recsys = {
    * Creates an Entry with optional parentUuid
    * @param: claimId: string
    * @param: parentUuid: string (optional)
-   * @param: uuid: string Specific uuid to use.
+   * @param uuid Specific uuid to use (e.g. for FYP); randomly generates one
+   *             otherwise.
    */
   createRecsysEntry: function (claimId, parentUuid, uuid = '') {
     if (window && window.store && claimId) {
@@ -154,6 +160,7 @@ const recsys: Recsys = {
       IS_WEB || (window && window.store && selectDaemonSettings(window.store.getState()).share_usage_data);
 
     if (recsys.entries[claimId] && shareTelemetry) {
+      // Exclude `events` in the submission https://github.com/OdyseeTeam/odysee-frontend/issues/1317
       const { events, ...entryData } = recsys.entries[claimId];
       const data = JSON.stringify(entryData);
 

--- a/flow-typed/search.js
+++ b/flow-typed/search.js
@@ -36,6 +36,12 @@ declare type SearchState = {
   personalRecommendations: { gid: string, uris: Array<string>, fetched: boolean },
 };
 
+declare type SearchResults = {
+  body: Array<{ name: string, claimId: string}>,
+  poweredBy: string,
+  uuid: string,
+};
+
 declare type SearchSuccess = {
   type: ACTIONS.SEARCH_SUCCESS,
   data: {

--- a/flow-typed/search.js
+++ b/flow-typed/search.js
@@ -28,7 +28,7 @@ declare type SearchOptions = {
 
 declare type SearchState = {
   options: SearchOptions,
-  resultsByQuery: {},
+  resultsByQuery: { [string]: { uris: Array<string>, recsys: string, uuid: string } },
   results: Array<string>,
   hasReachedMaxResultsLength: {},
   searching: boolean,
@@ -49,7 +49,8 @@ declare type SearchSuccess = {
     from: number,
     size: number,
     uris: Array<string>,
-    recsys: string,
+    poweredBy: string,
+    uuid: string,
   },
 };
 

--- a/ui/component/recommendedContent/view.jsx
+++ b/ui/component/recommendedContent/view.jsx
@@ -88,6 +88,7 @@ export default React.memo<Props>(function RecommendedContent(props: Props) {
   // e.g. never in a floating popup. With that, we can grab the FYP ID from
   // the search param directly. Otherwise, the parent component would need to
   // pass it.
+  // @see https://www.notion.so/FYP-Design-Notes-727782dde2cb485290c530ae96a34285
   const { search } = location;
   const urlParams = new URLSearchParams(search);
   const fypId = urlParams.get(FYP_ID);

--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -171,11 +171,12 @@ export const doSearch = (rawQuery: string, searchOptions: SearchOptions) => (
   const cmd = isSearchingRecommendations ? lighthouse.searchRecommendations : lighthouse.search;
 
   cmd(queryWithOptions)
-    .then((data: { body: Array<{ name: string, claimId: string }>, poweredBy: string }) => {
+    .then((data: SearchResults) => {
       const { body: result, poweredBy } = data;
       const uris = processLighthouseResults(result);
 
       if (isSearchingRecommendations) {
+        // Temporarily resolve using `claim_search` until the SDK bug is fixed.
         const claimIds = result.map((x) => x.claimId);
         dispatch(doResolveClaimIds(claimIds)).finally(() => {
           dispatch({

--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -172,7 +172,7 @@ export const doSearch = (rawQuery: string, searchOptions: SearchOptions) => (
 
   cmd(queryWithOptions)
     .then((data: SearchResults) => {
-      const { body: result, poweredBy } = data;
+      const { body: result, poweredBy, uuid } = data;
       const uris = processLighthouseResults(result);
 
       if (isSearchingRecommendations) {
@@ -186,7 +186,8 @@ export const doSearch = (rawQuery: string, searchOptions: SearchOptions) => (
               from: from,
               size: size,
               uris,
-              recsys: poweredBy,
+              poweredBy,
+              uuid,
             },
           });
         });
@@ -202,7 +203,8 @@ export const doSearch = (rawQuery: string, searchOptions: SearchOptions) => (
           from: from,
           size: size,
           uris,
-          recsys: poweredBy,
+          poweredBy,
+          uuid,
         },
       });
 

--- a/ui/redux/reducers/search.js
+++ b/ui/redux/reducers/search.js
@@ -32,7 +32,7 @@ export default handleActions(
       searching: true,
     }),
     [ACTIONS.SEARCH_SUCCESS]: (state: SearchState, action: SearchSuccess): SearchState => {
-      const { query, uris, from, size, recsys } = action.data;
+      const { query, uris, from, size, poweredBy: recsys, uuid } = action.data;
       const normalizedQuery = createNormalizedSearchKey(query);
       const urisForQuery = state.resultsByQuery[normalizedQuery] && state.resultsByQuery[normalizedQuery]['uris'];
 
@@ -44,7 +44,7 @@ export default handleActions(
       // The returned number of urls is less than the page size, so we're on the last page
       const noMoreResults = size && uris.length < size;
 
-      const results = { uris: newUris, recsys };
+      const results = { uris: newUris, recsys, uuid };
       return {
         ...state,
         searching: false,

--- a/ui/redux/selectors/search.js
+++ b/ui/redux/selectors/search.js
@@ -25,8 +25,7 @@ export const selectState = (state: State): SearchState => state.search;
 export const selectSearchValue: (state: State) => string = (state) => selectState(state).searchQuery;
 export const selectSearchOptions: (state: State) => SearchOptions = (state) => selectState(state).options;
 export const selectIsSearching: (state: State) => boolean = (state) => selectState(state).searching;
-export const selectSearchResultByQuery: (state: State) => { [string]: Array<string> } = (state) =>
-  selectState(state).resultsByQuery;
+export const selectSearchResultByQuery = (state: State) => selectState(state).resultsByQuery;
 export const selectHasReachedMaxResultsLength: (state: State) => { [boolean]: Array<boolean> } = (state) =>
   selectState(state).hasReachedMaxResultsLength;
 export const selectMentionSearchResults: (state: State) => Array<string> = (state) => selectState(state).results;

--- a/ui/util/handle-fetch.js
+++ b/ui/util/handle-fetch.js
@@ -2,8 +2,9 @@
 export default function handleFetchResponse(response: Response): Promise<any> {
   const headers = response.headers;
   const poweredBy = headers.get('x-powered-by');
+  const uuid = headers.get('x-uuid');
 
   return response.status === 200
-    ? response.json().then((body) => ({ body, poweredBy }))
+    ? response.json().then((body) => ({ body, poweredBy, uuid }))
     : Promise.reject(new Error(response.statusText));
 }


### PR DESCRIPTION
Closes [#1717 Use server-side generated UUID for related-items logging](https://github.com/OdyseeTeam/odysee-frontend/issues/1717)
