### PR TITLE
Fix a bunch of `lbry://undefined` resolves

### DIFF
--- a/ui/component/fileThumbnail/index.js
+++ b/ui/component/fileThumbnail/index.js
@@ -7,7 +7,7 @@ const select = (state, props) => {
   const { uri } = props;
 
   return {
-    hasResolvedClaim: selectHasResolvedClaimForUri(state, uri),
+    hasResolvedClaim: uri ? selectHasResolvedClaimForUri(state, uri) : undefined,
     thumbnailFromClaim: selectThumbnailForUri(state, uri),
   };
 };

--- a/ui/component/fileThumbnail/view.jsx
+++ b/ui/component/fileThumbnail/view.jsx
@@ -16,7 +16,7 @@ import classnames from 'classnames';
 import Thumb from './internal/thumb';
 
 type Props = {
-  uri: string,
+  uri?: string,
   tileLayout?: boolean,
   thumbnail: ?string, // externally sourced image
   children?: Node,
@@ -26,7 +26,7 @@ type Props = {
   small?: boolean,
   forcePlaceholder?: boolean,
   // -- redux --
-  hasResolvedClaim: boolean,
+  hasResolvedClaim: ?boolean, // undefined if uri is not given (irrelevant); boolean otherwise.
   thumbnailFromClaim: ?string,
   doResolveUri: (uri: string) => void,
 };
@@ -54,7 +54,7 @@ function FileThumbnail(props: Props) {
   const isGif = thumbnail && thumbnail.endsWith('gif');
 
   React.useEffect(() => {
-    if (!hasResolvedClaim && !passedThumbnail) {
+    if (hasResolvedClaim === false && uri && !passedThumbnail) {
       doResolveUri(uri);
     }
   }, [hasResolvedClaim, passedThumbnail, doResolveUri, uri]);
@@ -68,7 +68,7 @@ function FileThumbnail(props: Props) {
           small={small}
           src={url}
           className={classnames('media__thumb', className, {
-            'media__thumb--resolving': !hasResolvedClaim,
+            'media__thumb--resolving': hasResolvedClaim === false,
             'media__thumb--small': small,
           })}
         >
@@ -108,7 +108,7 @@ function FileThumbnail(props: Props) {
   return (
     <div
       className={classnames('media__thumb', className, {
-        'media__thumb--resolving': !hasResolvedClaim,
+        'media__thumb--resolving': hasResolvedClaim === false,
         'media__thumb--small': small,
       })}
     >

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -160,6 +160,9 @@ export const selectClaimForUri = createCachedSelector(
 )((state, uri, returnRepost = true) => `${String(uri)}:${returnRepost ? '1' : '0'}`);
 
 export const selectHasResolvedClaimForUri = (state: State, uri: string) => {
+  // This selector assumes that `uri` is never null and is valid. It
+  // cannot differentiate whether the undefined claim is due to being
+  // unresolved or an invalid `uri`. Client beware.
   const claim = selectClaimForUri(state, uri);
   return claim !== undefined;
 };


### PR DESCRIPTION
Note: This goes into the playlist PR, not `master`.  Not pushing directly in case there are rebase problems, or if there is conflict in meaning.

## Issue
Seeing a bunch of bad resolve calls.
<img width="304" alt=" undefined-resolve" src="https://user-images.githubusercontent.com/64950861/174993285-5cf3cd09-ebf0-4315-824d-389f0a5b9a2a.png">

## Change
- FileThumbnail can work without `uri`, so we still need to check for `uri` before making the fetch.
- Given that `hasResolvedClaim` now incorporates `uri` into the logic (differentiating between unresolved vs. not needed), use `=== false` instead for clarity.
- The extra `&& uri` is to keep lint happy.
