### PR TITLE
Change collection item fetch-page from 5 to 50

### DIFF
--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -135,7 +135,7 @@ export function doResolveUris(
       });
 
       if (collectionIds.length) {
-        dispatch(doFetchItemsInCollections({ collectionIds: collectionIds, pageSize: 5 }));
+        dispatch(doFetchItemsInCollections({ collectionIds: collectionIds, pageSize: 50 }));
       }
 
       return result;


### PR DESCRIPTION
## Reproduce:
- http://localhost:9090/@AlphaNerd:8/the-crypto-market-dumps-again-(xmr-is-on:6
- One of the comments contain a link to a playlist of 13 items, which results in 3 additional `claim_searches` of 5 each

## Notes
In `doResolveUri`, if the `uri` is a collection, it will attempt to fetch all items in the collection.

Can't think of any special reason to keep the page-size small, and not seeing any notes in the commits either, so bumping it to 50.

