### PR TITLE
ReportContent: redirect back after logging in

### DIFF
--- a/ui/component/header/view.jsx
+++ b/ui/component/header/view.jsx
@@ -21,6 +21,7 @@ import WunderBar from 'component/wunderbar';
 type Props = {
   authenticated: boolean,
   authHeader: boolean,
+  authRedirect?: string, // Redirects to '/' by default.
   backout: {
     backLabel?: string,
     backNavDefault?: string,
@@ -56,6 +57,7 @@ const Header = (props: Props) => {
   const {
     authenticated,
     authHeader,
+    authRedirect,
     backout,
     balance,
     emailToVerify,
@@ -105,6 +107,8 @@ const Header = (props: Props) => {
   const sidebarLabel = sidebarOpen
     ? __('Close sidebar - hide channels you are following.')
     : __('Expand sidebar - view channels you are following.');
+
+  const authRedirectParam = authRedirect ? `?redirect=${authRedirect}` : '';
 
   const onBackout = React.useCallback(
     (e: any) => {
@@ -169,8 +173,18 @@ const Header = (props: Props) => {
         </>
       ) : !isMobile ? (
         <div className="header__authButtons">
-          <Button navigate={`/$/${PAGES.AUTH_SIGNIN}`} button="link" label={__('Log In')} disabled={user === null} />
-          <Button navigate={`/$/${PAGES.AUTH}`} button="primary" label={__('Sign Up')} disabled={user === null} />
+          <Button
+            navigate={`/$/${PAGES.AUTH_SIGNIN}${authRedirectParam}`}
+            button="link"
+            label={__('Log In')}
+            disabled={user === null}
+          />
+          <Button
+            navigate={`/$/${PAGES.AUTH}${authRedirectParam}`}
+            button="primary"
+            label={__('Sign Up')}
+            disabled={user === null}
+          />
         </div>
       ) : (
         <HeaderProfileMenuButton />

--- a/ui/component/page/view.jsx
+++ b/ui/component/page/view.jsx
@@ -17,6 +17,7 @@ const Footer = lazyImport(() => import('web/component/footer' /* webpackChunkNam
 
 type Props = {
   authPage: boolean,
+  authRedirect?: string, // Redirects to '/' by default.
   backout: {
     backLabel?: string,
     backNavDefault?: string,
@@ -43,6 +44,7 @@ type Props = {
 function Page(props: Props) {
   const {
     authPage = false,
+    authRedirect,
     backout,
     chatDisabled,
     children,
@@ -95,6 +97,7 @@ function Page(props: Props) {
       {!noHeader && (
         <Header
           authHeader={authPage}
+          authRedirect={authRedirect}
           backout={backout}
           sidebarOpen={sidebarOpen}
           isAbsoluteSideNavHidden={isAbsoluteSideNavHidden}

--- a/ui/page/reportContent/view.jsx
+++ b/ui/page/reportContent/view.jsx
@@ -1,9 +1,12 @@
 // @flow
 import React from 'react';
+import { useHistory } from 'react-router';
 import Page from 'component/page';
 import ReportContent from 'component/reportContent';
 
 export default function ReportContentPage(props: any) {
+  const { location } = useHistory();
+
   return (
     <Page
       noSideNavigation
@@ -12,6 +15,7 @@ export default function ReportContentPage(props: any) {
         backoutLabel: __('Done'),
         title: __('Report content'),
       }}
+      authRedirect={`${location.pathname}${location.search}`} // 'report_content?claimId=xxx'
     >
       <ReportContent />
     </Page>


### PR DESCRIPTION
## Issue
Closes #1709 - If you sign in while reporting, you end up in the homepage

## Notes
The other option is to just make `<Header>` always redirect back to where it came from using the full path. But existing code elsewhere seem to always trim off any params (e.g. `location.search`, `location.hash`) when doing redirects.

So, ended up making it generic and let the caller decide where to redirect (and with what params).
