### PR TITLE
Handle browsers that don't support `IntersectionObserver`

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -525,33 +525,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
             });
         }
       }
-
-      // fix invisible vidcrunch overlay on IOS  << TODO: does not belong here. Move to ads.jsx (#739)
-      if (IS_IOS) {
-        // ads video player
-        const adsClaimDiv = document.querySelector('.ads__claim-item');
-
-        if (adsClaimDiv) {
-          // hide ad video by default
-          adsClaimDiv.style.display = 'none';
-
-          // ad containing div, we can keep part on page
-          const adsClaimParentDiv = adsClaimDiv.parentNode;
-
-          // watch parent div for when it is on viewport
-          const observer = new IntersectionObserver(function (entries) {
-            // when ad div parent becomes visible by 1px, show the ad video
-            if (entries[0].isIntersecting === true) {
-              adsClaimDiv.style.display = 'block';
-            }
-
-            observer.disconnect();
-          });
-
-          // $FlowFixMe
-          observer.observe(adsClaimParentDiv);
-        }
-      }
     })();
 
     // Cleanup


### PR DESCRIPTION
See commit notes for implementation details.

## Issue
Closes [#1736 fetch support for older Safari ](https://github.com/OdyseeTeam/odysee-frontend/issues/1736)

## Review notes
- The `fetch` issue is only with iOS 8 which the iPad Air 2 came with originally. It supports an upgrade to iOS 15 now.
  - `fetch` is supported at least from iOS 11 onwards (maybe earlier), so I don't think we need to patch that far behind because our SSL cert doesn't work on it anyway. We would also need to handle missing `URLSearchParams` if so.
    - <img width="477" alt="image" src="https://user-images.githubusercontent.com/64950861/175237182-a3f13dad-31d1-4d32-b7d2-2315b78b2ab3.png">
- With iOS 11, the page loads now :heavy_check_mark: 
  - But thumbnails are not loading.  I think there is an issue with the CDN SSL like what I was seeing in iOS 8 above (_lambdatest's devtools is super laggy so I couldn't see what's wrong.  BrowserStack's devtools work, but they don't upgrade to iOS 15_).
  - It's definitely not related to the `IntersectionObserver` because the gerbil doesn't use it.  Non-CDN images load fine.
  - <img width="403" alt="image" src="https://user-images.githubusercontent.com/64950861/175236558-499093a9-2e23-466a-8985-99779623c502.png">
