### PR TITLE
Recsys: fix missing uuid

### DIFF
--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -93,6 +93,9 @@ const recsys: Recsys = {
 
       if (!recsys.entries[claimId]) {
         recsys.createRecsysEntry(claimId, null, uuid || recommendedMeta.uuid);
+      } else if (!recsys.entries[claimId].uuid) {
+        // Stubs might not have the uuid ready at the time. Refill now.
+        recsys.entries[claimId].uuid = uuid || recommendedMeta.uuid;
       }
 
       const claimIds = getClaimIdsFromUris(uris);


### PR DESCRIPTION
Ticket: #1745

## Issue
The search result (and the uuid) won't be ready when a recommendation is clicked, but a stub recsyst entry is created at this point. In the past, the uuid was randomly generated, so it didn't matter.

## Fix
Ensure the uuid field is filled when the recommendations are finally loaded.
