### PR TITLE
Add lbry_api_url to env defaults

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -12,6 +12,7 @@ LBRY_WEB_API=https://api.na-backend.odysee.com
 LBRY_WEB_PUBLISH_API=https://publish.na-backend.odysee.com/v1
 LBRY_WEB_PUBLISH_API_V2=https://publish.na-backend.odysee.com/api/v2/publish/
 LBRY_WEB_BUFFER_API=https://collector-service.api.lbry.tv/api/v1/events/video
+LBRY_API_URL=https://api.odysee.com
 COMMENT_SERVER_API=https://comments.odysee.tv/api/v2
 SEARCH_SERVER_API_ALT=https://recsys.odysee.tv/search
 SEARCH_SERVER_API=https://lighthouse.odysee.tv/search


### PR DESCRIPTION
Currently `LBRY_API_URL` is not set in `.env.defaults` but rather uses the default value in `Lbryio`. 