### PR TITLE
Recsys: add `isEmbed` to videos in Markdown (posts, comments)

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -82,7 +82,8 @@ type Props = {
   claimId: ?string,
   title: ?string,
   channelTitle: string,
-  embedded: boolean,
+  embedded: boolean, // `/$/embed`
+  embeddedInternal: boolean, // Markdown (Posts and Comments)
   internalFeatureEnabled: ?boolean,
   isAudio: boolean,
   poster: ?string,
@@ -142,6 +143,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     title,
     channelTitle,
     embedded,
+    embeddedInternal,
     // internalFeatureEnabled, // for people on the team to test new features internally
     isAudio,
     poster,
@@ -310,7 +312,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         player.recsys({
           videoId: claimId,
           userId: userId,
-          embedded: embedded,
+          embedded: embedded || embeddedInternal,
         });
       }
 
@@ -381,7 +383,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         vjsPlayer.recsys.options_ = {
           videoId: claimId,
           userId: userId,
-          embedded: embedded,
+          embedded: embedded || embeddedInternal,
         };
 
         vjsPlayer.recsys.lastTimeUpdate = null;

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -525,6 +525,7 @@ function VideoViewer(props: Props) {
         playNext={doPlayNext}
         playPrevious={doPlayPrevious}
         embedded={embedded}
+        embeddedInternal={isMarkdownOrComment}
         claimValues={claim.value}
         doAnalyticsView={doAnalyticsView}
         doAnalyticsBuffer={doAnalyticsBuffer}

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -561,8 +561,6 @@ export const selectIsUriResolving = (state: State, uri: string) => {
   return resolvingUris && resolvingUris.includes(uri);
 };
 
-export const selectPlayingUri = (state: State) => selectState(state).playingUri;
-
 export const selectChannelClaimCounts = createSelector(selectState, (state) => state.channelClaimCounts || {});
 
 export const makeSelectPendingClaimForUri = (uri: string) =>


### PR DESCRIPTION
It seems like the existing `embedded` needs to specifically mean `/$/embed` (external from odysee.com), so had to add another variable.
