### PR TITLE
Workaround for markdown crash with Google Translate

### DIFF
--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -253,7 +253,7 @@ export default React.memo<MarkdownProps>(function MarkdownPreview(props: Markdow
   }
 
   return (
-    <div dir="auto" className={classnames('markdown-preview', className)}>
+    <div dir="auto" className={classnames('notranslate markdown-preview', className)}>
       {
         remark()
           .use(remarkAttr, remarkAttrOpts)


### PR DESCRIPTION
## Issue
Depending on what the markdown content was, React crashes when unmounting the component if Google Translate is active.

## Change
It seems like the content is too dynamic to apply the same workaround used in 1772 for FileReactions (someone else can take a stab).

Until we have a better solution, just make the markdown component (posts, comments, file description, etc.) not participate in Chrome-level translations. It's not a good solution from a user standpoint, but it at least it doesn't crash.
