### PR TITLE
PublishDate: make widget follow the 24h format setting

### DIFF
--- a/ui/component/publishReleaseDate/index.js
+++ b/ui/component/publishReleaseDate/index.js
@@ -1,12 +1,15 @@
 import { connect } from 'react-redux';
+import * as SETTINGS from 'constants/settings';
 import { makeSelectPublishFormValue } from 'redux/selectors/publish';
 import { doUpdatePublishForm } from 'redux/actions/publish';
+import { selectClientSetting } from 'redux/selectors/settings';
 import PublishReleaseDate from './view';
 
 const select = (state) => ({
   releaseTime: makeSelectPublishFormValue('releaseTime')(state),
   releaseTimeEdited: makeSelectPublishFormValue('releaseTimeEdited')(state),
   releaseTimeError: makeSelectPublishFormValue('releaseTimeError')(state),
+  clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/publishReleaseDate/view.jsx
+++ b/ui/component/publishReleaseDate/view.jsx
@@ -17,18 +17,21 @@ const RESET_TO_ORIGINAL = 'reset-to-original';
 const FUTURE_DATE_ERROR = 'Cannot set to a future date.';
 
 type Props = {
-  releaseTime: ?number,
-  releaseTimeEdited: ?number,
-  updatePublishForm: ({}) => void,
   allowDefault: ?boolean,
   showNowBtn: ?boolean,
   useMaxDate: ?boolean,
+  // --- redux:
+  releaseTime: ?number,
+  releaseTimeEdited: ?number,
+  clock24h: boolean,
+  updatePublishForm: ({}) => void,
 };
 
 const PublishReleaseDate = (props: Props) => {
   const {
     releaseTime,
     releaseTimeEdited,
+    clock24h,
     updatePublishForm,
     allowDefault = true,
     showNowBtn = true,
@@ -155,7 +158,7 @@ const PublishReleaseDate = (props: Props) => {
             onBlur={handleBlur}
             onChange={onDateTimePickerChanged}
             value={date}
-            format="y-MM-dd h:mm a"
+            format={clock24h ? 'y-MM-dd HH:mm' : 'y-MM-dd h:mm a'}
             disableClock
             clearIcon={null}
           />


### PR DESCRIPTION
Closes #1738

## Test
You can use `new Date(store.getState().publish.releaseTimeEdited * 1000)` to test along, with the following to keep in mind:
- On a cleared form, the calendar should be showing "--:--:--" but it is currently showing some value. The fix is in the upcoming publish reform branch.
- When an entered value is invalid (e.g. future), `releaseTimeEdited` is not updated + form disabled + warning appears (i.e. invalid values are not stored in redux).