### PR TITLE
Batch-resolve private collections

### DIFF
--- a/ui/component/collectionItemsList/index.js
+++ b/ui/component/collectionItemsList/index.js
@@ -1,6 +1,11 @@
 import { connect } from 'react-redux';
-import { doCollectionEdit } from 'redux/actions/collections';
-import { selectUrlsForCollectionId } from 'redux/selectors/collections';
+import { doCollectionEdit, doFetchItemsInCollection } from 'redux/actions/collections';
+import {
+  selectUrlsForCollectionId,
+  selectIsResolvingCollectionForId,
+  selectIsCollectionPrivateForId,
+  selectCollectionForId,
+} from 'redux/selectors/collections';
 
 import CollectionItemsList from './view';
 
@@ -9,11 +14,15 @@ const select = (state, props) => {
 
   return {
     collectionUrls: selectUrlsForCollectionId(state, collectionId),
+    collection: selectCollectionForId(state, collectionId),
+    isResolvingCollection: selectIsResolvingCollectionForId(state, collectionId),
+    isPrivateCollection: selectIsCollectionPrivateForId(state, collectionId),
   };
 };
 
 const perform = {
   doCollectionEdit,
+  doFetchItemsInCollection,
 };
 
 export default connect(select, perform)(CollectionItemsList);

--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -14,6 +14,7 @@ import {
 } from 'redux/selectors/collections';
 import * as COLS from 'constants/collections';
 import { isPermanentUrl } from 'util/claim';
+import { parseClaimIdFromPermanentUrl } from 'util/url';
 
 const FETCH_BATCH_SIZE = 50;
 
@@ -83,6 +84,11 @@ export const doCollectionDelete = (id: string, colKey: ?string = undefined) => (
 //   });
 // };
 
+function isPrivateCollectionId(collectionId: string) {
+  // Private (unpublished) collections uses UUID.
+  return collectionId.includes('-');
+}
+
 export const doFetchItemsInCollections = (
   resolveItemsOptions: {
     collectionIds: Array<string>,
@@ -107,7 +113,16 @@ export const doFetchItemsInCollections = (
 
   if (resolveStartedCallback) resolveStartedCallback();
 
-  const collectionIdsToSearch = collectionIds.filter((claimId) => !state.claims.byId[claimId]);
+  const privateCollectionIds = [];
+  const collectionIdsToSearch = [];
+
+  collectionIds.forEach((id) => {
+    if (isPrivateCollectionId(id)) {
+      privateCollectionIds.push(id);
+    } else if (!state.claims.byId[id]) {
+      collectionIdsToSearch.push(id);
+    }
+  });
 
   if (collectionIdsToSearch.length) {
     // TODO: this might fail if there are >50 collections due to the claim_search
@@ -119,11 +134,12 @@ export const doFetchItemsInCollections = (
 
   const stateAfterClaimSearch = getState();
 
-  async function fetchItemsForCollectionClaim(claim: CollectionClaim, pageSize?: number) {
-    const totalItems = claim.value.claims && claim.value.claims.length;
-    const claimId = claim.claim_id;
-    const itemOrder = claim.value.claims;
-
+  async function fetchItemsForCollectionClaim(
+    collectionId: string,
+    totalItems: number,
+    itemIdsInOrder: Array<string>,
+    pageSize?: number
+  ) {
     const sortResults = (items: Array<Claim>, claimList) => {
       const newItems: Array<Claim> = [];
       claimList.forEach((id) => {
@@ -162,17 +178,17 @@ export const doFetchItemsInCollections = (
 
       for (let i = 0; i < Math.ceil(totalItems / batchSize); i++) {
         batches[i] = Lbry.claim_search({
-          claim_ids: claim.value.claims.slice(i * batchSize, (i + 1) * batchSize),
+          claim_ids: itemIdsInOrder.slice(i * batchSize, (i + 1) * batchSize),
           page: 1,
           page_size: batchSize,
           no_totals: true,
         });
       }
       const itemsInBatches = await Promise.all(batches);
-      const result = mergeBatches(itemsInBatches, itemOrder);
+      const result = mergeBatches(itemsInBatches, itemIdsInOrder);
 
       // $FlowFixMe
-      const itemsById: { claimId: string, items?: ?Array<GenericClaim> } = { claimId: claimId };
+      const itemsById: { claimId: string, items?: ?Array<GenericClaim> } = { claimId: collectionId };
       if (result.items) {
         itemsById.items = result.items;
       } else {
@@ -181,7 +197,7 @@ export const doFetchItemsInCollections = (
       return itemsById;
     } catch (e) {
       return {
-        claimId: claimId,
+        claimId: collectionId,
         items: null,
       };
     }
@@ -189,12 +205,34 @@ export const doFetchItemsInCollections = (
 
   const invalidCollectionIds = [];
   const promisedCollectionItemFetches = [];
+
   collectionIds.forEach((collectionId) => {
-    const claim = selectClaimForClaimId(stateAfterClaimSearch, collectionId);
-    if (!claim) {
-      invalidCollectionIds.push(collectionId);
+    if (isPrivateCollectionId(collectionId)) {
+      const collection = selectCollectionForId(state, collectionId);
+      if (collection?.items.length > 0) {
+        promisedCollectionItemFetches.push(
+          fetchItemsForCollectionClaim(
+            collectionId,
+            collection.items.length,
+            collection.items.map((url) => parseClaimIdFromPermanentUrl(url, 'junk')),
+            pageSize
+          )
+        );
+      }
     } else {
-      promisedCollectionItemFetches.push(fetchItemsForCollectionClaim(claim, pageSize));
+      const claim = selectClaimForClaimId(stateAfterClaimSearch, collectionId);
+      if (!claim) {
+        invalidCollectionIds.push(collectionId);
+      } else {
+        promisedCollectionItemFetches.push(
+          fetchItemsForCollectionClaim(
+            collectionId,
+            claim.value.claims && claim.value.claims.length,
+            claim.value.claims,
+            pageSize
+          )
+        );
+      }
     }
   });
 
@@ -210,7 +248,11 @@ export const doFetchItemsInCollections = (
     // $FlowFixMe
     const collectionItems: Array<any> = entry.items;
     const collectionId = entry.claimId;
-    if (collectionItems) {
+
+    if (isPrivateCollectionId(collectionId) && collectionItems) {
+      // Nothing to do for now. We are only interested in getting the resolved
+      // data for each item in the private collection.
+    } else if (collectionItems) {
       const claim = selectClaimForClaimId(stateAfterClaimSearch, collectionId);
 
       const editedCollection = selectEditedCollectionForId(stateAfterClaimSearch, collectionId);
@@ -284,6 +326,7 @@ export const doFetchItemsInCollections = (
   dispatch({
     type: ACTIONS.COLLECTION_ITEMS_RESOLVE_COMPLETED,
     data: {
+      resolvedPrivateCollectionIds: privateCollectionIds,
       resolvedCollections: newCollectionObjectsById,
       failedCollectionIds: invalidCollectionIds,
     },

--- a/ui/redux/reducers/collections.js
+++ b/ui/redux/reducers/collections.js
@@ -193,7 +193,7 @@ const collectionsReducer = handleActions(
       };
     },
     [ACTIONS.COLLECTION_ITEMS_RESOLVE_COMPLETED]: (state, action) => {
-      const { resolvedCollections, failedCollectionIds } = action.data;
+      const { resolvedPrivateCollectionIds, resolvedCollections, failedCollectionIds } = action.data;
       const { pending, edited, isResolvingCollectionById, resolved } = state;
       const newPending = Object.assign({}, pending);
       const newEdited = Object.assign({}, edited);
@@ -218,6 +218,12 @@ const collectionsReducer = handleActions(
       if (failedCollectionIds && Object.keys(failedCollectionIds).length) {
         failedCollectionIds.forEach((failedId) => {
           delete newResolving[failedId];
+        });
+      }
+
+      if (resolvedPrivateCollectionIds && resolvedPrivateCollectionIds.length > 0) {
+        resolvedPrivateCollectionIds.forEach((id) => {
+          delete newResolving[id];
         });
       }
 

--- a/ui/redux/selectors/collections.js
+++ b/ui/redux/selectors/collections.js
@@ -450,5 +450,5 @@ export const selectIsCollectionPrivateForId = createSelector(
   selectBuiltinCollections,
   selectMyUnpublishedCollections,
   selectCurrentQueueList,
-  (id, builtinById, unpublishedById, queue) => builtinById[id] || unpublishedById[id] || queue[id]
+  (id, builtinById, unpublishedById, queue) => Boolean(builtinById[id] || unpublishedById[id] || queue[id])
 );

--- a/ui/util/url.js
+++ b/ui/util/url.js
@@ -183,4 +183,18 @@ export function generateGoogleCacheUrl(search, path) {
   }
 }
 
+const CLAIM_ID_LENGTH = 40;
+
+export function parseClaimIdFromPermanentUrl(url, failureId = '0') {
+  // - `parseURI` is too expensive for large loops, so this serves as a lighter
+  // alternative when iterating a list of permanent URLs.
+  // - It does not verify the permanent URL format, so only use this for areas
+  // where parsing failure is not fatal (e.g. if parsing for ist of IDs to
+  // resolve, missing a few wouldn't matter since components can resolve
+  // individually).
+  const parts = url.split('#');
+  const id = parts[parts.length - 1];
+  return id && id.length === CLAIM_ID_LENGTH ? id : failureId;
+}
+
 export const getPathForPage = (page) => `/$/${page}/`;


### PR DESCRIPTION
> _:warning: This goes into `playlist-v2` branch instead of `master` due to large conflicts. 
> :information_source:  Can be shipped together with that, or after.  
> :bulb: Maybe this can be reviewed and merged into salt, so we can test both `playlist-v2` and this PR together, since `playlist-v2` still have some outstanding issues to handle._

## Ticket
#1758

This alleviates the lock-up that is caused by large number of invidual resolves. There will still be some minor stutter due to the large DOM that React needs to handle -- that is logged in 1758 and will be handled separately.

Performance:
- ~200 items: completes 2s
- ~600 items: placeholders appear after 10s, completes after 40s (vs. CPU 100% for >4 minutes in production).

## Issue
Private list items are being resolved individually, super slow if the list is large (>100). Published lists doesn't have this issue.

## Assessment
doFetchItemsInCollections contains most of the useful logic, but it isn't called for private/built-in lists because it's not an actual claim.

## Approach
Tweaked doFetchItemsInCollections to handle private (UUID-based) collections.
