### PR TITLE
Fix notification target for some types

### DIFF
--- a/ui/component/headerNotificationButton/view.jsx
+++ b/ui/component/headerNotificationButton/view.jsx
@@ -9,7 +9,6 @@ import Icon from 'component/common/icon';
 import NotificationBubble from 'component/notificationBubble';
 import React from 'react';
 import Tooltip from 'component/common/tooltip';
-import { formatLbryUrlForWeb } from 'util/url';
 import Notification from 'component/notification';
 import DateTime from 'component/dateTime';
 import ChannelThumbnail from 'component/channelThumbnail';
@@ -18,6 +17,7 @@ import Button from 'component/button';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import { RULE } from 'constants/notifications';
 import UriIndicator from 'component/uriIndicator';
+import { getNotificationLink } from '../notification/helpers/target';
 import { generateNotificationTitle } from '../notification/helpers/title';
 import { generateNotificationText } from '../notification/helpers/text';
 import { parseURI } from 'util/lbryURI';
@@ -106,26 +106,18 @@ export default function NotificationHeaderButton(props: Props) {
   if (!notificationsEnabled) return null;
 
   function handleNotificationClick(notification) {
-    const { id, notification_parameters, is_read } = notification;
+    const { id, is_read } = notification;
 
     if (!is_read) {
       seeNotification([id]);
       readNotification([id]);
     }
-    let notificationLink = formatLbryUrlForWeb(notification_parameters.device.target);
-    if (notification_parameters.dynamic?.hash) {
-      notificationLink += '?lc=' + notification_parameters.dynamic.hash + '&view=discussion';
-    }
-    push(notificationLink);
+
+    push(getNotificationLink(notification));
   }
 
   function getWebUri(notification) {
-    const { notification_parameters } = notification;
-    let notificationLink = formatLbryUrlForWeb(notification_parameters.device.target);
-    if (notification_parameters.dynamic?.hash) {
-      notificationLink += '?lc=' + notification_parameters.dynamic.hash + '&view=discussion';
-    }
-    return notificationLink;
+    return getNotificationLink(notification);
   }
 
   function menuEntry(notification) {

--- a/ui/component/notification/helpers/target.jsx
+++ b/ui/component/notification/helpers/target.jsx
@@ -1,0 +1,59 @@
+// @flow
+import { LINKED_COMMENT_QUERY_PARAM } from 'constants/comment';
+import { RULE } from 'constants/notifications';
+import * as PAGES from 'constants/pages';
+import { DISCUSSION_PAGE, PAGE_VIEW_QUERY } from 'page/channel/view'; // TODO: move into const to avoid lazy-load problems
+import { parseURI } from 'util/lbryURI';
+import { formatLbryUrlForWeb } from 'util/url';
+
+export function getNotificationTarget(notification: WebNotification) {
+  const { notification_rule, notification_parameters } = notification;
+
+  switch (notification_rule) {
+    case RULE.WEEKLY_WATCH_REMINDER:
+    case RULE.DAILY_WATCH_AVAILABLE:
+    case RULE.DAILY_WATCH_REMIND:
+      return `/$/${PAGES.CHANNELS_FOLLOWING}`;
+    case RULE.MISSED_OUT:
+    case RULE.REWARDS_APPROVAL_PROMPT:
+      return `/$/${PAGES.REWARDS_VERIFY}?redirect=/$/${PAGES.REWARDS}`;
+    case RULE.FIAT_TIP:
+      return `/$/${PAGES.WALLET}?fiatType=incoming&tab=fiat-payment-history&currency=fiat`;
+    default:
+      return notification_parameters.device.target;
+  }
+}
+
+function getUrlParams(notification, notificationTarget) {
+  const { notification_rule, notification_parameters } = notification;
+
+  const isCommentNotification =
+    notification_rule === RULE.COMMENT ||
+    notification_rule === RULE.COMMENT_REPLY ||
+    notification_rule === RULE.CREATOR_COMMENT;
+
+  const urlParams = new URLSearchParams();
+
+  if (isCommentNotification && notification_parameters.dynamic.hash) {
+    urlParams.append(LINKED_COMMENT_QUERY_PARAM, notification_parameters.dynamic.hash);
+  }
+
+  try {
+    const { isChannel } = parseURI(notificationTarget);
+    if (isChannel) urlParams.append(PAGE_VIEW_QUERY, DISCUSSION_PAGE);
+  } catch (e) {}
+
+  return urlParams;
+}
+
+/**
+ *
+ * @param notification
+ * @param target Optional (minor optimization if pre-calculated outside). Must be value from getNotificationTarget().
+ * @returns {string}
+ */
+export function getNotificationLink(notification: WebNotification, target: ?string) {
+  const notificationTarget = target || getNotificationTarget(notification);
+  const urlParams = getUrlParams(notification, notificationTarget);
+  return `${formatLbryUrlForWeb(notificationTarget)}?${urlParams.toString()}`;
+}


### PR DESCRIPTION
## Ticket
Part of [#1742 Notification popup: incorrect target](https://github.com/OdyseeTeam/odysee-frontend/issues/1742)

Commentron uses old links for some of the notification types -- the app needs to override.

## Change
Factored out the code that determines the new target and use it in both Notifications Page and Popup Menu.
