### PR TITLE
Bump weekly-watch auto claim interval

### DIFF
--- a/ui/redux/selectors/rewards.js
+++ b/ui/redux/selectors/rewards.js
@@ -77,8 +77,8 @@ export const selectWeeklyWatchClaimedThisWeek = createSelector(selectUnclaimedRe
   if (weeklyWatch && weeklyWatch.data && weeklyWatch.data.last_claimed) {
     const last = new Date(weeklyWatch.data.last_claimed);
     const diff = new Date() - last;
-    const diffDays = Math.ceil(diff / (1000 * 60 * 60 * 24));
-    return diffDays < 6;
+    const diffDays = diff / (1000 * 60 * 60 * 24);
+    return diffDays < 6.5;
   }
   return false;
 });


### PR DESCRIPTION
## Ticket
Closes [#1768 Check reward claiming logic](https://github.com/OdyseeTeam/odysee-frontend/issues/1768)

## Change
- Bump to >6.5 days
- Remove unnecessary `Math.ceil` -- not sure why I added that. It was causing diff to hit earlier than necessary.

> _and I'm 5 days away._

Not sure how to replicate/explain this, though -- the old code would have still covered this range.  One possibility is when `last_claimed` is not defined, where we assume user hasn't claimed yet. We could flip this to assume "claimed" and just let the user manually claim as the fallback -- let me know.
