### PR TITLE
Assume `weekly_watch` is claimed when data is insufficient

### DIFF
--- a/ui/redux/actions/rewards.js
+++ b/ui/redux/actions/rewards.js
@@ -144,7 +144,7 @@ export function doClaimEligiblePurchaseRewards() {
     if (unclaimedRewards.find((ur) => ur.reward_type === rewards.TYPE_FIRST_STREAM)) {
       dispatch(doClaimRewardType(rewards.TYPE_FIRST_STREAM));
     } else {
-      if (!selectWeeklyWatchClaimedThisWeek(state)) {
+      if (selectWeeklyWatchClaimedThisWeek(state) === false) {
         dispatch(doClaimRewardType(rewards.TYPE_WEEKLY_WATCH, { failSilently: true }));
       }
     }

--- a/ui/redux/selectors/rewards.js
+++ b/ui/redux/selectors/rewards.js
@@ -80,7 +80,7 @@ export const selectWeeklyWatchClaimedThisWeek = createSelector(selectUnclaimedRe
     const diffDays = diff / (1000 * 60 * 60 * 24);
     return diffDays < 6.5;
   }
-  return false;
+  return undefined;
 });
 
 export const selectIsRewardApproved = createSelector(selectUser, (user) => user && user.is_reward_approved);


### PR DESCRIPTION
## Issue
If the reward-list fetch is slow, the selector assumes the weekly_watch hasn't been claimed yet, causing an unnecessary claim.

## Change
The selector now tells the caller if there is no data -- up to caller on what to do (in this case, don't claim the reward).

It should be harmless if the claim action was missed, since the user can still manually claim it.