### PR TITLE
tus: Fix `upload not found` scenario

### DIFF
--- a/web/setup/publish-v2.js
+++ b/web/setup/publish-v2.js
@@ -147,7 +147,7 @@ export function makeResumableUploadRequest(
           xhr.send(jsonPayload);
         }
 
-        setTimeout(() => makeNotifyRequest(), 15000);
+        makeNotifyRequest();
       },
     });
 


### PR DESCRIPTION
## Steps
When it upload reaches 100%, click Cancel (not refresh).

## Issue
There was an old hack in b0509bc9 where we decided to wait a while before sending `notify` as the server was not responsive. Since the task was dispatched before the Cancel action, the server cleared the upload first and later received the `notify`.

## Change
Instead of trying to cancel the timer, I think the hack is no longer needed given the throughput and lock fixes. With things running back in sequential mode, the Cancel button will now just show the "upload already completed" modal in this scenario.
