### PR TITLE
Publish: restore percentage label when uploading

### DIFF
--- a/ui/component/webUploadList/internal/web-upload-item.jsx
+++ b/ui/component/webUploadList/internal/web-upload-item.jsx
@@ -98,7 +98,7 @@ export default function WebUploadItem(props: Props) {
         }
       } else {
         const progressInt = parseInt(progress);
-        return progressInt === 100 ? __('Processing...') : __('Uploading...');
+        return progressInt === 100 ? __('Processing...') : `${__('Uploading...')} (${progressInt}%)`;
       }
     } else {
       return __('Uploading...');


### PR DESCRIPTION
Closes #1804

Can't recall why it was removed ... probably for something not important.
