### PR TITLE
Fix lbry:// URLs in iframes being broken by Safari

### DIFF
--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -1,5 +1,6 @@
 // @flow
 import { CHANNEL_STAKED_LEVEL_VIDEO_COMMENTS, MISSING_THUMB_DEFAULT } from 'config';
+import { platform } from 'util/platform';
 import { formattedEmote, inlineEmote } from 'util/remark-emote';
 import { formattedLinks, inlineLinks } from 'util/remark-lbry';
 import { formattedTimestamp, inlineTimestamp } from 'util/remark-timestamp';
@@ -141,7 +142,7 @@ const schema = { ...defaultSchema };
 schema.protocols.href.push('lbry');
 schema.attributes.a.push('embed');
 
-const REPLACE_REGEX = /(<iframe\s+src=["'])(.*?(?=))(["']\s*><\/iframe>)/g;
+const REPLACE_REGEX = /(?:<iframe\s+src=["'])(.*?(?=))(?:["']\s*><\/iframe>)/g;
 
 // ****************************************************************************
 // ****************************************************************************
@@ -162,7 +163,11 @@ export default React.memo<MarkdownProps>(function MarkdownPreview(props: Markdow
   } = props;
 
   const strippedContent = content
-    ? content.replace(REPLACE_REGEX, (iframeHtml) => {
+    ? content.replace(REPLACE_REGEX, (iframeHtml, iframeUrl) => {
+        if (platform.isSafari()) {
+          return iframeUrl;
+        }
+
         // Let the browser try to create an iframe to see if the markup is valid
         const outer = document.createElement('div');
         outer.innerHTML = iframeHtml;


### PR DESCRIPTION
When Safari parses lbry:// URLs, it breaks them as they are not
compliant with the RFC 3986 URI syntax. This causes iframes in text
posts which link to a lbry:// URL to not display on Safari.

Instead, just use the lbry:// URL matched from the iframe regex instead
of parsing the iframe on Safari.

For more info see https://github.com/OdyseeTeam/odysee-ios/issues/217#issuecomment-1116993724.

## Fixes

Issue Number: N/A

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

On https://odysee.com/@dev-test:8/test-embed:b

![image1](https://user-images.githubusercontent.com/71804605/177791949-e97d4d0b-36f9-4f13-8486-0e2259870741.png)
![image2](https://user-images.githubusercontent.com/71804605/177792061-8433e3ba-3161-4d27-bf75-07097a958040.png)

## What is the new behavior?

iframes and URL text rendered correctly, like on other browsers.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change

</details>
