### PR TITLE
(patch) tus: Fix `upload not found` scenario

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -4,7 +4,7 @@
 
 # --- Minimum Version (Format: YYYYMMDDNNN) ---
 # Bump this when we want to nudge the user to refresh.
-MINIMUM_VERSION=20220705001
+MINIMUM_VERSION=20220708001
 
 # --- Base config ---
 WEBPACK_WEB_PORT=9090

--- a/ui/component/webUploadList/internal/web-upload-item.jsx
+++ b/ui/component/webUploadList/internal/web-upload-item.jsx
@@ -142,7 +142,9 @@ export default function WebUploadItem(props: Props) {
 
   function getCancelButton() {
     if (!locked) {
-      if (status === 'notify') {
+      if (parseInt(progress) === 100) {
+        return null;
+      } else if (status === 'notify') {
         return (
           <Button
             button="link"

--- a/web/setup/publish-v2.js
+++ b/web/setup/publish-v2.js
@@ -147,6 +147,8 @@ export function makeResumableUploadRequest(
           xhr.send(jsonPayload);
         }
 
+        // Server needs time to process the upload before we can send `notify`.
+        // TODO: Is it file-size dependent?
         setTimeout(() => makeNotifyRequest(), 15000);
       },
     });


### PR DESCRIPTION
Second attempt, this time just hiding the cancel button when the upload is done. If user is impatient and refreshed in between this and `notify`, it will still be resumable later.

Bumped MINIMUM_VERSION to nudge for a refresh so we get a slightly more accurate logging, and also to prevent the issue from lingering.
