### PR TITLE
Fix v1-publish items not removable

### DIFF
--- a/ui/component/webUploadList/internal/web-upload-item.jsx
+++ b/ui/component/webUploadList/internal/web-upload-item.jsx
@@ -142,42 +142,44 @@ export default function WebUploadItem(props: Props) {
 
   function getCancelButton() {
     if (!locked) {
-      if (parseInt(progress) === 100) {
-        return null;
-      } else if (status === 'notify') {
-        return (
-          <Button
-            button="link"
-            label={__('Remove')}
-            onClick={() => {
-              doOpenModal(MODALS.CONFIRM, {
-                title: __('Remove entry?'),
-                body: (
-                  <>
-                    <p>
-                      {__('The file was successfully uploaded, but we could not retrieve the confirmation status.')}
-                    </p>
-                    <p>
-                      {__(
-                        'Wait 5-10 minutes, then refresh and check the Uploads list and Wallet transactions before attempting to re-upload.'
-                      )}
-                    </p>
-                    <p className="section__subtitle">
-                      {__('This entry can be safely removed if the transaction is visible in those pages.')}
-                    </p>
-                    <div className="help--warning">
-                      <p>{__('Press OK to clear this entry from the "Currently Uploading" list.')}</p>
-                    </div>
-                  </>
-                ),
-                onConfirm: (closeModal) => {
-                  doUpdateUploadRemove(params.guid);
-                  closeModal();
-                },
-              });
-            }}
-          />
-        );
+      if (resumable) {
+        if (status === 'notify') {
+          return (
+            <Button
+              button="link"
+              label={__('Remove')}
+              onClick={() => {
+                doOpenModal(MODALS.CONFIRM, {
+                  title: __('Remove entry?'),
+                  body: (
+                    <>
+                      <p>
+                        {__('The file was successfully uploaded, but we could not retrieve the confirmation status.')}
+                      </p>
+                      <p>
+                        {__(
+                          'Wait 5-10 minutes, then refresh and check the Uploads list and Wallet transactions before attempting to re-upload.'
+                        )}
+                      </p>
+                      <p className="section__subtitle">
+                        {__('This entry can be safely removed if the transaction is visible in those pages.')}
+                      </p>
+                      <div className="help--warning">
+                        <p>{__('Press OK to clear this entry from the "Currently Uploading" list.')}</p>
+                      </div>
+                    </>
+                  ),
+                  onConfirm: (closeModal) => {
+                    doUpdateUploadRemove(params.guid);
+                    closeModal();
+                  },
+                });
+              }}
+            />
+          );
+        } else if (parseInt(progress) === 100) {
+          return null;
+        }
       }
 
       return <Button label={__('Cancel')} button="link" onClick={handleCancel} />;


### PR DESCRIPTION
## Issue
https://odysee-workspace.slack.com/archives/C02GSHBKYEM/p1657571082411839?thread_ts=1654909550.197639&cid=C02GSHBKYEM

If the user refreshed on a v1 upload, we can't do much but must at least provide a Cancel button for them to remove the entry.

## Change
- Restore the cancel button behavior for v1 like it was before.  The recent changes on the visibility of the Cancel button should only be applied to v2.
- Also fixed missing cancel button on v2 after refresh if the progress reached 100%.