### PR TITLE
(patch) Add "Hide Repost" button in channel page

### DIFF
--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -270,7 +270,7 @@ function DiscoverPage(props: Props) {
           }
           meta={getMeta()}
           hasSource
-          hideRepostsOverride={dynamicRouteProps ? true : undefined}
+          hideRepostsOverride={dynamicRouteProps ? false : undefined}
           searchLanguages={dynamicRouteProps?.options?.searchLanguages}
         />
       </ClaimSearchFilterContext.Provider>


### PR DESCRIPTION
Fixes the "force repost" behavior in Category Page.

Got the logic wrong when the boolean parameter was inverted from "force" (+ve) to "hideRepostOverride" (-ve) to support the "Hide Repost" button.

`hideRepostOverride`:
- undefined = follow user setting
- true = always hide
- false = always show << we want this
