### PR TITLE
Grab Discover IDs from homepage API

### DIFF
--- a/ui/page/channelsFollowingDiscover/index.js
+++ b/ui/page/channelsFollowingDiscover/index.js
@@ -1,16 +1,12 @@
 import { connect } from 'react-redux';
-import { selectFollowedTags } from 'redux/selectors/tags';
-import { selectMutedChannels } from 'redux/selectors/blocked';
 import { selectSubscriptions } from 'redux/selectors/subscriptions';
 import { selectHomepageData, selectHomepageDiscover } from 'redux/selectors/settings';
-import ChannelsFollowingManagePage from './view';
+import ChannelsFollowingDiscover from './view';
 
 const select = (state) => ({
-  followedTags: selectFollowedTags(state),
   subscribedChannels: selectSubscriptions(state),
-  blockedChannels: selectMutedChannels(state),
   homepageData: selectHomepageData(state),
   discoverData: selectHomepageDiscover(state),
 });
 
-export default connect(select)(ChannelsFollowingManagePage);
+export default connect(select)(ChannelsFollowingDiscover);

--- a/ui/page/channelsFollowingDiscover/index.js
+++ b/ui/page/channelsFollowingDiscover/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { selectFollowedTags } from 'redux/selectors/tags';
 import { selectMutedChannels } from 'redux/selectors/blocked';
 import { selectSubscriptions } from 'redux/selectors/subscriptions';
-import { selectHomepageData } from 'redux/selectors/settings';
+import { selectHomepageData, selectHomepageDiscover } from 'redux/selectors/settings';
 import ChannelsFollowingManagePage from './view';
 
 const select = (state) => ({
@@ -10,6 +10,7 @@ const select = (state) => ({
   subscribedChannels: selectSubscriptions(state),
   blockedChannels: selectMutedChannels(state),
   homepageData: selectHomepageData(state),
+  discoverData: selectHomepageDiscover(state),
 });
 
 export default connect(select)(ChannelsFollowingManagePage);

--- a/ui/page/channelsFollowingDiscover/view.jsx
+++ b/ui/page/channelsFollowingDiscover/view.jsx
@@ -1,34 +1,21 @@
 // @flow
-import * as ICONS from 'constants/icons';
-import * as PAGES from 'constants/pages';
 import React from 'react';
 import Page from 'component/page';
-import Button from 'component/button';
-import ClaimTilesDiscover from 'component/claimTilesDiscover';
 import ClaimListDiscover from 'component/claimListDiscover';
 import * as CS from 'constants/claim_search';
-import { toCapitalCase } from 'util/string';
 import { CUSTOM_HOMEPAGE, SIMPLE_SITE } from 'config';
 
 const MORE_CHANNELS_ANCHOR = 'MoreChannels';
 
 type Props = {
-  followedTags: Array<Tag>,
   subscribedChannels: Array<Subscription>,
   blockedChannels: Array<string>,
   homepageData: any,
   discoverData: ?Array<string>,
 };
 
-type ChannelsFollowingItem = {
-  title: string,
-  link?: string,
-  help?: any,
-  options?: {},
-};
-
 function ChannelsFollowingDiscover(props: Props) {
-  const { followedTags, subscribedChannels, blockedChannels, homepageData, discoverData } = props;
+  const { /* subscribedChannels, */ homepageData, discoverData } = props;
   const { PRIMARY_CONTENT, LATEST } = homepageData;
 
   let channelIds;
@@ -42,94 +29,8 @@ function ChannelsFollowingDiscover(props: Props) {
     }
   }
 
-  let rowData: Array<ChannelsFollowingItem> = [];
-  const notChannels = subscribedChannels
-    .map(({ uri }) => uri)
-    .concat(blockedChannels)
-    .map((uri) => uri.split('#')[1]);
-
-  rowData.push({
-    title: 'Top Channels Of All Time',
-    link: `/$/${PAGES.DISCOVER}?claim_type=channel&${CS.ORDER_BY_KEY}=${CS.ORDER_BY_TOP}&${CS.FRESH_KEY}=${CS.FRESH_ALL}`,
-    options: {
-      pageSize: 12,
-      claimType: 'channel',
-      orderBy: ['effective_amount'],
-    },
-  });
-
-  rowData.push({
-    title: 'Trending Channels',
-    link: `/$/${PAGES.DISCOVER}?claim_type=channel`,
-    options: {
-      pageSize: 8,
-      claimType: 'channel',
-      orderBy: ['trending_group', 'trending_mixed'],
-    },
-  });
-
-  if (followedTags.length > 0 && followedTags.length < 5) {
-    const followedRows = followedTags.map((tag: Tag) => ({
-      title: `Trending Channels for #${toCapitalCase(tag.name)}`,
-      link: `/$/${PAGES.DISCOVER}?t=${tag.name}&claim_type=channel`,
-      options: {
-        claimType: 'channel',
-        pageSize: 4,
-        tags: [tag.name],
-      },
-    }));
-    rowData.push(...followedRows);
-  }
-
-  if (followedTags.length > 4) {
-    rowData.push({
-      title: 'Trending For Your Tags',
-      link: `/$/${PAGES.TAGS_FOLLOWING}?claim_type=channel`,
-      options: {
-        claimType: 'channel',
-        tags: followedTags.map((tag) => tag.name),
-      },
-    });
-  }
-
-  const rowDataWithGenericOptions = rowData.map((row) => {
-    return {
-      ...row,
-      options: {
-        ...row.options,
-        notChannels,
-      },
-    };
-  });
-
   return (
     <Page className="discoverPage-wrapper">
-      {!SIMPLE_SITE &&
-        rowDataWithGenericOptions.map(({ title, link, help, options = {} }) => (
-          <div key={title} className="claim-grid__wrapper">
-            <h1 className="section__actions">
-              {link ? (
-                <Button
-                  className="claim-grid__title"
-                  button="link"
-                  navigate={link}
-                  iconRight={ICONS.ARROW_RIGHT}
-                  label={__(title)}
-                />
-              ) : (
-                <span className="claim-grid__title">{__(title)}</span>
-              )}
-              {help}
-            </h1>
-
-            <ClaimTilesDiscover {...options} />
-          </div>
-        ))}
-      {!SIMPLE_SITE && (
-        <h1 id={MORE_CHANNELS_ANCHOR} className="claim-grid__title">
-          {__('More Channels')}
-        </h1>
-      )}
       <ClaimListDiscover
         defaultOrderBy={CS.ORDER_BY_TRENDING}
         defaultFreshness={CS.FRESH_ALL}

--- a/ui/page/channelsFollowingDiscover/view.jsx
+++ b/ui/page/channelsFollowingDiscover/view.jsx
@@ -17,6 +17,7 @@ type Props = {
   subscribedChannels: Array<Subscription>,
   blockedChannels: Array<string>,
   homepageData: any,
+  discoverData: ?Array<string>,
 };
 
 type ChannelsFollowingItem = {
@@ -27,16 +28,20 @@ type ChannelsFollowingItem = {
 };
 
 function ChannelsFollowingDiscover(props: Props) {
-  const { followedTags, subscribedChannels, blockedChannels, homepageData } = props;
+  const { followedTags, subscribedChannels, blockedChannels, homepageData, discoverData } = props;
   const { PRIMARY_CONTENT, LATEST } = homepageData;
+
   let channelIds;
-  if (CUSTOM_HOMEPAGE) {
+  if (discoverData) {
+    channelIds = discoverData;
+  } else if (CUSTOM_HOMEPAGE) {
     if (LATEST) {
       channelIds = LATEST.channelIds;
     } else if (PRIMARY_CONTENT) {
       channelIds = PRIMARY_CONTENT.channelIds;
     }
   }
+
   let rowData: Array<ChannelsFollowingItem> = [];
   const notChannels = subscribedChannels
     .map(({ uri }) => uri)

--- a/ui/page/channelsFollowingDiscover/view.jsx
+++ b/ui/page/channelsFollowingDiscover/view.jsx
@@ -4,6 +4,7 @@ import Page from 'component/page';
 import ClaimListDiscover from 'component/claimListDiscover';
 import * as CS from 'constants/claim_search';
 import { CUSTOM_HOMEPAGE, SIMPLE_SITE } from 'config';
+import { parseClaimIdFromPermanentUrl } from 'util/url';
 
 const MORE_CHANNELS_ANCHOR = 'MoreChannels';
 
@@ -15,7 +16,7 @@ type Props = {
 };
 
 function ChannelsFollowingDiscover(props: Props) {
-  const { /* subscribedChannels, */ homepageData, discoverData } = props;
+  const { subscribedChannels, homepageData, discoverData } = props;
   const { PRIMARY_CONTENT, LATEST } = homepageData;
 
   let channelIds;
@@ -36,6 +37,7 @@ function ChannelsFollowingDiscover(props: Props) {
         defaultFreshness={CS.FRESH_ALL}
         claimType={CS.CLAIM_CHANNEL}
         claimIds={CUSTOM_HOMEPAGE && channelIds ? channelIds : undefined}
+        excludedChannelIds={subscribedChannels.map((x) => parseClaimIdFromPermanentUrl(x.uri))}
         scrollAnchor={MORE_CHANNELS_ANCHOR}
         maxPages={SIMPLE_SITE ? 3 : undefined}
         hideFilters={SIMPLE_SITE}

--- a/ui/redux/selectors/settings.js
+++ b/ui/redux/selectors/settings.js
@@ -82,6 +82,18 @@ export const selectHomepageMeme = (state) => {
   return homepages ? homepages['en'].meme || {} : {};
 };
 
+export const selectHomepageDiscover = (state) => {
+  const homepageCode = selectHomepageCode(state);
+  const homepages = window.homepages;
+  if (homepages) {
+    const discover = homepages[homepageCode].discover;
+    if (discover) {
+      return discover;
+    }
+  }
+  return homepages ? homepages['en'].discover || [] : [];
+};
+
 export const selectHomepageAnnouncement = (state) => {
   const homepageCode = selectHomepageCode(state);
   const homepages = window.homepages;

--- a/ui/util/url.js
+++ b/ui/util/url.js
@@ -182,3 +182,19 @@ export function generateGoogleCacheUrl(search, path) {
     }
   }
 }
+
+const CLAIM_ID_LENGTH = 40;
+
+export function parseClaimIdFromPermanentUrl(url, failureId = '0') {
+  // - `parseURI` is too expensive for large loops, so this serves as a lighter
+  // alternative when iterating a list of permanent URLs.
+  // - It does not verify the permanent URL format, so only use this for areas
+  // where parsing failure is not fatal (e.g. if parsing for ist of IDs to
+  // resolve, missing a few wouldn't matter since components can resolve
+  // individually).
+  const parts = url.split('#');
+  const id = parts[parts.length - 1];
+  return id && id.length === CLAIM_ID_LENGTH ? id : failureId;
+}
+
+export const getPathForPage = (page) => `/$/${page}/`;

--- a/web/src/getHomepageJSON.js
+++ b/web/src/getHomepageJSON.js
@@ -65,6 +65,7 @@ const getHomepageJsonV2 = (format) => {
     v2[hp] = {
       categories: reformatV2Categories(memo.homepageData[hp].categories, format),
       meme: memo.homepageData[hp].meme,
+      discover: memo.homepageData[hp].discover,
       announcement: memo.announcements[hp],
     };
   });


### PR DESCRIPTION
:warning: Requires https://github.com/OdyseeTeam/odysee-homepages/pull/1751
Test: `kp`

Adds ability for homepage team to define the Discover list of IDs.
If undefined, falls back to English's list. If English is also undefined, falls back to LATEST / PRIMARY.
