### PR TITLE
(patch) Publish: add additional info in the error log

### DIFF
--- a/web/setup/publish-error.js
+++ b/web/setup/publish-error.js
@@ -1,14 +1,14 @@
 // @flow
 import * as tus from 'tus-js-client';
 import { COMMIT_ID } from 'config';
+import { platform } from 'util/platform';
 
 function generateCause(v1Type: ?string, xhr: ?any, uploader: ?TusUploader = null) {
   return {
     cause: {
-      appCommitId: COMMIT_ID,
+      app: `${COMMIT_ID ? COMMIT_ID.slice(0, 8) : '?'} | ${platform.os()} | ${platform.browser()}`,
       ...(xhr ? { xhrResponseURL: xhr.responseURL } : {}),
-      ...(xhr ? { xhrStatus: xhr.status } : {}),
-      ...(xhr ? { xhrStatusText: xhr.statusText } : {}),
+      ...(xhr ? { xhrStatus: `${xhr.status} (${xhr.statusText})` } : {}),
       ...(v1Type ? { type: v1Type } : {}),
       ...(uploader?._fingerprint ? { fingerprint: uploader?._fingerprint } : {}),
       ...(uploader?._retryAttempt ? { retryAttempt: uploader?._retryAttempt } : {}),


### PR DESCRIPTION
Patch for d41b9ff1

- Add os and browser details to isolate the "failed to upload chunk" that's due to timestamp changes in Android (see Issue 631)
