### PR TITLE
tus: handle "failed to upload chunk" when file is modified

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2384,5 +2384,6 @@
   "Removed from %playlist_name%": "Removed from %playlist_name%",
   "Are you sure you want to quit and clear the current Queue?": "Are you sure you want to quit and clear the current Queue?",
   "The current video will keep playing.": "The current video will keep playing.",
+  "Error uploading chunk. Click \"retry\" in the Uploads page to resume upload.": "Error uploading chunk. Click \"retry\" in the Uploads page to resume upload.",
   "--end--": "--end--"
 }

--- a/ui/component/webUploadList/internal/web-upload-item.jsx
+++ b/ui/component/webUploadList/internal/web-upload-item.jsx
@@ -122,7 +122,13 @@ export default function WebUploadItem(props: Props) {
         return null;
       }
 
-      const isFileActive = file instanceof File;
+      let isFileActive = file instanceof File;
+      // #631: There are logs showing that some users can't resume no matter how
+      // many times they tried, which seems to indicate the net::ERR_UPLOAD_FILE_CHANGED
+      // problem. Since we can't programmatically detect this scenario, always
+      // assume so and ask the user to re-select the file.
+      isFileActive = false;
+
       return (
         <Button
           label={isFileActive ? __('Resume') : __('Retry')}

--- a/web/setup/publish-v2.js
+++ b/web/setup/publish-v2.js
@@ -71,7 +71,7 @@ export function makeResumableUploadRequest(
     const uploader = new tus.Upload(file, {
       ...urlOptions,
       chunkSize: UPLOAD_CHUNK_SIZE_BYTE,
-      retryDelays: [8000, 10000, 15000, 20000, 30000],
+      retryDelays: [8000, 15000, 30000],
       parallelUploads: 1,
       storeFingerprintForResuming: false,
       urlStorage: new NoopUrlStorage(),
@@ -93,6 +93,8 @@ export function makeResumableUploadRequest(
         let customErr;
         if (status === STATUS_LOCKED || errMsg === 'file currently locked') {
           customErr = 'File is locked. Try resuming after waiting a few minutes';
+        } else if (errMsg.startsWith('tus: failed to upload chunk at offset')) {
+          customErr = 'Error uploading chunk. Click "retry" in the Uploads page to resume upload.';
         }
 
         window.store.dispatch(doUpdateUploadProgress({ guid, status: 'error' }));


### PR DESCRIPTION
## Issue
#631 
`https://github.com/tus/tus-js-client/issues/255`

## Reproduce
- `touch` the file while it is being uploaded, or anything that would change `File` object.
    - This can happen in real life: Android, by torrent apps, by anti-virus, etc.
    - On Google Drive, it shows up as "File Unreadable" and there is no way to resume (`https://support.google.com/drive/thread/46682177/mp4-file-upload-fails-with-file-unreadable-error?hl=en`)

Currently, unless the user refreshes, the "Resume" button uses the same `File` object, so we end up with the same error again.

## Change
- Since we can't programatically detect this scenario (vs. temp network glitch), always assume it so and force the user to re-select the file.
- Reduce the number of auto-retries back to 3, since it's pretty much pointless if it not a trivial connection issue.
