### PR TITLE
Disable autoplay when clicking comment reply notification links

### DIFF
--- a/ui/component/fileRenderInitiator/view.jsx
+++ b/ui/component/fileRenderInitiator/view.jsx
@@ -25,7 +25,12 @@ type Props = {
   fileInfo: FileListItem,
   uri: string,
   history: { push: (params: string | { pathname: string, state: ?{} }) => void },
-  location: { search: ?string, pathname: string, href: string, state: { forceAutoplay: boolean } },
+  location: {
+    search: ?string,
+    pathname: string,
+    href: string,
+    state: ?{ forceAutoplay?: boolean, forceDisableAutoplay?: boolean },
+  },
   obscurePreview: boolean,
   insufficientCredits: boolean,
   claimThumbnail?: string,
@@ -82,13 +87,13 @@ export default function FileRenderInitiator(props: Props) {
   const isMobile = useIsMobile();
 
   const { search, href, state: locationState, pathname } = location;
+  const { forceAutoplay: forceAutoplayParam, forceDisableAutoplay } = locationState || {};
   const urlParams = search && new URLSearchParams(search);
   const collectionId = urlParams && urlParams.get(COLLECTIONS_CONSTS.COLLECTION_ID);
 
   // check if there is a time or autoplay parameter, if so force autoplay
   const urlTimeParam = href && href.indexOf('t=') > -1;
-  const forceAutoplayParam = locationState && locationState.forceAutoplay;
-  const shouldAutoplay = !embedded && (forceAutoplayParam || urlTimeParam || autoplay);
+  const shouldAutoplay = !forceDisableAutoplay && !embedded && (forceAutoplayParam || urlTimeParam || autoplay);
 
   const isFree = costInfo && costInfo.cost === 0;
   const canViewFile = isLivestreamClaim

--- a/ui/component/headerNotificationButton/view.jsx
+++ b/ui/component/headerNotificationButton/view.jsx
@@ -105,7 +105,7 @@ export default function NotificationHeaderButton(props: Props) {
 
   if (!notificationsEnabled) return null;
 
-  function handleNotificationClick(notification) {
+  function handleNotificationClick(notification, isReply) {
     const { id, is_read } = notification;
 
     if (!is_read) {
@@ -113,7 +113,7 @@ export default function NotificationHeaderButton(props: Props) {
       readNotification([id]);
     }
 
-    push(getNotificationLink(notification));
+    push({ pathname: getNotificationLink(notification), state: !isReply ? undefined : { forceDisableAutoplay: true } });
   }
 
   function getWebUri(notification) {
@@ -125,6 +125,7 @@ export default function NotificationHeaderButton(props: Props) {
 
     let channelUrl;
     let icon;
+    let isReply = false;
     switch (notification_rule) {
       case RULE.CREATOR_SUBSCRIBER:
         icon = <Icon icon={ICONS.SUBSCRIBE} sectionIcon />;
@@ -137,6 +138,7 @@ export default function NotificationHeaderButton(props: Props) {
       case RULE.COMMENT_REPLY:
         channelUrl = notification_parameters.dynamic.reply_author;
         icon = creatorIcon(channelUrl, notification_parameters?.dynamic?.comment_author_thumbnail);
+        isReply = true;
         break;
       case RULE.NEW_CONTENT:
         channelUrl = notification_parameters.dynamic.channel_url;
@@ -168,7 +170,11 @@ export default function NotificationHeaderButton(props: Props) {
     }
 
     return (
-      <NavLink onClick={() => handleNotificationClick(notification)} key={id} to={getWebUri(notification)}>
+      <NavLink
+        onClick={() => handleNotificationClick(notification, isReply)}
+        key={id}
+        to={{ pathname: getWebUri(notification), state: !isReply ? undefined : { forceDisableAutoplay: true } }}
+      >
         <div
           className={is_read ? 'menu__list--notification' : 'menu__list--notification menu__list--notification-unread'}
           key={id}

--- a/ui/component/headerNotificationButton/view.jsx
+++ b/ui/component/headerNotificationButton/view.jsx
@@ -105,7 +105,7 @@ export default function NotificationHeaderButton(props: Props) {
 
   if (!notificationsEnabled) return null;
 
-  function handleNotificationClick(notification, isReply) {
+  function handleNotificationClick(notification, disableAutoplay) {
     const { id, is_read } = notification;
 
     if (!is_read) {
@@ -113,7 +113,10 @@ export default function NotificationHeaderButton(props: Props) {
       readNotification([id]);
     }
 
-    push({ pathname: getNotificationLink(notification), state: !isReply ? undefined : { forceDisableAutoplay: true } });
+    push({
+      pathname: getNotificationLink(notification),
+      state: !disableAutoplay ? undefined : { forceDisableAutoplay: true },
+    });
   }
 
   function getWebUri(notification) {
@@ -125,7 +128,7 @@ export default function NotificationHeaderButton(props: Props) {
 
     let channelUrl;
     let icon;
-    let isReply = false;
+    let disableAutoplay = false;
     switch (notification_rule) {
       case RULE.CREATOR_SUBSCRIBER:
         icon = <Icon icon={ICONS.SUBSCRIBE} sectionIcon />;
@@ -134,11 +137,12 @@ export default function NotificationHeaderButton(props: Props) {
       case RULE.CREATOR_COMMENT:
         channelUrl = notification_parameters.dynamic.comment_author;
         icon = creatorIcon(channelUrl, notification_parameters?.dynamic?.comment_author_thumbnail);
+        disableAutoplay = true;
         break;
       case RULE.COMMENT_REPLY:
         channelUrl = notification_parameters.dynamic.reply_author;
         icon = creatorIcon(channelUrl, notification_parameters?.dynamic?.comment_author_thumbnail);
-        isReply = true;
+        disableAutoplay = true;
         break;
       case RULE.NEW_CONTENT:
         channelUrl = notification_parameters.dynamic.channel_url;
@@ -171,9 +175,9 @@ export default function NotificationHeaderButton(props: Props) {
 
     return (
       <NavLink
-        onClick={() => handleNotificationClick(notification, isReply)}
+        onClick={() => handleNotificationClick(notification, disableAutoplay)}
         key={id}
-        to={{ pathname: getWebUri(notification), state: !isReply ? undefined : { forceDisableAutoplay: true } }}
+        to={{ pathname: getWebUri(notification), state: !disableAutoplay ? undefined : { forceDisableAutoplay: true } }}
       >
         <div
           className={is_read ? 'menu__list--notification' : 'menu__list--notification menu__list--notification-unread'}


### PR DESCRIPTION
## Fixes

Issue Number: closes #1849

- Only applies to Comment Replies since assumes the video was already watched before