### PR TITLE
notify: remove forced timeout, just beautify message

### DIFF
--- a/ui/constants/errors.js
+++ b/ui/constants/errors.js
@@ -2,4 +2,5 @@ export const ALREADY_CLAIMED = 'once the invite reward has been claimed the refe
 export const REFERRER_NOT_FOUND = 'A odysee account could not be found for the referrer you provided.';
 export const PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL = 'There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.';
 export const SDK_FETCH_TIMEOUT = 'Your action timed out, but may have been completed.';
+export const SDK_LEDGER_TRANSACTION_TIMEOUT = 'Timed out waiting for transaction.';
 export const FETCH_TIMEOUT = 'promise timeout';


### PR DESCRIPTION
## Issue
The forced timeout seems to be causing more errors than usual on large files, which naturally take longer on the SDK side.

## Change
Just beautify the message instead of forcing a timeout. Should have done this in the first place.

Note that I wasn't able to fully test this given it's hard to replicate, but it shouldn't cause any problems even if the code fails to capture the scenario -- it will just show the original error message, and the "remove" modal will still explain things.
