### PR TITLE
Don't lazy-load ModalError

### DIFF
--- a/ui/modal/modalRouter/view.jsx
+++ b/ui/modal/modalRouter/view.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { withRouter } from 'react-router';
 import LoadingBarOneOff from 'component/loadingBarOneOff';
 import * as MODALS from 'constants/modal_types';
+import ModalError from 'modal/modalError';
 import { lazyImport } from 'util/lazyImport';
 
 // prettier-ignore
@@ -27,7 +28,7 @@ const MAP = Object.freeze({
   [MODALS.CONFIRM_TRANSACTION]: lazyImport(() => import('modal/modalConfirmTransaction' /* webpackChunkName: "modalConfirmTransaction" */)),
   [MODALS.CUSTOMIZE_HOMEPAGE]: lazyImport(() => import('modal/modalCustomizeHomepage' /* webpackChunkName: "modalCustomizeHomepage" */)),
   [MODALS.DOWNLOADING]: lazyImport(() => import('modal/modalDownloading' /* webpackChunkName: "modalDownloading" */)),
-  [MODALS.ERROR]: lazyImport(() => import('modal/modalError' /* webpackChunkName: "modalError" */)),
+  [MODALS.ERROR]: ModalError,
   [MODALS.FILE_SELECTION]: lazyImport(() => import('modal/modalFileSelection' /* webpackChunkName: "modalFileSelection" */)),
   [MODALS.FILE_TIMEOUT]: lazyImport(() => import('modal/modalFileTimeout' /* webpackChunkName: "modalFileTimeout" */)),
   [MODALS.FIRST_REWARD]: lazyImport(() => import('modal/modalFirstReward' /* webpackChunkName: "modalFirstReward" */)),


### PR DESCRIPTION
## Issue
If something wrong happens due to internet connection and we have something to convey through the modal, the message is lost because we can't fetch the lazy loaded modal.

## Change
Make ModalError part of ui.js

## Future
ModalError handles `event/desktop_errors` -- if failed to dispatch this due to connection errors, maybe should try stash and retry later, so that we don't lose any valuable logs?  Not that critical, though.
