### PR TITLE
Publish: don't fail on `preview` timeout

### DIFF
--- a/ui/modal/modalPublishPreview/view.jsx
+++ b/ui/modal/modalPublishPreview/view.jsx
@@ -108,7 +108,7 @@ const ModalPublishPreview = (props: Props) => {
   const livestream =
     (uri && isLivestreamClaim) ||
     //   $FlowFixMe
-    (previewResponse.outputs[0] && previewResponse.outputs[0].value && !previewResponse.outputs[0].value.source);
+    (previewResponse?.outputs[0] && previewResponse.outputs[0].value && !previewResponse.outputs[0].value.source);
   // leave the confirm modal up if we're not going straight to upload/reflecting
   // @if TARGET='web'
   React.useEffect(() => {
@@ -155,8 +155,8 @@ const ModalPublishPreview = (props: Props) => {
   //   $FlowFixMe add outputs[0] etc to PublishResponse type
   const isOptimizeAvail = filePath && filePath !== '' && isVid && ffmpegStatus.available;
 
-  var modalTitle = 'Upload';
-  var confirmBtnText = 'Save';
+  let modalTitle = 'Upload';
+  let confirmBtnText = 'Save';
 
   if (isStillEditing) {
     if (livestream || isLivestreamClaim) {

--- a/web/setup/publish-v1.js
+++ b/web/setup/publish-v1.js
@@ -16,6 +16,7 @@ const ENDPOINT = LBRY_WEB_PUBLISH_API;
 const ENDPOINT_METHOD = 'publish';
 
 const PUBLISH_FETCH_TIMEOUT_MS = 60000;
+const PREVIEW_FETCH_TIMEOUT_MS = 10000;
 
 export function makeUploadRequest(
   token: string,
@@ -52,7 +53,7 @@ export function makeUploadRequest(
     xhr.open('POST', ENDPOINT);
     xhr.setRequestHeader(X_LBRY_AUTH_TOKEN, token);
     if (!remoteUrl) {
-      xhr.timeout = PUBLISH_FETCH_TIMEOUT_MS;
+      xhr.timeout = isPreview ? PREVIEW_FETCH_TIMEOUT_MS : PUBLISH_FETCH_TIMEOUT_MS;
     }
     xhr.responseType = 'json';
     xhr.upload.onprogress = (e) => {
@@ -69,7 +70,7 @@ export function makeUploadRequest(
     };
     xhr.ontimeout = () => {
       if (isPreview) {
-        analytics.error(`publish-v1: preview timed out after ${PUBLISH_FETCH_TIMEOUT_MS / 1000}s`);
+        analytics.error(`publish-v1: preview timed out after ${PREVIEW_FETCH_TIMEOUT_MS / 1000}s`);
         resolve(null);
       } else {
         analytics.error(`publish-v1: timed out after ${PUBLISH_FETCH_TIMEOUT_MS / 1000}s`);

--- a/web/setup/publish-v1.js
+++ b/web/setup/publish-v1.js
@@ -68,9 +68,14 @@ export function makeUploadRequest(
       reject(generateError(__('There was a problem with your upload. Please try again.'), params, xhr));
     };
     xhr.ontimeout = () => {
-      analytics.error(`publish-v1: timed out after ${PUBLISH_FETCH_TIMEOUT_MS / 1000}s`);
-      window.store.dispatch(doUpdateUploadProgress({ guid, status: 'error' }));
-      reject(generateError(PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL, params, xhr));
+      if (isPreview) {
+        analytics.error(`publish-v1: preview timed out after ${PUBLISH_FETCH_TIMEOUT_MS / 1000}s`);
+        resolve(null);
+      } else {
+        analytics.error(`publish-v1: timed out after ${PUBLISH_FETCH_TIMEOUT_MS / 1000}s`);
+        window.store.dispatch(doUpdateUploadProgress({ guid, status: 'error' }));
+        reject(generateError(PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL, params, xhr));
+      }
     };
     xhr.onabort = () => {
       window.store.dispatch(doUpdateUploadRemove(guid));

--- a/web/setup/publish.js
+++ b/web/setup/publish.js
@@ -54,6 +54,11 @@ export default function apiPublishCallViaWeb(
   return makeRequest(token, params, fileField, preview)
     .then((xhr) => {
       let error;
+
+      if (preview && xhr === null) {
+        return resolve(null);
+      }
+
       if (xhr && xhr.response) {
         if (xhr.status >= 200 && xhr.status < 300 && !xhr.response.error) {
           return resolve(xhr.response.result);


### PR DESCRIPTION
## Issue
- Seeing lots of preview timeout failures (should be SDK timeout).
- https://odysee-workspace.slack.com/archives/C02GSHBKYEM/p1658270926490769
- We are showing the "wait a few minutes and check transactions" message in this scenario, as if it was published.

## Change
Don't fail on this scenario -- just not show the estimated transaction amount.

## Future consideration
I think we can shorten the timeout further specifically for preview ... 60s seems too much just for an intermediate modal that can actually be suppressed by the user in the first place.  Thoughts?
