### PR TITLE
Use single-line for eslint-bypass comments

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -451,8 +451,7 @@ function App(props: Props) {
         // console.log(err); <-- disabling this ... it's clogging up Sentry logs.
       }
     };
-    // (one time after locale is fetched)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one time after locale is fetched
   }, [locale]);
 
   useEffect(() => {

--- a/ui/component/channelSelector/view.jsx
+++ b/ui/component/channelSelector/view.jsx
@@ -85,8 +85,7 @@ export default function ChannelSelector(props: Props) {
       doSetIncognito(true);
     }
 
-    // on mount, if we get to autoSet a channel, set it.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- On mount if we get to autoSet a channel, set it.
   }, []);
 
   return (

--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -201,8 +201,7 @@ export default function CommentList(props: Props) {
       setPage(page + 1);
       setDebouncedUri(undefined);
     }
-    // only for comparing uri with debounced uri
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only for comparing uri with debounced uri
   }, [debouncedUri, uri]);
 
   // Force comments reset
@@ -223,8 +222,7 @@ export default function CommentList(props: Props) {
   // so set the current page as the fetched page to start fetching new pages from there
   useEffect(() => {
     if (page < currentFetchedPage) setPage(currentFetchedPage > 0 ? currentFetchedPage : 1);
-    // only on uri change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only on uri change
   }, [uri]);
 
   // Fetch top-level comments

--- a/ui/component/fileRenderFloating/view.jsx
+++ b/ui/component/fileRenderFloating/view.jsx
@@ -322,8 +322,7 @@ export default function FileRenderFloating(props: Props) {
     // Initial update for relativePosRef:
     relativePosRef.current = calculateRelativePos(position.x, position.y);
 
-    // only on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only on mount
   }, []);
 
   React.useEffect(() => {

--- a/ui/component/livestreamChatLayout/view.jsx
+++ b/ui/component/livestreamChatLayout/view.jsx
@@ -235,8 +235,8 @@ export default function LivestreamChatLayout(props: Props) {
         return () => clearTimeout(timer);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [commentsLength]); // (Just respond to 'commentsLength' updates and nothing else)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Just respond to 'commentsLength' and nothing else
+  }, [commentsLength]);
 
   // Restore Scroll Pos after mobile input opens keyboard and avoid scroll height conflicts
   React.useEffect(() => {

--- a/ui/component/notification/helpers/text.jsx
+++ b/ui/component/notification/helpers/text.jsx
@@ -13,8 +13,8 @@ export function generateNotificationText(rule: string, notificationParams: any) 
   switch (rule) {
     default:
       console.log(`TEXT: Unhandled notification_rule:%c ${rule}`, 'color:yellow'); // eslint-disable-line
-    // (intended fallthrough)
-    // eslint-disable-next-line no-fallthrough
+
+    // eslint-disable-next-line no-fallthrough -- Intended fallthrough from 'default'
     case RULE.NEW_CONTENT:
     case RULE.NEW_LIVESTREAM:
     case RULE.CREATOR_SUBSCRIBER:

--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -295,8 +295,7 @@ function AppRouter(props: Props) {
     ) {
       doSetActiveChannel(null, true);
     }
-    // only on pathname change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only on 'pathname' change
   }, [pathname]);
 
   // react-router doesn't decode pathanmes before doing the route matching check

--- a/ui/component/swipeableDrawer/view.jsx
+++ b/ui/component/swipeableDrawer/view.jsx
@@ -190,8 +190,7 @@ export default function SwipeableDrawer(props: Props) {
     if (startOpen && !open) {
       toggleDrawer();
     }
-    // on page mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   React.useEffect(() => {
@@ -218,8 +217,7 @@ export default function SwipeableDrawer(props: Props) {
       }
     };
 
-    // close drawer on unmount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- close drawer on unmount
   }, []);
 
   const drawerElemRef = React.useCallback(

--- a/ui/component/textareaWithSuggestions/view.jsx
+++ b/ui/component/textareaWithSuggestions/view.jsx
@@ -313,8 +313,8 @@ export default function TextareaWithSuggestions(props: Props) {
       inputElement.focus();
       if (messageValue) inputElement.setSelectionRange(messageValue.length, messageValue.length);
     }
-    // do NOT listen to messageValue change, otherwise will autofocus while typing
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- do NOT listen to messageValue, otherwise will autofocus while typing
   }, [autoFocus, inputRef]);
 
   React.useEffect(() => {

--- a/ui/effects/use-resolve-pins.js
+++ b/ui/effects/use-resolve-pins.js
@@ -43,8 +43,7 @@ export default function useResolvePins(props: Props) {
         setResolvedPinUris(pins.claimIds.map<string>((id) => claimsById[id]?.canonical_url));
       }
     }
-    // Only do this over a false->true->false transition for hasResolvedPinUris.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only do this over a false->true->false transition for hasResolvedPinUris.
   }, [hasResolvedPinUris]);
 
   return resolvedPinUris;

--- a/ui/page/channel/view.jsx
+++ b/ui/page/channel/view.jsx
@@ -118,8 +118,7 @@ function ChannelPage(props: Props) {
 
     return discussionWasMounted && currentView === PAGE.DISCUSSION;
 
-    // only re-calculate on discussionWasMounted or uri change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-calculate on discussionWasMounted or uri change
   }, [discussionWasMounted, uri]);
 
   const hasUnpublishedCollections = unpublishedCollections && Object.keys(unpublishedCollections).length;

--- a/ui/page/channelsFollowingManage/view.jsx
+++ b/ui/page/channelsFollowingManage/view.jsx
@@ -56,8 +56,7 @@ export default function ChannelsFollowingManage(props: Props) {
     } else {
       setFilteredUris(filteredUris);
     }
-    // (only need to respond to 'filterQuery')
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only need to respond to 'filterQuery'
   }, [filterQuery]);
 
   React.useEffect(() => {

--- a/ui/page/discover/livestreamSection.jsx
+++ b/ui/page/discover/livestreamSection.jsx
@@ -73,8 +73,7 @@ export default function LivestreamSection(props: Props) {
     const langCsv = resolveLangForClaimSearch(languageSetting, searchInLanguage, searchLanguages, langParam);
     const lang = langCsv ? langCsv.split(',') : null;
     doFetchActiveLivestreams(CS.ORDER_BY_NEW_VALUE, lang);
-    // (on mount only)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- On mount only
   }, []);
 
   React.useEffect(() => {

--- a/ui/page/livestream/view.jsx
+++ b/ui/page/livestream/view.jsx
@@ -85,8 +85,7 @@ export default function LivestreamPage(props: Props) {
     if (claimId && channelName && !socketConnection?.connected) {
       doCommentSocketConnect(uri, channelName, claimId);
     }
-    // willAutoplay mount only
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- willAutoplay mount only
   }, [channelUrl, claim, doCommentSocketConnect, doCommentSocketDisconnect, socketConnection, uri]);
 
   React.useEffect(() => {
@@ -103,8 +102,7 @@ export default function LivestreamPage(props: Props) {
         if (claimId && channelName) doCommentSocketDisconnect(claimId, channelName);
       }
     };
-    // only on unmount -> leave page
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only on unmount -> leave page
   }, []);
 
   useFetchLiveStatus(isStreamPlaying ? undefined : livestreamChannelId, doFetchChannelLiveStatus);

--- a/ui/page/show/view.jsx
+++ b/ui/page/show/view.jsx
@@ -112,8 +112,7 @@ export default function ShowPage(props: Props) {
     if (!canonicalUrl && isNewestPath) {
       doResolveUri(uri);
     }
-    // only for mount on a latest content page
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only for mount on a latest content page
   }, []);
 
   useEffect(() => {

--- a/ui/page/signInVerify/view.jsx
+++ b/ui/page/signInVerify/view.jsx
@@ -50,8 +50,7 @@ function SignInVerifyPage(props: Props) {
     if (!needsRecaptcha && !isAuthenticationSuccess && !verificationApiHistory.called) {
       verifyUser();
     }
-    // (on mount only)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- On mount only
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
Patch for 4893085e

Double-dash is the documented way to add comment after an eslint rule, so saves one additional line/clutter.
