### PR TITLE
Add flow to "collection type"

### DIFF
--- a/flow-typed/Collections.js
+++ b/flow-typed/Collections.js
@@ -6,7 +6,7 @@ declare type Collection = {
   thumbnail?: {
     url?: string,
   },
-  type: string,
+  type: CollectionType,
   createdAt?: ?number,
   updatedAt: number,
   totalItems?: number,
@@ -14,6 +14,8 @@ declare type Collection = {
   editsCleared?: boolean,
   sourceId?: string, // if copied, claimId of original collection
 };
+
+declare type CollectionType = 'playlist' | 'channelList' | 'collection'; // Must match COL_TYPES
 
 declare type CollectionState = {
   unpublished: CollectionGroup,
@@ -40,7 +42,7 @@ declare type CollectionCreateParams = {
     url?: string,
   },
   items: ?Array<string>,
-  type: string,
+  type: CollectionType,
   sourceId?: string, // if copied, claimId of original collection
 };
 
@@ -49,7 +51,7 @@ declare type CollectionEditParams = {
   remove?: boolean,
   replace?: boolean,
   order?: { from: number, to: number },
-  type?: string,
+  type?: CollectionType,
   name?: string,
   description?: string,
   thumbnail?: {

--- a/ui/component/buttonAddToQueue/view.jsx
+++ b/ui/component/buttonAddToQueue/view.jsx
@@ -17,7 +17,7 @@ type Props = {
   playingUrl: ?string,
   playingCollectionUrls: ?Array<string>,
   doToast: (props: { message: string }) => void,
-  doCollectionEdit: (id: string, any) => void,
+  doCollectionEdit: (id: string, CollectionEditParams) => void,
   doUriInitiatePlay: (playingOptions: PlayingUri, isPlayable?: boolean, isFloating?: boolean) => void,
   doSetPlayingUri: (props: any) => void,
 };
@@ -44,10 +44,12 @@ function ButtonAddToQueue(props: Props) {
     doToast({ message: hasClaimInQueue ? __('Item removed from Queue') : __('Item added to Queue') });
 
     const itemsToAdd = playingCollectionUrls || [playingUrl];
+
     doCollectionEdit(COLLECTIONS_CONSTS.QUEUE_ID, {
+      // $FlowIgnore: already not using 'itemsToAdd' when 'playingUrl' is null.
       uris: playingUrl && playingUrl !== uri && !hasPlayingUriInQueue ? [...itemsToAdd, uri] : [uri],
       remove: hasClaimInQueue,
-      type: 'playlist',
+      type: COLLECTIONS_CONSTS.COL_TYPES.PLAYLIST,
     });
 
     if (!hasClaimInQueue) {

--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -4,6 +4,7 @@ import * as ICONS from 'constants/icons';
 import * as PAGES from 'constants/pages';
 import * as MODALS from 'constants/modal_types';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
+import { COL_TYPES } from 'constants/collections';
 import React from 'react';
 import classnames from 'classnames';
 import { Menu, MenuButton, MenuList, MenuItem } from '@reach/menu-button';
@@ -418,7 +419,7 @@ function ClaimMenuList(props: Props) {
                     {/* CURRENTLY ONLY SUPPORT PLAYLISTS FOR PLAYABLE; LATER DIFFERENT TYPES */}
                     <MenuItem
                       className="comment__menu-option"
-                      onSelect={() => openModal(MODALS.COLLECTION_ADD, { uri, type: 'playlist' })}
+                      onSelect={() => openModal(MODALS.COLLECTION_ADD, { uri, type: COL_TYPES.PLAYLIST })}
                     >
                       <div className="menu__link">
                         <Icon aria-hidden icon={ICONS.PLAYLIST_ADD} />

--- a/ui/component/claimPreview/internal/buttonRemoveFromCollection/view.jsx
+++ b/ui/component/claimPreview/internal/buttonRemoveFromCollection/view.jsx
@@ -2,6 +2,7 @@
 import * as ICONS from 'constants/icons';
 import React from 'react';
 import Button from 'component/button';
+import { COL_TYPES } from 'constants/collections';
 
 type Props = {
   uri: string,
@@ -9,7 +10,7 @@ type Props = {
   focusable: boolean,
   // -- redux --
   doToast: (props: { message: string }) => void,
-  doCollectionEdit: (id: string, any) => void,
+  doCollectionEdit: (id: string, CollectionEditParams) => void,
 };
 
 function ButtonAddToQueue(props: Props) {
@@ -20,7 +21,7 @@ function ButtonAddToQueue(props: Props) {
 
     doToast({ message: __('Item removed') });
 
-    doCollectionEdit(collectionId, { uris: [uri], remove: true, type: 'playlist' });
+    doCollectionEdit(collectionId, { uris: [uri], remove: true, type: COL_TYPES.PLAYLIST });
   }
 
   return (

--- a/ui/constants/collections.js
+++ b/ui/constants/collections.js
@@ -8,8 +8,11 @@ export const PLACEHOLDER = 'My Awesome Playlist';
 export const COLLECTION_ID = 'lid';
 export const COLLECTION_INDEX = 'linx';
 
-export const COL_TYPE_PLAYLIST = 'playlist';
-export const COL_TYPE_CHANNELS = 'channelList';
+export const COL_TYPES = Object.freeze({
+  PLAYLIST: 'playlist',
+  CHANNELS: 'channelList',
+  COLLECTION: 'collection', // temp placeholder for mixed content
+});
 
 export const WATCH_LATER_ID = 'watchlater';
 export const WATCH_LATER_NAME = 'Watch Later';

--- a/ui/modal/modalRemoveCollection/view.jsx
+++ b/ui/modal/modalRemoveCollection/view.jsx
@@ -1,11 +1,12 @@
 // @flow
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Modal } from 'modal/modal';
 import Button from 'component/button';
 import Card from 'component/common/card';
 import I18nMessage from 'component/i18nMessage';
-import { useHistory } from 'react-router-dom';
 import { FormField } from 'component/common/form';
+import { COL_TYPES } from 'constants/collections';
 
 type Props = {
   claim: Claim,
@@ -82,7 +83,7 @@ function ModalRemoveCollection(props: Props) {
                       description,
                       items: collectionUrls,
                       thumbnail: { url: thumbnail_url },
-                      type: 'playlist',
+                      type: COL_TYPES.PLAYLIST,
                     };
                     doLocalCollectionCreate(createParams);
                   }

--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -14,6 +14,7 @@ import {
 } from 'redux/selectors/collections';
 import * as COLS from 'constants/collections';
 import { isPermanentUrl } from 'util/claim';
+import { resolveCollectionType } from 'util/collections';
 import { parseClaimIdFromPermanentUrl } from 'util/url';
 
 const FETCH_BATCH_SIZE = 50;
@@ -262,7 +263,7 @@ export const doFetchItemsInCollections = (
       const streamTypes = new Set();
 
       let newItems = [];
-      let isPlaylist;
+      let collectionType;
 
       if (collectionItems) {
         collectionItems.forEach((collectionItem) => {
@@ -273,11 +274,8 @@ export const doFetchItemsInCollections = (
           }
           resolvedItemsByUrl[collectionItem.canonical_url] = collectionItem;
         });
-        isPlaylist =
-          valueTypes.size === 1 &&
-          valueTypes.has('stream') &&
-          ((streamTypes.size === 1 && (streamTypes.has('audio') || streamTypes.has('video'))) ||
-            (streamTypes.size === 2 && streamTypes.has('audio') && streamTypes.has('video')));
+
+        collectionType = resolveCollectionType(valueTypes, streamTypes);
       }
 
       newCollectionObjectsById[collectionId] = {
@@ -285,7 +283,7 @@ export const doFetchItemsInCollections = (
         id: collectionId,
         name: title || name,
         itemCount: claim.value.claims.length,
-        type: isPlaylist ? 'playlist' : 'collection',
+        type: collectionType,
         updatedAt: timestamp,
         description,
         thumbnail,
@@ -480,7 +478,7 @@ export const doClearQueueList = () => (dispatch: Dispatch, getState: GetState) =
   const hasItemsInQueue = selectHasItemsInQueue(state);
 
   if (hasItemsInQueue) {
-    return dispatch(doCollectionEdit(COLS.QUEUE_ID, { remove: true, type: 'playlist' }));
+    return dispatch(doCollectionEdit(COLS.QUEUE_ID, { remove: true, type: COLS.COL_TYPES.PLAYLIST }));
   }
 };
 

--- a/ui/redux/actions/content.js
+++ b/ui/redux/actions/content.js
@@ -2,6 +2,7 @@
 import * as ACTIONS from 'constants/action_types';
 import * as MODALS from 'constants/modal_types';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
+import { COL_TYPES } from 'constants/collections';
 import * as PAGES from 'constants/pages';
 // @if TARGET='app'
 import { ipcRenderer } from 'electron';
@@ -274,7 +275,7 @@ export function doUriInitiatePlay(
             );
 
         if (itemsToAdd) {
-          dispatch(doCollectionEdit(COLLECTIONS_CONSTS.QUEUE_ID, { uris: [...itemsToAdd], type: 'playlist' }));
+          dispatch(doCollectionEdit(COLLECTIONS_CONSTS.QUEUE_ID, { uris: [...itemsToAdd], type: COL_TYPES.PLAYLIST }));
         }
         dispatch(doChangePlayingUriParam({ ...playingOptions, collection: { ...playingCollection } }));
       } else {
@@ -317,9 +318,12 @@ export function doPlaylistAddAndAllowPlaying({
     let collectionId = id;
     if (createNew) {
       dispatch(
-        doLocalCollectionCreate({ name: collectionName, items: uri ? [uri] : [], type: 'playlist' }, (newId) => {
-          collectionId = newId;
-        })
+        doLocalCollectionCreate(
+          { name: collectionName, items: uri ? [uri] : [], type: COL_TYPES.PLAYLIST },
+          (newId) => {
+            collectionId = newId;
+          }
+        )
       );
     } else if (collectionId && uri) {
       if (collectionId === COLLECTIONS_CONSTS.QUEUE_ID) {
@@ -340,11 +344,11 @@ export function doPlaylistAddAndAllowPlaying({
           doCollectionEdit(COLLECTIONS_CONSTS.QUEUE_ID, {
             uris: playingUrl && playingUrl !== uri && !hasPlayingUriInQueue ? [...itemsToAdd, uri] : [uri],
             remove: hasClaimInQueue,
-            type: 'playlist',
+            type: COL_TYPES.PLAYLIST,
           })
         );
       } else {
-        dispatch(doCollectionEdit(collectionId, { uris: [uri], remove, type: 'playlist' }));
+        dispatch(doCollectionEdit(collectionId, { uris: [uri], remove, type: COL_TYPES.PLAYLIST }));
       }
     }
 

--- a/ui/redux/reducers/collections.js
+++ b/ui/redux/reducers/collections.js
@@ -12,7 +12,7 @@ const defaultState: CollectionState = {
       name: COLS.WATCH_LATER_NAME,
       createdAt: undefined,
       updatedAt: getCurrentTimeInSec(),
-      type: COLS.COL_TYPE_PLAYLIST,
+      type: COLS.COL_TYPES.PLAYLIST,
     },
     favorites: {
       items: [],
@@ -20,7 +20,7 @@ const defaultState: CollectionState = {
       name: COLS.FAVORITES_NAME,
       createdAt: undefined,
       updatedAt: getCurrentTimeInSec(),
-      type: COLS.COL_TYPE_PLAYLIST,
+      type: COLS.COL_TYPES.PLAYLIST,
     },
   },
   resolved: {},
@@ -36,7 +36,7 @@ const defaultState: CollectionState = {
     id: COLS.QUEUE_ID,
     name: COLS.QUEUE_NAME,
     updatedAt: getCurrentTimeInSec(),
-    type: COLS.COL_TYPE_PLAYLIST,
+    type: COLS.COL_TYPES.PLAYLIST,
   },
 };
 

--- a/ui/redux/selectors/collections.js
+++ b/ui/redux/selectors/collections.js
@@ -186,7 +186,7 @@ export const selectMyPublishedMixedCollections = createSelector(selectMyPublishe
     // $FlowFixMe
     Object.entries(published).filter(([key, collection]) => {
       // $FlowFixMe
-      return collection.type === 'collection';
+      return collection.type === COLLECTIONS_CONSTS.COL_TYPES.COLLECTION;
     })
   );
   return myCollections;
@@ -197,7 +197,7 @@ export const selectMyPublishedPlaylistCollections = createSelector(selectMyPubli
     // $FlowFixMe
     Object.entries(published).filter(([key, collection]) => {
       // $FlowFixMe
-      return collection.type === 'playlist';
+      return collection.type === COLLECTIONS_CONSTS.COL_TYPES.PLAYLIST;
     })
   );
   return myCollections;

--- a/ui/util/collections.js
+++ b/ui/util/collections.js
@@ -1,4 +1,5 @@
 // @flow
+import { COL_TYPES } from 'constants/collections';
 
 export const selectCountForCollection = (collection: Collection) => {
   if (collection) {
@@ -19,3 +20,28 @@ export const selectCountForCollection = (collection: Collection) => {
 
   return null;
 };
+
+/**
+ * Determines the overall type for a particular collection.
+ *
+ * Pass in the set of `claim::value_type` and `claim::stream_type` for all
+ * entries in that collection.
+ *
+ * 'collection', I believe, is the placeholder for mixed-type collection.
+ *
+ * @param valueTypes
+ * @param streamTypes
+ * @returns {string}
+ */
+export function resolveCollectionType(valueTypes: Set<string>, streamTypes: Set<string>): CollectionType {
+  if (
+    valueTypes.size === 1 &&
+    valueTypes.has('stream') &&
+    ((streamTypes.size === 1 && (streamTypes.has('audio') || streamTypes.has('video'))) ||
+      (streamTypes.size === 2 && streamTypes.has('audio') && streamTypes.has('video')))
+  ) {
+    return COL_TYPES.PLAYLIST;
+  }
+
+  return COL_TYPES.COLLECTION;
+}


### PR DESCRIPTION
## Issue
Problem with using literal:
- error-prone (typo)
- harder to add new types (e.g. sections, channels, etc.) -- it will be easier to search for areas to update if a constant was used.

## Changes
- Use constant.
- Add flow to capture potential mistakes.
- Factor out the collection-type logic so that it'll be easier to tweak later.
