### PR TITLE
Fix channel edit menu button

### DIFF
--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -255,7 +255,7 @@ function ClaimMenuList(props: Props) {
       prepareEdit(claim, editUri, claimType);
     } else {
       const channelUrl = claim.name + ':' + claim.claim_id;
-      push(`/${channelUrl}?${PAGE_VIEW_QUERY}=${PUBLISH_PAGE}`);
+      push(`/${channelUrl}?${PAGE_VIEW_QUERY}=${EDIT_PAGE}`);
     }
   }
 


### PR DESCRIPTION
## Fixes

Issue Number: n/a

https://odysee.com/$/channels -> click a channel menu -> edit
Leads to the wrong page