### PR TITLE
Fix next item button appearing on livestreams

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -145,9 +145,9 @@ function VideoViewer(props: Props) {
         return prevNextItem.current;
       }
     } else {
-      return autoplayNext ? nextRecommendedUri : undefined;
+      return autoplayNext && !isLivestreamClaim ? nextRecommendedUri : undefined;
     }
-  }, [autoplayNext, currentPlaylistItemIndex, nextPlaylistUri, nextRecommendedUri]);
+  }, [autoplayNext, currentPlaylistItemIndex, isLivestreamClaim, nextPlaylistUri, nextRecommendedUri]);
 
   // and "play previous" behaviours
   const prevPreviousItem = React.useRef(previousListUri);


### PR DESCRIPTION
## Fixes

Fixes Issue Number: #1859 

Play a video -> autoplay ON -> recommended loaded -> play a livestream -> the play next button stays there