### PR TITLE
Pass "search in language" to some Lighthouse calls

### DIFF
--- a/ui/component/recommendedContent/index.js
+++ b/ui/component/recommendedContent/index.js
@@ -5,6 +5,8 @@ import { doFetchRecommendedContent } from 'redux/actions/search';
 import { selectRecommendedContentForUri, selectIsSearching } from 'redux/selectors/search';
 import { selectOdyseeMembershipIsPremiumPlus } from 'redux/selectors/user';
 import RecommendedContent from './view';
+import { selectClientSetting } from 'redux/selectors/settings';
+import * as SETTINGS from 'constants/settings';
 
 const select = (state, props) => {
   const recommendedContentUris = selectRecommendedContentForUri(state, props.uri);
@@ -15,6 +17,7 @@ const select = (state, props) => {
     recommendedContentUris,
     nextRecommendedUri,
     isSearching: selectIsSearching(state),
+    searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
     hasPremiumPlus: selectOdyseeMembershipIsPremiumPlus(state),
   };
 };

--- a/ui/component/recommendedContent/view.jsx
+++ b/ui/component/recommendedContent/view.jsx
@@ -13,6 +13,7 @@ import { FYP_ID } from 'constants/urlParams';
 import classnames from 'classnames';
 import RecSys from 'recsys';
 import { getClaimMetadata } from 'util/claim';
+import LangFilterIndicator from 'component/langFilterIndicator';
 
 const VIEW_ALL_RELATED = 'view_all_related';
 const VIEW_MORE_FROM = 'view_more_from';
@@ -24,6 +25,7 @@ type Props = {
   recommendedContentUris: Array<string>,
   nextRecommendedUri: string,
   isSearching: boolean,
+  searchInLanguage: boolean,
   doFetchRecommendedContent: (string, ?FypParam) => void,
   claim: ?StreamClaim,
   claimId: string,
@@ -39,6 +41,7 @@ export default React.memo<Props>(function RecommendedContent(props: Props) {
     recommendedContentUris,
     nextRecommendedUri,
     isSearching,
+    searchInLanguage,
     claim,
     location,
     hasPremiumPlus,
@@ -127,6 +130,8 @@ export default React.memo<Props>(function RecommendedContent(props: Props) {
       titleActions={
         signingChannel && (
           <div className="recommended-content__bubble">
+            {searchInLanguage && <LangFilterIndicator />}
+
             <Button
               className={classnames('button-bubble', {
                 'button-bubble--active': viewMode === VIEW_ALL_RELATED,

--- a/ui/component/searchOptions/index.js
+++ b/ui/component/searchOptions/index.js
@@ -3,11 +3,14 @@ import { doUpdateSearchOptions } from 'redux/actions/search';
 import { selectSearchOptions } from 'redux/selectors/search';
 import { doToggleSearchExpanded } from 'redux/actions/app';
 import { selectSearchOptionsExpanded } from 'redux/selectors/app';
+import { selectClientSetting } from 'redux/selectors/settings';
+import * as SETTINGS from 'constants/settings';
 import SearchOptions from './view';
 
 const select = (state) => ({
   options: selectSearchOptions(state),
   expanded: selectSearchOptionsExpanded(state),
+  searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
 });
 
 const perform = (dispatch, ownProps) => {

--- a/ui/component/searchOptions/view.jsx
+++ b/ui/component/searchOptions/view.jsx
@@ -6,6 +6,7 @@ import { Form, FormField } from 'component/common/form';
 import Button from 'component/button';
 import Icon from 'component/common/icon';
 import classnames from 'classnames';
+import LangFilterIndicator from 'component/langFilterIndicator';
 
 const CLAIM_TYPES = {
   [SEARCH_OPTIONS.INCLUDE_FILES]: 'Files',
@@ -41,12 +42,21 @@ type Props = {
   options: {},
   simple: boolean,
   expanded: boolean,
+  searchInLanguage: boolean,
   toggleSearchExpanded: () => void,
   onSearchOptionsChanged: (string) => void,
 };
 
 const SearchOptions = (props: Props) => {
-  const { options, simple, setSearchOption, expanded, toggleSearchExpanded, onSearchOptionsChanged } = props;
+  const {
+    options,
+    simple,
+    setSearchOption,
+    expanded,
+    searchInLanguage,
+    toggleSearchExpanded,
+    onSearchOptionsChanged,
+  } = props;
 
   const stringifiedOptions = JSON.stringify(options);
 
@@ -216,13 +226,16 @@ const SearchOptions = (props: Props) => {
 
   return (
     <div>
-      <Button
-        button="alt"
-        label={__('Filter')}
-        icon={ICONS.FILTER}
-        iconRight={expanded ? ICONS.UP : ICONS.DOWN}
-        onClick={toggleSearchExpanded}
-      />
+      <div>
+        <Button
+          button="alt"
+          label={__('Filter')}
+          icon={ICONS.FILTER}
+          iconRight={expanded ? ICONS.UP : ICONS.DOWN}
+          onClick={toggleSearchExpanded}
+        />
+        {searchInLanguage && <LangFilterIndicator />}
+      </div>
       <Form
         className={classnames('search__options', {
           'search__options--expanded': expanded,

--- a/ui/component/wunderbarSuggestions/index.js
+++ b/ui/component/wunderbarSuggestions/index.js
@@ -1,14 +1,16 @@
-import * as MODALS from 'constants/modal_types';
 import { connect } from 'react-redux';
-import { selectShowMatureContent } from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage, selectShowMatureContent } from 'redux/selectors/settings';
 import { doToast } from 'redux/actions/notifications';
-import { doOpenModal, doHideModal } from 'redux/actions/app';
+import { doHideModal } from 'redux/actions/app';
 import { withRouter } from 'react-router';
 import { doResolveUris } from 'redux/actions/claims';
 import analytics from 'analytics';
 import Wunderbar from './view';
+import * as SETTINGS from 'constants/settings';
 
 const select = (state, props) => ({
+  languageSetting: selectLanguage(state),
+  searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
   showMature: selectShowMatureContent(state),
 });
 
@@ -20,7 +22,6 @@ const perform = (dispatch, ownProps) => ({
     analytics.apiLogSearch();
   },
   doShowSnackBar: (message) => dispatch(doToast({ isError: true, message })),
-  doOpenMobileSearch: () => dispatch(doOpenModal(MODALS.MOBILE_SEARCH)),
   doCloseMobileSearch: () => dispatch(doHideModal()),
 });
 

--- a/ui/component/wunderbarSuggestions/view.jsx
+++ b/ui/component/wunderbarSuggestions/view.jsx
@@ -36,18 +36,20 @@ const WUNDERBAR_INPUT_DEBOUNCE_MS = 1000;
 const LIGHTHOUSE_MIN_CHARACTERS = 3;
 
 type Props = {
-  searchQuery: ?string,
   onSearch: (string) => void,
-  navigateToSearchPage: (string) => void,
-  doResolveUris: (string) => void,
-  doShowSnackBar: (string) => void,
-  showMature: boolean,
   isMobile: boolean,
-  doCloseMobileSearch: () => void,
   channelsOnly?: boolean,
   noTopSuggestion?: boolean,
   noBottomLinks?: boolean,
   customSelectAction?: (string) => void,
+  // --- redux ---
+  searchInLanguage: boolean,
+  languageSetting: string,
+  showMature: boolean,
+  doResolveUris: (string) => void,
+  navigateToSearchPage: (string) => void,
+  doShowSnackBar: (string) => void,
+  doCloseMobileSearch: () => void,
 };
 
 export default function WunderBarSuggestions(props: Props) {
@@ -62,6 +64,8 @@ export default function WunderBarSuggestions(props: Props) {
     noTopSuggestion,
     noBottomLinks,
     customSelectAction,
+    searchInLanguage,
+    languageSetting,
   } = props;
   const inputRef: ElementRef<any> = React.useRef();
   const viewResultsRef: ElementRef<any> = React.useRef();
@@ -79,9 +83,7 @@ export default function WunderBarSuggestions(props: Props) {
   const [term, setTerm] = React.useState(queryFromUrl);
   const [debouncedTerm, setDebouncedTerm] = React.useState('');
   const searchSize = isMobile ? 20 : 5;
-  const additionalOptions = channelsOnly
-    ? { isBackgroundSearch: false, [SEARCH_OPTIONS.CLAIM_TYPE]: SEARCH_OPTIONS.INCLUDE_CHANNELS }
-    : {};
+  const additionalOptions = getAdditionalOptions(channelsOnly, searchInLanguage ? languageSetting : null);
   const { results, loading } = useLighthouse(debouncedTerm, showMature, searchSize, additionalOptions, 0);
   const noResults = debouncedTerm && !loading && results && results.length === 0;
   const nameFromQuery = debouncedTerm.trim().replace(/\s+/g, '').replace(/:/g, '#');
@@ -103,6 +105,21 @@ export default function WunderBarSuggestions(props: Props) {
 
   const isTyping = debouncedTerm !== term;
   const showPlaceholder = isTyping || loading;
+
+  function getAdditionalOptions(channelsOnly: ?boolean, language: ?string) {
+    const additionalOptions = {};
+
+    if (channelsOnly) {
+      additionalOptions.isBackgroundSearch = false;
+      additionalOptions[SEARCH_OPTIONS.CLAIM_TYPE] = SEARCH_OPTIONS.INCLUDE_CHANNELS;
+    }
+
+    if (language) {
+      additionalOptions[SEARCH_OPTIONS.LANGUAGE] = language;
+    }
+
+    return additionalOptions;
+  }
 
   function handleSelect(value) {
     if (!value) {

--- a/ui/constants/search.js
+++ b/ui/constants/search.js
@@ -28,6 +28,7 @@ export const SEARCH_OPTIONS = {
   SORT_DESCENDING: 'release_time',
   EXACT: 'exact',
   PRICE_FILTER_FREE: 'free_only',
+  LANGUAGE: 'language',
   TIME_FILTER: 'time_filter',
   TIME_FILTER_LAST_HOUR: 'lasthour',
   TIME_FILTER_TODAY: 'today',

--- a/ui/page/search/index.js
+++ b/ui/page/search/index.js
@@ -7,15 +7,18 @@ import {
   selectSearchOptions,
   makeSelectHasReachedMaxResultsLength,
 } from 'redux/selectors/search';
-import { selectShowMatureContent } from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage, selectShowMatureContent } from 'redux/selectors/settings';
 import { getSearchQueryString } from 'util/query-params';
 import { selectOdyseeMembershipIsPremiumPlus } from 'redux/selectors/user';
 import SearchPage from './view';
+import * as SETTINGS from 'constants/settings';
 
 const select = (state, props) => {
   const showMature = selectShowMatureContent(state);
   const urlParams = new URLSearchParams(props.location.search);
   const hasPremiumPlus = selectOdyseeMembershipIsPremiumPlus(state);
+  const languageSetting = selectLanguage(state);
+  const searchInLanguage = selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE);
 
   let urlQuery = urlParams.get('q') || null;
   if (urlQuery) {
@@ -26,6 +29,7 @@ const select = (state, props) => {
     ...selectSearchOptions(state),
     isBackgroundSearch: false,
     nsfw: showMature,
+    ...(searchInLanguage ? { language: languageSetting } : {}),
   };
 
   const query = getSearchQueryString(urlQuery, searchOptions);

--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -1,9 +1,10 @@
 // @flow
 import * as ACTIONS from 'constants/action_types';
 import * as MODALS from 'constants/modal_types';
+import * as SETTINGS from 'constants/settings';
 import { doOpenModal } from 'redux/actions/app';
 import { doToast } from 'redux/actions/notifications';
-import { selectShowMatureContent } from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage, selectShowMatureContent } from 'redux/selectors/settings';
 import { selectClaimForUri, selectClaimIdForUri, selectClaimIsNsfwForUri } from 'redux/selectors/claims';
 import { doClaimSearch, doResolveClaimIds, doResolveUris } from 'redux/actions/claims';
 import { buildURI, isURIValid } from 'util/lbryURI';
@@ -78,6 +79,7 @@ type SearchOptions = {
   related_to?: string,
   nsfw?: boolean,
   isBackgroundSearch?: boolean,
+  language?: string,
   gid?: string, // for fyp only
   uuid?: string, // for fyp only
 };
@@ -250,9 +252,17 @@ export const doFetchRecommendedContent = (uri: string, fyp: ?FypParam = null) =>
   const claim = selectClaimForUri(state, uri);
   const matureEnabled = selectShowMatureContent(state);
   const claimIsMature = selectClaimIsNsfwForUri(state, uri);
+  const languageSetting = selectLanguage(state);
+  const searchInLanguage = selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE);
+  const language = searchInLanguage ? languageSetting : null;
 
   if (claim && claim.value && claim.claim_id) {
-    const options: SearchOptions = getRecommendationSearchOptions(matureEnabled, claimIsMature, claim.claim_id);
+    const options: SearchOptions = getRecommendationSearchOptions(
+      matureEnabled,
+      claimIsMature,
+      claim.claim_id,
+      language
+    );
 
     if (fyp) {
       options['gid'] = fyp.gid;

--- a/ui/scss/component/_button.scss
+++ b/ui/scss/component/_button.scss
@@ -1005,6 +1005,10 @@ svg + .button__label {
   // margin-top: var(--spacing-xs);
   display: flex;
 
+  .icon--langFilter {
+    margin-right: var(--spacing-s);
+  }
+
   .button-toggle:nth-child(2) {
     margin-left: 2px;
     @media (min-width: $breakpoint-small) {

--- a/ui/util/query-params.js
+++ b/ui/util/query-params.js
@@ -77,7 +77,7 @@ export const getSearchQueryString = (query: string, options: any = {}) => {
   }
 
   const additionalOptions = {};
-  const { related_to, nsfw, free_only, gid, uuid } = options;
+  const { related_to, nsfw, free_only, language, gid, uuid } = options;
 
   if (related_to) {
     additionalOptions[SEARCH_OPTIONS.RELATED_TO] = related_to;
@@ -94,6 +94,10 @@ export const getSearchQueryString = (query: string, options: any = {}) => {
 
   if (nsfw === false) {
     additionalOptions[SEARCH_OPTIONS.INCLUDE_MATURE] = false;
+  }
+
+  if (language) {
+    additionalOptions[SEARCH_OPTIONS.LANGUAGE] = language;
   }
 
   if (additionalOptions) {

--- a/ui/util/search.js
+++ b/ui/util/search.js
@@ -106,9 +106,15 @@ export function getUriForSearchTerm(term: string) {
  * @param matureEnabled
  * @param claimIsMature
  * @param claimId
+ * @param language
  * @returns {{size: number, nsfw: boolean, isBackgroundSearch: boolean}}
  */
-export function getRecommendationSearchOptions(matureEnabled: boolean, claimIsMature: boolean, claimId: string) {
+export function getRecommendationSearchOptions(
+  matureEnabled: boolean,
+  claimIsMature: boolean,
+  claimId: string,
+  language: ?string
+) {
   const options = { size: 20, nsfw: matureEnabled, isBackgroundSearch: true };
 
   if (SIMPLE_SITE) {
@@ -119,6 +125,10 @@ export function getRecommendationSearchOptions(matureEnabled: boolean, claimIsMa
 
   if (matureEnabled || !claimIsMature) {
     options[SEARCH_OPTIONS.RELATED_TO] = claimId;
+  }
+
+  if (language) {
+    options[SEARCH_OPTIONS.LANGUAGE] = language;
   }
 
   return options;


### PR DESCRIPTION
_It's up on `kp`, but cors issue is also there.  Can't fully test -- just checked the payload.
The recs one does go through, but doesn't seem to make any difference._

----

Closes #1106

- Include:
  - Wunderbar popup
  - Search Page
  - Recommended Section
- Exclude:
  - Channel search bar
