### PR TITLE
Publish: log the params for v1 errors

### DIFF
--- a/web/setup/publish-v1.js
+++ b/web/setup/publish-v1.js
@@ -24,6 +24,7 @@ export function makeUploadRequest(
   file: File | string,
   isPreview?: boolean
 ) {
+  const originalParams = { ...params };
   const { remote_url: remoteUrl } = params;
 
   const body = new FormData();
@@ -66,7 +67,7 @@ export function makeUploadRequest(
     };
     xhr.onerror = () => {
       window.store.dispatch(doUpdateUploadProgress({ guid, status: 'error' }));
-      reject(generateError(__('There was a problem with your upload. Please try again.'), params, xhr));
+      reject(generateError(__('There was a problem with your upload. Please try again.'), originalParams, xhr));
     };
     xhr.ontimeout = () => {
       if (isPreview) {


### PR DESCRIPTION
Trying to figure out "stream name cannot be blank" problem.

Eventually the `misc` could be opened up for all errors, but not exposing it in the function prototype for now.
