### PR TITLE
Optimize resolves for edited playlists

### DIFF
--- a/ui/component/collectionItemsList/index.js
+++ b/ui/component/collectionItemsList/index.js
@@ -5,6 +5,7 @@ import {
   selectIsResolvingCollectionForId,
   selectIsCollectionPrivateForId,
   selectCollectionForId,
+  selectCollectionHasEditsForId,
 } from 'redux/selectors/collections';
 
 import CollectionItemsList from './view';
@@ -17,6 +18,7 @@ const select = (state, props) => {
     collection: selectCollectionForId(state, collectionId),
     isResolvingCollection: selectIsResolvingCollectionForId(state, collectionId),
     isPrivateCollection: selectIsCollectionPrivateForId(state, collectionId),
+    isEditedCollection: selectCollectionHasEditsForId(state, collectionId),
   };
 };
 

--- a/ui/component/collectionItemsList/view.jsx
+++ b/ui/component/collectionItemsList/view.jsx
@@ -16,6 +16,7 @@ type Props = {
   // -- redux --
   collection: Collection,
   isPrivateCollection: boolean,
+  isEditedCollection: boolean,
   isResolvingCollection: boolean,
   collectionUrls: Array<string>,
   doCollectionEdit: (id: string, params: CollectionEditParams) => void,
@@ -27,6 +28,7 @@ const CollectionItemsList = (props: Props) => {
     collectionId,
     collection,
     isPrivateCollection,
+    isEditedCollection,
     collectionUrls,
     isResolvingCollection,
     doCollectionEdit,
@@ -39,7 +41,8 @@ const CollectionItemsList = (props: Props) => {
   const { totalItems } = collection || {};
 
   const urlsReady = collectionUrls && (totalItems === undefined || totalItems === collectionUrls.length);
-  const shouldFetchItems = isPrivateCollection || (!urlsReady && collectionId && !didTryResolve && !collection);
+  const shouldFetchItems =
+    isPrivateCollection || isEditedCollection || (!urlsReady && collectionId && !didTryResolve && !collection);
 
   function handleOnDragEnd(result: any) {
     const { source, destination } = result;

--- a/ui/page/collection/index.js
+++ b/ui/page/collection/index.js
@@ -8,6 +8,7 @@ import {
   selectUrlsForCollectionId,
   selectIsResolvingCollectionForId,
   selectBrokenUrlsForCollectionId,
+  selectMyEditedCollections,
 } from 'redux/selectors/collections';
 import { doFetchItemsInCollection } from 'redux/actions/collections';
 
@@ -27,6 +28,7 @@ const select = (state, props) => {
     collection: selectCollectionForId(state, collectionId),
     collectionUrls: selectUrlsForCollectionId(state, collectionId),
     brokenUrls: selectBrokenUrlsForCollectionId(state, collectionId),
+    editedCollections: selectMyEditedCollections(state),
     isResolvingCollection: selectIsResolvingCollectionForId(state, collectionId),
   };
 };


### PR DESCRIPTION
## Issue
When viewing own edited playlist (`/$/playlist/<id>`), the GUI jumped the gun and resolved entries individually because `urlsReady` is true given that edited URLs are stored in the wallet.

This is the same problem with the private list that was fix recently, but we also need to resolve the collection to get the collection claim, but resolve the edited URLs from the wallet instead of from the claim.
