### PR TITLE
Announcements: handle history being replaced when Homepage changes

### DIFF
--- a/flow-typed/content.js
+++ b/flow-typed/content.js
@@ -9,9 +9,11 @@ declare type ContentState = {
   recommendationParentId: { [string]: string }, // claimId: referrerId
   recommendationUrls: { [string]: Array<string> }, // claimId: [lbryUrls...]
   recommendationClicks: { [string]: Array<number> }, // "claimId": [clicked indices...]
-  lastViewedAnnouncement: ?string, // undefined = not seen in wallet.
+  lastViewedAnnouncement: LastViewedAnnouncement, // undefined = not seen in wallet.
   recsysEntries: { [ClaimId]: RecsysEntry }, // Persistent shadow copy. The main one resides in RecSys.
 };
+
+declare type LastViewedAnnouncement = Array<string>;
 
 declare type WatchHistory = {
   uri: string,

--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -522,7 +522,7 @@ function App(props: Props) {
   useEffect(() => {
     window.clearLastViewedAnnouncement = () => {
       console.log('Clearing history. Please wait ...');
-      doSetLastViewedAnnouncement('');
+      doSetLastViewedAnnouncement('clear');
     };
   }, []);
 

--- a/ui/modal/modalAnnouncements/view.jsx
+++ b/ui/modal/modalAnnouncements/view.jsx
@@ -12,7 +12,7 @@ type Props = {
   // --- redux ---
   authenticated?: boolean,
   announcement: string,
-  lastViewedHash: ?string,
+  lastViewedHash: LastViewedAnnouncement,
   doHideModal: () => void,
   doSetLastViewedAnnouncement: (hash: string) => void,
 };
@@ -41,7 +41,7 @@ export default function ModalAnnouncements(props: Props) {
 
     const hash = getSimpleStrHash(announcement);
 
-    if (lastViewedHash === hash) {
+    if (lastViewedHash.includes(hash)) {
       if (isAutoInvoked) {
         doHideModal();
       } else {

--- a/ui/redux/actions/sync.js
+++ b/ui/redux/actions/sync.js
@@ -422,7 +422,7 @@ type SharedData = {
     updatedCollections: UpdatedCollectionGroup,
     builtinCollections: CollectionGroup,
     savedCollectionIds: Array<string>,
-    lastViewedAnnouncement: string,
+    lastViewedAnnouncement?: LastViewedAnnouncement,
   },
 };
 

--- a/ui/redux/reducers/content.js
+++ b/ui/redux/reducers/content.js
@@ -12,7 +12,7 @@ const defaultState: ContentState = {
   recommendationParentId: {},
   recommendationUrls: {},
   recommendationClicks: {},
-  lastViewedAnnouncement: '',
+  lastViewedAnnouncement: [],
   recsysEntries: {},
 };
 
@@ -94,7 +94,22 @@ reducers[ACTIONS.CLEAR_CONTENT_HISTORY_URI] = (state, action) => {
 
 reducers[ACTIONS.CLEAR_CONTENT_HISTORY_ALL] = (state) => ({ ...state, history: [] });
 
-reducers[ACTIONS.SET_LAST_VIEWED_ANNOUNCEMENT] = (state, action) => ({ ...state, lastViewedAnnouncement: action.data });
+reducers[ACTIONS.SET_LAST_VIEWED_ANNOUNCEMENT] = (state, action) => {
+  // Since homepages fall back to English if undefined, use an array instead of
+  // an object to simplify the logic and overall code-changes.
+  // The only flaw is when a particular homepage keeps producing new
+  // announcements, the history of other homepages will be pushed out. This
+  // scenario is unlikely, so just keep a reasonably large history size to
+  // account for this scenario.
+  const N_ENTRIES_TO_KEEP = 25;
+  const hash = action.data;
+
+  if (hash === 'clear') {
+    return { ...state, lastViewedAnnouncement: [] };
+  }
+
+  return { ...state, lastViewedAnnouncement: [hash].concat(state.lastViewedAnnouncement).slice(0, N_ENTRIES_TO_KEEP) };
+};
 
 reducers[ACTIONS.SET_RECSYS_ENTRIES] = (state, action) => ({ ...state, recsysEntries: action.data });
 
@@ -107,7 +122,9 @@ reducers[ACTIONS.SET_RECSYS_ENTRIES] = (state, action) => ({ ...state, recsysEnt
 
 reducers[ACTIONS.USER_STATE_POPULATE] = (state, action) => {
   const { lastViewedAnnouncement } = action.data;
-  return { ...state, lastViewedAnnouncement };
+  // Convert legacy string format to an array:
+  const newValue = typeof lastViewedAnnouncement === 'string' ? [lastViewedAnnouncement] : lastViewedAnnouncement || [];
+  return { ...state, lastViewedAnnouncement: newValue };
 };
 
 export default function reducer(state: ContentState = defaultState, action: any) {


### PR DESCRIPTION
## Reproduce
1. Change homepage to one that has a different announcement than English's (e.g. Spanish).
2. Refresh --> see Spanish announcement.
3. Change back to English.
4. Refresh --> see old English announcement again.

## Change
Keep a list of hashes instead of just 1 to account for various Homepages.
