### PR TITLE
Remove SDK_API_URL warning

### DIFF
--- a/ui/index.jsx
+++ b/ui/index.jsx
@@ -64,10 +64,6 @@ if (process.env.NODE_ENV === 'production') {
   });
 }
 
-if (process.env.SDK_API_URL) {
-  console.warn('SDK_API_URL env var is deprecated. Use SDK_API_HOST instead'); // @eslint-disable-line
-}
-
 Lbry.setDaemonConnectionString(PROXY_URL);
 
 Lbry.setOverride(


### PR DESCRIPTION
## Issue
This appears in each sentry breadcrumb

## Note
The warning seems to be useless since there is no code (even in other repos and build machine) that uses SDK_API_HOST.
