### PR TITLE
Fix blank string in Error Modal on livestream-creation timeout

### DIFF
--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -1,4 +1,5 @@
 // @flow
+import * as ERRORS from 'constants/errors';
 import * as MODALS from 'constants/modal_types';
 import * as ACTIONS from 'constants/action_types';
 import * as PAGES from 'constants/pages';
@@ -289,7 +290,13 @@ export const doPublishDesktop = (filePath: string, preview?: boolean) => (dispat
       type: ACTIONS.PUBLISH_FAIL,
     });
 
-    actions.push(doError({ message: error.message, cause: error.cause }));
+    let message = typeof error === 'string' ? error : error.message;
+
+    if (message.endsWith(ERRORS.SDK_FETCH_TIMEOUT)) {
+      message = ERRORS.PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL;
+    }
+
+    actions.push(doError({ message, cause: error.cause }));
     dispatch(batchActions(...actions));
   };
 


### PR DESCRIPTION
Livestream-creation goes through a different code path than the usual v1/v2 publishing, and there was a bug for not handling "Error vs. string" in the middle of this path.

While at it, ensured that we show the full explanation for this path instead of the generic "${method}: Your action timed out, but may have been completed.".
