### PR TITLE
Filter out '\n' from 'name'

### DIFF
--- a/ui/component/publish/livestream/publishLivestream/view.jsx
+++ b/ui/component/publish/livestream/publishLivestream/view.jsx
@@ -4,7 +4,7 @@ import { SOURCE_NONE, SOURCE_SELECT, SOURCE_UPLOAD } from 'constants/publish_sou
 import React, { useState, useEffect } from 'react';
 import Card from 'component/common/card';
 import { FormField } from 'component/common/form';
-import { regexInvalidURI } from 'util/lbryURI';
+import { sanitizeName } from 'util/lbryURI';
 import Spinner from 'component/spinner';
 import * as PUBLISH_MODES from 'constants/publish_types';
 import PublishName from '../../shared/publishName';
@@ -190,11 +190,6 @@ function PublishLivestream(props: Props) {
     updatePublishForm({ fileDur: duration, fileSize: size, fileVid: isvid });
   }
 
-  function parseName(newName) {
-    let INVALID_URI_CHARS = new RegExp(regexInvalidURI, 'gu');
-    return newName.replace(INVALID_URI_CHARS, '-');
-  }
-
   /*
   function autofillTitle(file) {
     const newTitle = (file && file.name && file.name.substr(0, file.name.lastIndexOf('.'))) || name || '';
@@ -261,7 +256,7 @@ function PublishLivestream(props: Props) {
     };
 
     if (!isStillEditing) {
-      publishFormParams.name = parseName(fileName);
+      publishFormParams.name = sanitizeName(fileName);
     }
 
     // File path is not supported on web for security reasons so we use the name instead.

--- a/ui/component/publish/upload/publishFile/view.jsx
+++ b/ui/component/publish/upload/publishFile/view.jsx
@@ -3,7 +3,7 @@ import { SITE_NAME, WEB_PUBLISH_SIZE_LIMIT_GB, SIMPLE_SITE } from 'config';
 import React, { useState, useEffect } from 'react';
 import Lbry from 'lbry';
 import { toHex } from 'util/hex';
-import { regexInvalidURI } from 'util/lbryURI';
+import { sanitizeName } from 'util/lbryURI';
 import FileSelector from 'component/common/file-selector';
 import Button from 'component/button';
 import Card from 'component/common/card';
@@ -306,11 +306,6 @@ function PublishFile(props: Props) {
     // @endif
   }
 
-  function parseName(newName) {
-    let INVALID_URI_CHARS = new RegExp(regexInvalidURI, 'gu');
-    return newName.replace(INVALID_URI_CHARS, '-');
-  }
-
   function handleTitleChange(event) {
     updatePublishForm({ title: event.target.value });
   }
@@ -411,7 +406,7 @@ function PublishFile(props: Props) {
     };
 
     if (!isStillEditing) {
-      publishFormParams.name = parseName(fileName);
+      publishFormParams.name = sanitizeName(fileName);
     }
 
     // File path is not supported on web for security reasons so we use the name instead.

--- a/ui/redux/selectors/publish.js
+++ b/ui/redux/selectors/publish.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { createCachedSelector } from 're-reselect';
-import { parseURI, buildURI, parseName } from 'util/lbryURI';
+import { parseURI, buildURI, sanitizeName } from 'util/lbryURI';
 import { dedupeLanguages } from 'util/publish';
 import {
   selectClaimsById,
@@ -167,7 +167,7 @@ export const selectCollectionClaimParamsForUri = (state: State, uri: string, col
 
   const collectionParams: CollectionPublishParams = {
     thumbnail_url: collection ? collection.thumbnail?.url : getThumbnailFromClaim(claim),
-    name: collectionName ? parseName(collectionName) : undefined,
+    name: collectionName ? sanitizeName(collectionName) : undefined,
     description: collection ? collection.description : makeSelectMetadataItemForUri(uri, 'description')(state),
     title: collection ? collectionName : title,
     bid: String(amount || 0.001),

--- a/ui/util/lbryURI.js
+++ b/ui/util/lbryURI.js
@@ -4,7 +4,7 @@ const channelNameMinLength = 1;
 const claimIdMaxLength = 40;
 
 // see https://spec.lbry.com/#urls
-export const regexInvalidURI = /[ =&#:$@%?;/\\"<>%{}|^~[\]`\u{0000}-\u{0008}\u{000b}-\u{000c}\u{000e}-\u{001F}\u{D800}-\u{DFFF}\u{FFFE}-\u{FFFF}]/u;
+export const regexInvalidURI = /[ =&#:$@%?;/\\\n"<>%{}|^~[\]`\u{0000}-\u{0008}\u{000b}-\u{000c}\u{000e}-\u{001F}\u{D800}-\u{DFFF}\u{FFFE}-\u{FFFF}]/u;
 export const regexAddress = /^(b|r)(?=[^0OIl]{32,33})[0-9A-Za-z]{32,33}$/;
 const regexPartProtocol = '^((?:lbry://)?)';
 const regexPartStreamOrChannelName = '([^:$#/]*)';

--- a/ui/util/lbryURI.js
+++ b/ui/util/lbryURI.js
@@ -343,7 +343,7 @@ export function isURIEqual(uriA: string, uriB: string) {
   return a === b;
 }
 
-export function parseName(newName: string) {
-  let INVALID_URI_CHARS = new RegExp(regexInvalidURI, 'gu');
-  return newName.replace(INVALID_URI_CHARS, '-');
+export function sanitizeName(name: string) {
+  const INVALID_URI_CHARS = new RegExp(regexInvalidURI, 'gu');
+  return name.replace(INVALID_URI_CHARS, '-');
 }


### PR DESCRIPTION
## Issue
"_Stream name has invalid characters_"
https://odysee-workspace.slack.com/archives/C02GSHBKYEM/p1659617796387469

## Replicate
Linux allows any character for a file name, so '\n' slipped through when selecting a file from the file browser.

![image](https://user-images.githubusercontent.com/64950861/182864295-21cabf1d-7087-46da-b151-e261ad44a7cc.png)

## Change
The actual fix is just the `regexInvalidURI` regex change (please double-check).
The rest is just DRY stuff.
