### PR TITLE
Show claims with invalid channel signatures as Anonymous

### DIFF
--- a/ui/component/uriIndicator/view.jsx
+++ b/ui/component/uriIndicator/view.jsx
@@ -57,11 +57,12 @@ class UriIndicator extends React.PureComponent<Props> {
     } else if (claim) {
       const signingChannel = claim.signing_channel && claim.signing_channel.amount;
       const isChannelClaim = claim.value_type === 'channel';
+      const isChannelSignatureValid = claim.is_channel_signature_valid;
       const channelClaim = isChannelClaim ? claim : claim.signing_channel;
 
       return {
         hasChannelData: Boolean(channelClaim),
-        isAnonymous: !signingChannel && !isChannelClaim,
+        isAnonymous: !isChannelSignatureValid && !isChannelClaim,
         channelName: channelClaim?.name,
         channelLink: isLinkType ? channelClaim?.canonical_url || channelClaim?.permanent_url : false,
         channelTitle:

--- a/ui/component/uriIndicator/view.jsx
+++ b/ui/component/uriIndicator/view.jsx
@@ -55,7 +55,6 @@ class UriIndicator extends React.PureComponent<Props> {
         channelTitle: channelInfo.title,
       };
     } else if (claim) {
-      const signingChannel = claim.signing_channel && claim.signing_channel.amount;
       const isChannelClaim = claim.value_type === 'channel';
       const isChannelSignatureValid = claim.is_channel_signature_valid;
       const channelClaim = isChannelClaim ? claim : claim.signing_channel;


### PR DESCRIPTION
Show claims with invalid channel signature on previewTile as Anonymous. (Does already show as Anonymous on content page)

Example can be seen on this channel http://odysee.com/@MyGreatChannel:3a. This claim http://odysee.com/aaaaaa:07 showed as belonging to the channel, but it wasn't signed by the channel owner. (Invalid channel signature)

Also can be seen here https://odysee.com/@KeyTestChannel:d (Public key is updated, but some claims aren't singed with new key)

New|Old
![anonymous](https://user-images.githubusercontent.com/34790748/182953209-50ae7310-1201-474c-9d0d-838b49280473.png)

(Tom said that hub should check validness of signatures by default for claim_search in general. But also said this maybe ok, so made a PR in case it is)