### PR TITLE
Fix notification popup redirects

### DIFF
--- a/ui/component/headerNotificationButton/view.jsx
+++ b/ui/component/headerNotificationButton/view.jsx
@@ -17,7 +17,7 @@ import Button from 'component/button';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import { RULE } from 'constants/notifications';
 import UriIndicator from 'component/uriIndicator';
-import { getNotificationLink } from '../notification/helpers/target';
+import { getNotificationLocation } from '../notification/helpers/target';
 import { generateNotificationTitle } from '../notification/helpers/title';
 import { generateNotificationText } from '../notification/helpers/text';
 import { parseURI } from 'util/lbryURI';
@@ -112,15 +112,6 @@ export default function NotificationHeaderButton(props: Props) {
       seeNotification([id]);
       readNotification([id]);
     }
-
-    push({
-      pathname: getNotificationLink(notification),
-      state: !disableAutoplay ? undefined : { forceDisableAutoplay: true },
-    });
-  }
-
-  function getWebUri(notification) {
-    return getNotificationLink(notification);
   }
 
   function menuEntry(notification) {
@@ -177,7 +168,10 @@ export default function NotificationHeaderButton(props: Props) {
       <NavLink
         onClick={() => handleNotificationClick(notification, disableAutoplay)}
         key={id}
-        to={{ pathname: getWebUri(notification), state: !disableAutoplay ? undefined : { forceDisableAutoplay: true } }}
+        to={{
+          ...getNotificationLocation(notification),
+          state: !disableAutoplay ? undefined : { forceDisableAutoplay: true },
+        }}
       >
         <div
           className={is_read ? 'menu__list--notification' : 'menu__list--notification menu__list--notification-unread'}

--- a/ui/component/notification/helpers/target.jsx
+++ b/ui/component/notification/helpers/target.jsx
@@ -1,4 +1,5 @@
 // @flow
+import * as CONFIGS from 'config';
 import { LINKED_COMMENT_QUERY_PARAM } from 'constants/comment';
 import { RULE } from 'constants/notifications';
 import * as PAGES from 'constants/pages';
@@ -56,4 +57,15 @@ export function getNotificationLink(notification: WebNotification, target: ?stri
   const notificationTarget = target || getNotificationTarget(notification);
   const urlParams = getUrlParams(notification, notificationTarget);
   return `${formatLbryUrlForWeb(notificationTarget)}?${urlParams.toString()}`;
+}
+
+export function getNotificationLocation(notification: WebNotification, target: ?string) {
+  const link = getNotificationLink(notification, target);
+  // Not all params come from 'notificationTarget',
+  // so generate the link first then only parse it.
+  const url = new URL(link, CONFIGS.URL);
+  return {
+    pathname: url.pathname,
+    ...(url.search ? { search: url.search } : {}),
+  };
 }


### PR DESCRIPTION
## Issue
- Closes #1953
- Closes #1952

The change in d34d32ac caused the `search` parameter to be blank (everything went into `pathname`).

## Change
1. Parse the notification target and define `pathname` and `search` to feed into `NavLink::to`
2. It seems like the `push` in `NavLink::onClick` is redundant (`onClick` and `to` is union'd?), so removed that.