### PR TITLE
Revert "Default api calls from 'get' to 'post'"

### DIFF
--- a/extras/lbryinc/lbryio.js
+++ b/extras/lbryinc/lbryio.js
@@ -19,7 +19,7 @@ Lbryio.setLocalApi = (endpoint) => {
   Lbryio.CONNECTION_STRING = endpoint.replace(/\/*$/, '/'); // exactly one slash at the end;
 };
 
-Lbryio.call = (resource, action, params = {}, method = 'post') => {
+Lbryio.call = (resource, action, params = {}, method = 'get') => {
   if (!Lbryio.enabled) {
     return Promise.reject(new Error(__('LBRY internal API is disabled')));
   }


### PR DESCRIPTION
Cloudflare not working nicely with post calls for blocking/filtering caching, reverting for now. We'll see if we can fix, and if not, may need to exclude filtered/blocked, or anything where auth token is null. 