### PR TITLE
commentCreate: prevent CommentSelectors from re-rendering on input change

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -174,33 +174,39 @@ export function CommentCreate(props: Props) {
   const minAmountRef = React.useRef(minAmount);
   minAmountRef.current = minAmount;
 
-  const addEmoteToComment = (emote: string) => {
+  const addEmoteToComment = React.useCallback((emote: string) => {
     setCommentValue((prev) => prev + (prev && prev.charAt(prev.length - 1) !== ' ' ? ` ${emote} ` : `${emote} `));
-  };
+  }, []);
 
-  const handleSelectSticker = (sticker: any) => {
-    // $FlowFixMe
-    setSelectedSticker(sticker);
-    setReviewingStickerComment(true);
-    setTipAmount(sticker.price || 0);
-    setShowSelectors((prev) => ({ tab: prev.tab || undefined, open: false }));
+  const handleSelectSticker = React.useCallback(
+    (sticker: any) => {
+      // $FlowFixMe
+      setSelectedSticker(sticker);
+      setReviewingStickerComment(true);
+      setTipAmount(sticker.price || 0);
+      setShowSelectors((prev) => ({ tab: prev.tab || undefined, open: false }));
 
-    // added this here since selecting a sticker can cause scroll issues
-    if (onSlimInputClose) onSlimInputClose();
+      // added this here since selecting a sticker can cause scroll issues
+      if (onSlimInputClose) onSlimInputClose();
 
-    if (sticker.price && sticker.price > 0) {
-      setActiveTab(canReceiveFiatTip ? TAB_FIAT : TAB_LBC);
-      setTipSelector(true);
-    }
-  };
+      if (sticker.price && sticker.price > 0) {
+        setActiveTab(canReceiveFiatTip ? TAB_FIAT : TAB_LBC);
+        setTipSelector(true);
+      }
+    },
+    [canReceiveFiatTip, onSlimInputClose]
+  );
 
-  const commentSelectorsProps = {
-    claimIsMine,
-    addEmoteToComment,
-    handleSelectSticker,
-    isOpen: showSelectors.open,
-    openTab: showSelectors.tab || undefined,
-  };
+  const commentSelectorsProps = React.useMemo(() => {
+    return {
+      claimIsMine,
+      addEmoteToComment,
+      handleSelectSticker,
+      isOpen: showSelectors.open,
+      openTab: showSelectors.tab || undefined,
+    };
+  }, [claimIsMine, addEmoteToComment, handleSelectSticker, showSelectors.open, showSelectors.tab]);
+
   const submitButtonProps = { button: 'primary', type: 'submit', requiresAuth: true };
   const actionButtonProps = { button: 'alt' };
   const tipButtonProps = {
@@ -217,6 +223,16 @@ export function CommentCreate(props: Props) {
     price: selectedSticker ? selectedSticker.price : 0,
     exchangeRate,
   };
+
+  const commentSelectorElem = React.useMemo(
+    () => (
+      <CommentSelectors
+        {...commentSelectorsProps}
+        closeSelector={() => setShowSelectors((prev) => ({ tab: prev.tab || undefined, open: false }))}
+      />
+    ),
+    [commentSelectorsProps]
+  );
 
   // **************************************************************************
   // Functions
@@ -647,12 +663,7 @@ export function CommentCreate(props: Props) {
             value={commentValue}
             uri={uri}
           />
-          {!isMobile && (
-            <CommentSelectors
-              {...commentSelectorsProps}
-              closeSelector={() => setShowSelectors({ tab: showSelectors.tab || undefined, open: false })}
-            />
-          )}
+          {!isMobile && commentSelectorElem}
         </>
       )}
 

--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -175,9 +175,7 @@ export function CommentCreate(props: Props) {
   minAmountRef.current = minAmount;
 
   const addEmoteToComment = (emote: string) => {
-    setCommentValue(
-      commentValue + (commentValue && commentValue.charAt(commentValue.length - 1) !== ' ' ? ` ${emote} ` : `${emote} `)
-    );
+    setCommentValue((prev) => prev + (prev && prev.charAt(prev.length - 1) !== ' ' ? ` ${emote} ` : `${emote} `));
   };
 
   const handleSelectSticker = (sticker: any) => {
@@ -185,7 +183,7 @@ export function CommentCreate(props: Props) {
     setSelectedSticker(sticker);
     setReviewingStickerComment(true);
     setTipAmount(sticker.price || 0);
-    setShowSelectors({ tab: showSelectors.tab || undefined, open: false });
+    setShowSelectors((prev) => ({ tab: prev.tab || undefined, open: false }));
 
     // added this here since selecting a sticker can cause scroll issues
     if (onSlimInputClose) onSlimInputClose();


### PR DESCRIPTION
:warning: this goes into `chat-revamp-v2` rather than the usual `master`.

Actual change (minus refactoring):  [link](https://github.com/OdyseeTeam/odysee-frontend/pull/1964/commits/9c182fab2d56117a80537baa482cf2f3ebedc845?diff=split&w=1)

## Issue
Typing on the input field is slow (although ok in development build) because everything is re-rendered when `commentValue` changes. `EmoteCategory` is the slowest based on the profiler.

## Change
Memoize `<CommentSelectors>` so that `EmoteCategory` doesn't re-render.

