### PR TITLE
Refactor `analytics.js`

### DIFF
--- a/extras/lbryinc/lbryio.js
+++ b/extras/lbryinc/lbryio.js
@@ -241,7 +241,7 @@ function sendCallAnalytics(resource, action, params) {
   switch (resource) {
     case 'customer':
       if (action === 'tip') {
-        analytics.reportEvent('spend_virtual_currency', {
+        analytics.event.report('spend_virtual_currency', {
           // https://developers.google.com/analytics/devguides/collection/ga4/reference/events#spend_virtual_currency
           value: params.amount,
           virtual_currency_name: params.currency.toLowerCase(),

--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -2,7 +2,8 @@
 import { Lbryio } from 'lbryinc';
 import * as Sentry from '@sentry/browser';
 import * as RENDER_MODES from 'constants/file_render_modes';
-import { SDK_API_PATH } from 'config';
+import { watchman } from 'analytics/watchman';
+import type { Watchman } from 'analytics/watchman';
 
 // --- GA ---
 // - Events: 500 max (cannot be deleted).
@@ -33,27 +34,15 @@ export const GA_DIMENSIONS = {
   END_TIME_MS: 'end_time_ms',
 };
 
-// import getConnectionSpeed from 'util/detect-user-bandwidth';
-
-// let userDownloadBandwidthInBitsPerSecond;
-// async function getUserBandwidth() {
-//   userDownloadBandwidthInBitsPerSecond = await getConnectionSpeed();
-// }
-
-// get user bandwidth every minute, starting after an initial one minute wait
-// setInterval(getUserBandwidth, 1000 * 60);
-
 const isProduction = process.env.NODE_ENV === 'production';
 let gAnalyticsEnabled = false;
 const devInternalApis = process.env.LBRY_API_URL && process.env.LBRY_API_URL.includes('dev');
-
-const WATCHMAN_BACKEND_ENDPOINT = 'https://watchman.na-backend.odysee.com/reports/playback';
-const SEND_DATA_TO_WATCHMAN_INTERVAL = 10; // in seconds
 
 type Analytics = {
   setState: (enable: boolean) => void,
   appStartTime: number,
   eventStartTime: any,
+  video: Watchman,
   error: (string) => Promise<any>,
   sentryError: ({} | string, {}) => Promise<any>,
   setUser: (Object) => void,
@@ -62,21 +51,6 @@ type Analytics = {
   tagFollowEvent: (string, boolean, ?string) => void,
   playerLoadedEvent: (string, ?boolean) => void,
   playerVideoStartedEvent: (?boolean) => void,
-  videoStartEvent: (?string, number, string, ?number, string, any, ?number, boolean) => void,
-  videoIsPlaying: (boolean, any) => void,
-  videoBufferEvent: (
-    StreamClaim,
-    {
-      timeAtBuffer: number,
-      bufferDuration: number,
-      bitRate: number,
-      duration: number,
-      userId: string,
-      playerPoweredBy: string,
-      readyState: number,
-      isLivestream: boolean,
-    }
-  ) => Promise<any>,
   adsFetchedEvent: () => void,
   emailProvidedEvent: () => void,
   emailVerifiedEvent: () => void,
@@ -99,202 +73,14 @@ type LogPublishParams = {
 
 const isGaAllowed = false; // internalAnalyticsEnabled && isProduction; -- TODO: will be moved in upcoming commit
 
-/**
- * Determine the mobile device type viewing the data
- * This function returns one of 'and' (Android), 'ios', or 'web'.
- *
- * @returns {String}
- */
-function getDeviceType() {
-  // We may not care what the device is if it's in a web browser. Commenting out for now.
-  // if (!IS_WEB) {
-  //   return 'elt';
-  // }
-  // const userAgent = navigator.userAgent || navigator.vendor || window.opera;
-  //
-  // if (/android/i.test(userAgent)) {
-  //   return 'adr';
-  // }
-  //
-  // // iOS detection from: http://stackoverflow.com/a/9039885/177710
-  // if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
-  //   return 'ios';
-  // }
-
-  // default as web, this can be optimized
-  if (!IS_WEB) {
-    return 'dsk';
-  }
-  return 'web';
-}
-// variables initialized for watchman
-let amountOfBufferEvents = 0;
-let amountOfBufferTimeInMS = 0;
-let videoType, userId, claimUrl, playerPoweredBy, videoPlayer, bitrateAsBitsPerSecond, isLivestream;
-let lastSentTime;
-
-// calculate data for backend, send them, and reset buffer data for next interval
-async function sendAndResetWatchmanData() {
-  if (!userId) {
-    return 'Can only be used with a user id';
-  }
-
-  if (!videoPlayer) {
-    return 'Video player not initialized';
-  }
-
-  let timeSinceLastIntervalSend = new Date() - lastSentTime;
-  lastSentTime = new Date();
-
-  let protocol;
-  if (videoType === 'application/x-mpegURL' && !isLivestream) {
-    protocol = 'hls';
-    // get bandwidth if it exists from the texttrack (so it's accurate if user changes quality)
-    // $FlowFixMe
-    bitrateAsBitsPerSecond = videoPlayer.tech(true).vhs?.playlists?.media?.().attributes?.BANDWIDTH;
-  } else if (isLivestream) {
-    protocol = 'lvs';
-    // $FlowFixMe
-    bitrateAsBitsPerSecond = videoPlayer.tech(true).vhs?.playlists?.media?.().attributes?.BANDWIDTH;
-  } else {
-    protocol = 'stb';
-  }
-
-  // current position in video in MS
-  const positionInVideo = isLivestream ? 0 : videoPlayer && Math.round(videoPlayer.currentTime()) * 1000;
-
-  // get the duration marking the time in the video for relative position calculation
-  const totalDurationInSeconds = isLivestream ? 0 : videoPlayer && Math.round(videoPlayer.duration());
-
-  // temp: if buffering over the interval, the duration doesn't reset since we don't get an event
-  if (amountOfBufferTimeInMS > timeSinceLastIntervalSend) amountOfBufferTimeInMS = timeSinceLastIntervalSend;
-
-  // build object for watchman backend
-  const objectToSend = {
-    rebuf_count: amountOfBufferEvents,
-    rebuf_duration: amountOfBufferTimeInMS,
-    url: claimUrl.replace('lbry://', ''),
-    device: getDeviceType(),
-    duration: timeSinceLastIntervalSend,
-    protocol,
-    player: playerPoweredBy,
-    user_id: userId.toString(),
-    position: isLivestream ? 0 : Math.round(positionInVideo),
-    rel_position: isLivestream ? 0 : Math.round((positionInVideo / (totalDurationInSeconds * 1000)) * 100),
-    bitrate: bitrateAsBitsPerSecond,
-    bandwidth: undefined,
-    // ...(userDownloadBandwidthInBitsPerSecond && {bandwidth: userDownloadBandwidthInBitsPerSecond}), // add bandwidth if populated
-  };
-
-  // post to watchman
-  await sendWatchmanData(objectToSend);
-
-  // reset buffer data
-  amountOfBufferEvents = 0;
-  amountOfBufferTimeInMS = 0;
-}
-
-let watchmanInterval;
-// clear watchman interval and mark it as null (when video paused)
-function stopWatchmanInterval() {
-  clearInterval(watchmanInterval);
-  watchmanInterval = null;
-}
-
-// creates the setInterval that will run send to watchman on recurring basis
-function startWatchmanIntervalIfNotRunning() {
-  if (!watchmanInterval) {
-    // instantiate the first time to calculate duration from
-    lastSentTime = new Date();
-
-    // only set an interval if analytics are enabled and is prod
-    if (isProduction && IS_WEB) {
-      watchmanInterval = setInterval(sendAndResetWatchmanData, 1000 * SEND_DATA_TO_WATCHMAN_INTERVAL);
-    }
-  }
-}
-
-// post data to the backend
-async function sendWatchmanData(body) {
-  try {
-    const response = await fetch(WATCHMAN_BACKEND_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-    return response;
-  } catch (err) {}
-}
-
 const analytics: Analytics = {
   setState: (enable: boolean) => {
     gAnalyticsEnabled = enable;
+    analytics.video.setState(gAnalyticsEnabled);
   },
   appStartTime: 0,
   eventStartTime: {},
-
-  // receive buffer events from tracking plugin and save buffer amounts and times for backend call
-  videoBufferEvent: async (claim, data) => {
-    amountOfBufferEvents = amountOfBufferEvents + 1;
-    amountOfBufferTimeInMS = amountOfBufferTimeInMS + data.bufferDuration;
-  },
-  onDispose: () => {
-    stopWatchmanInterval();
-  },
-  /**
-   * Is told whether video is being started or paused, and adjusts interval accordingly
-   * @param {boolean} isPlaying - Whether video was started or paused
-   * @param {object} passedPlayer - VideoJS Player object
-   */
-  videoIsPlaying: (isPlaying, passedPlayer) => {
-    let playerIsSeeking = false;
-    // have to use this because videojs pauses/unpauses during seek
-    // sometimes the seeking function isn't populated yet so check for it as well
-    if (passedPlayer && passedPlayer.seeking) {
-      playerIsSeeking = passedPlayer.seeking();
-    }
-
-    // if being paused, and not seeking, send existing data and stop interval
-    if (!isPlaying && !playerIsSeeking) {
-      sendAndResetWatchmanData();
-      stopWatchmanInterval();
-      // if being told to pause, and seeking, send and restart interval
-    } else if (!isPlaying && playerIsSeeking) {
-      sendAndResetWatchmanData();
-      stopWatchmanInterval();
-      startWatchmanIntervalIfNotRunning();
-      // is being told to play, and seeking, don't do anything,
-      // assume it's been started already from pause
-    } else if (isPlaying && playerIsSeeking) {
-      // start but not a seek, assuming a start from paused content
-    } else if (isPlaying && !playerIsSeeking) {
-      startWatchmanIntervalIfNotRunning();
-    }
-  },
-  videoStartEvent: (
-    claimId,
-    timeToStartVideo,
-    poweredBy,
-    passedUserId,
-    canonicalUrl,
-    passedPlayer,
-    videoBitrate,
-    isLivestreamClaim
-  ) => {
-    // populate values for watchman when video starts
-    userId = passedUserId;
-    claimUrl = canonicalUrl;
-    playerPoweredBy = poweredBy;
-    isLivestream = isLivestreamClaim;
-
-    videoType = passedPlayer.currentSource().type;
-    videoPlayer = passedPlayer;
-    bitrateAsBitsPerSecond = videoBitrate;
-    !isLivestreamClaim && sendPromMetric('time_to_start', timeToStartVideo, playerPoweredBy);
-  },
+  video: watchman,
   error: (message) => {
     return new Promise((resolve) => {
       if (gAnalyticsEnabled && isProduction) {
@@ -479,15 +265,6 @@ const analytics: Analytics = {
 function sendGaEvent(event: string, params?: { [string]: string | number }) {
   if (isGaAllowed && window.gtag) {
     window.gtag('event', event, params);
-  }
-}
-
-function sendPromMetric(name: string, value?: number, player: string) {
-  if (IS_WEB) {
-    let url = new URL(SDK_API_PATH + '/metric/ui');
-    const params = { name: name, value: value ? value.toString() : '', player: player };
-    url.search = new URLSearchParams(params).toString();
-    return fetch(url, { method: 'post' }).catch(function (error) {});
   }
 }
 

--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -1,39 +1,34 @@
 // @flow
 import { Lbryio } from 'lbryinc';
 import * as Sentry from '@sentry/browser';
+import { apiLog } from 'analytics/apiLog';
 import { events } from 'analytics/events';
 import { watchman } from 'analytics/watchman';
+import type { ApiLog } from 'analytics/apiLog';
 import type { Events } from 'analytics/events';
 import type { Watchman } from 'analytics/watchman';
 
 const isProduction = process.env.NODE_ENV === 'production';
 let gAnalyticsEnabled = false;
-const devInternalApis = process.env.LBRY_API_URL && process.env.LBRY_API_URL.includes('dev');
 
 type Analytics = {
   setState: (enable: boolean) => void,
+  apiLog: ApiLog,
   event: Events,
   video: Watchman,
   error: (string) => Promise<any>,
   sentryError: ({} | string, {}) => Promise<any>,
   setUser: (Object) => void,
-  apiLogView: (string, string, string, ?number, ?() => void) => Promise<any>,
-  apiLogPublish: (ChannelClaim | StreamClaim) => void,
-};
-
-type LogPublishParams = {
-  uri: string,
-  claim_id: string,
-  outpoint: string,
-  channel_claim_id?: string,
 };
 
 const analytics: Analytics = {
   setState: (enable: boolean) => {
     gAnalyticsEnabled = enable;
+    analytics.apiLog.setState(gAnalyticsEnabled);
     analytics.event.setState(gAnalyticsEnabled);
     analytics.video.setState(gAnalyticsEnabled);
   },
+  apiLog: apiLog,
   event: events,
   video: watchman,
   error: (message) => {
@@ -67,52 +62,6 @@ const analytics: Analytics = {
   toggleThirdParty: (enabled: boolean): void => {
     // Retained to keep things compiling. We don't do third-party analytics,
     // so this can be removed, but together with the redux state.
-  },
-  apiLogView: (uri, outpoint, claimId, timeToStart) => {
-    return new Promise((resolve, reject) => {
-      if (gAnalyticsEnabled && (isProduction || devInternalApis)) {
-        const params: {
-          uri: string,
-          outpoint: string,
-          claim_id: string,
-          time_to_start?: number,
-        } = {
-          uri,
-          outpoint,
-          claim_id: claimId,
-        };
-
-        if (timeToStart && !IS_WEB) {
-          params.time_to_start = timeToStart;
-        }
-
-        resolve(Lbryio.call('file', 'view', params));
-      } else {
-        resolve();
-      }
-    });
-  },
-  apiLogSearch: () => {
-    if (gAnalyticsEnabled && isProduction) {
-      Lbryio.call('event', 'search');
-    }
-  },
-  apiLogPublish: (claimResult: ChannelClaim | StreamClaim) => {
-    // Don't check if this is production so channels created on localhost are still linked to user
-    if (gAnalyticsEnabled) {
-      const { permanent_url: uri, claim_id: claimId, txid, nout, signing_channel: signingChannel } = claimResult;
-      let channelClaimId;
-      if (signingChannel) {
-        channelClaimId = signingChannel.claim_id;
-      }
-      const outpoint = `${txid}:${nout}`;
-      const params: LogPublishParams = { uri, claim_id: claimId, outpoint };
-      if (channelClaimId) {
-        params['channel_claim_id'] = channelClaimId;
-      }
-
-      Lbryio.call('event', 'publish', params);
-    }
   },
 };
 

--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -1,38 +1,10 @@
 // @flow
 import { Lbryio } from 'lbryinc';
 import * as Sentry from '@sentry/browser';
-import * as RENDER_MODES from 'constants/file_render_modes';
+import { events } from 'analytics/events';
 import { watchman } from 'analytics/watchman';
+import type { Events } from 'analytics/events';
 import type { Watchman } from 'analytics/watchman';
-
-// --- GA ---
-// - Events: 500 max (cannot be deleted).
-// - Dimensions: 25 max (cannot be deleted, but can be "archived"). Usually
-//               tied to an event parameter for reporting purposes.
-//
-// Given the limitations above, we need to plan ahead before adding new Events
-// and Parameters.
-//
-// Events:
-// - Find a Recommended Event that is closest to what you need.
-//   https://support.google.com/analytics/answer/9267735?hl=en
-// - If doesn't exist, use a Custom Event.
-//
-// Parameters:
-// - Custom parameters don't appear in automated reports until they are tied to
-//   a Dimension.
-// - Add your entry to GA_DIMENSIONS below -- tt allows us to keep track so that
-//   we don't exceed the limit. Re-use existing parameters if possible.
-// - Register the Dimension in GA Console to make it visible in reports.
-
-export const GA_DIMENSIONS = {
-  TYPE: 'type',
-  ACTION: 'action',
-  VALUE: 'value',
-  START_TIME_MS: 'start_time_ms',
-  DURATION_MS: 'duration_ms',
-  END_TIME_MS: 'end_time_ms',
-};
 
 const isProduction = process.env.NODE_ENV === 'production';
 let gAnalyticsEnabled = false;
@@ -40,28 +12,13 @@ const devInternalApis = process.env.LBRY_API_URL && process.env.LBRY_API_URL.inc
 
 type Analytics = {
   setState: (enable: boolean) => void,
-  appStartTime: number,
-  eventStartTime: any,
+  event: Events,
   video: Watchman,
   error: (string) => Promise<any>,
   sentryError: ({} | string, {}) => Promise<any>,
   setUser: (Object) => void,
   apiLogView: (string, string, string, ?number, ?() => void) => Promise<any>,
   apiLogPublish: (ChannelClaim | StreamClaim) => void,
-  tagFollowEvent: (string, boolean, ?string) => void,
-  playerLoadedEvent: (string, ?boolean) => void,
-  playerVideoStartedEvent: (?boolean) => void,
-  adsFetchedEvent: () => void,
-  emailProvidedEvent: () => void,
-  emailVerifiedEvent: () => void,
-  rewardEligibleEvent: () => void,
-  initAppStartTime: (startTime: number) => void,
-  startupEvent: (time: number) => void,
-  eventStarted: (name: string, time: number, id?: string) => void,
-  eventCompleted: (name: string, time: number, id?: string) => void,
-  purchaseEvent: (number) => void,
-  openUrlEvent: (string) => void,
-  reportEvent: (string, any) => void,
 };
 
 type LogPublishParams = {
@@ -71,15 +28,13 @@ type LogPublishParams = {
   channel_claim_id?: string,
 };
 
-const isGaAllowed = false; // internalAnalyticsEnabled && isProduction; -- TODO: will be moved in upcoming commit
-
 const analytics: Analytics = {
   setState: (enable: boolean) => {
     gAnalyticsEnabled = enable;
+    analytics.event.setState(gAnalyticsEnabled);
     analytics.video.setState(gAnalyticsEnabled);
   },
-  appStartTime: 0,
-  eventStartTime: {},
+  event: events,
   video: watchman,
   error: (message) => {
     return new Promise((resolve) => {
@@ -106,9 +61,8 @@ const analytics: Analytics = {
     });
   },
   setUser: (userId) => {
-    if (isGaAllowed && userId && window.gtag) {
-      window.gtag('set', { user_id: userId });
-    }
+    analytics.event.setUser(userId);
+    // Pass on to other submodules as needed...
   },
   toggleThirdParty: (enabled: boolean): void => {
     // Retained to keep things compiling. We don't do third-party analytics,
@@ -160,121 +114,7 @@ const analytics: Analytics = {
       Lbryio.call('event', 'publish', params);
     }
   },
-  adsFetchedEvent: () => {
-    sendGaEvent('ad_fetched');
-  },
-  playerLoadedEvent: (renderMode, embedded) => {
-    const RENDER_MODE_TO_EVENT = (renderMode) => {
-      switch (renderMode) {
-        case RENDER_MODES.VIDEO:
-          return 'loaded_video';
-        case RENDER_MODES.AUDIO:
-          return 'loaded_audio';
-        case RENDER_MODES.MARKDOWN:
-          return 'loaded_markdown';
-        case RENDER_MODES.IMAGE:
-          return 'loaded_image';
-        case 'livestream':
-          return 'loaded_livestream';
-        default:
-          return 'loaded_misc';
-      }
-    };
-
-    sendGaEvent('player', {
-      [GA_DIMENSIONS.ACTION]: RENDER_MODE_TO_EVENT(renderMode),
-      [GA_DIMENSIONS.TYPE]: embedded ? 'embedded' : 'onsite',
-    });
-  },
-  playerVideoStartedEvent: (embedded) => {
-    sendGaEvent('player', {
-      [GA_DIMENSIONS.ACTION]: 'started_video',
-      [GA_DIMENSIONS.TYPE]: embedded ? 'embedded' : 'onsite',
-    });
-  },
-  tagFollowEvent: (tag, following) => {
-    sendGaEvent('tags', {
-      [GA_DIMENSIONS.ACTION]: following ? 'follow' : 'unfollow',
-      [GA_DIMENSIONS.VALUE]: tag,
-    });
-  },
-  emailProvidedEvent: () => {
-    sendGaEvent('engagement', {
-      [GA_DIMENSIONS.TYPE]: 'email_provided',
-    });
-  },
-  emailVerifiedEvent: () => {
-    sendGaEvent('engagement', {
-      [GA_DIMENSIONS.TYPE]: 'email_verified',
-    });
-  },
-  rewardEligibleEvent: () => {
-    sendGaEvent('engagement', {
-      [GA_DIMENSIONS.TYPE]: 'reward_eligible',
-    });
-  },
-  openUrlEvent: (url: string) => {
-    sendGaEvent('engagement', {
-      [GA_DIMENSIONS.TYPE]: 'open_url',
-      url,
-    });
-  },
-  trendingAlgorithmEvent: (trendingAlgorithm: string) => {
-    sendGaEvent('engagement', {
-      [GA_DIMENSIONS.TYPE]: 'trending_algorithm',
-      trending_algorithm: trendingAlgorithm,
-    });
-  },
-  initAppStartTime: (startTime: number) => {
-    analytics.appStartTime = startTime;
-  },
-  startupEvent: (time: number) => {
-    if (analytics.appStartTime !== 0) {
-      sendGaEvent('diag_app_ready', {
-        [GA_DIMENSIONS.DURATION_MS]: time - analytics.appStartTime,
-      });
-    }
-  },
-  eventStarted: (name: string, time: number, id?: string) => {
-    const key = id || name;
-    analytics.eventStartTime[key] = time;
-  },
-  eventCompleted: (name: string, time: number, id?: string) => {
-    const key = id || name;
-    if (analytics.eventStartTime[key]) {
-      sendGaEvent(name, {
-        [GA_DIMENSIONS.START_TIME_MS]: analytics.eventStartTime[key] - analytics.appStartTime,
-        [GA_DIMENSIONS.DURATION_MS]: time - analytics.eventStartTime[key],
-        [GA_DIMENSIONS.END_TIME_MS]: time - analytics.appStartTime,
-      });
-
-      delete analytics.eventStartTime[key];
-    }
-  },
-  purchaseEvent: (purchaseInt: number) => {
-    sendGaEvent('purchase', {
-      // https://developers.google.com/analytics/devguides/collection/ga4/reference/events#purchase
-      [GA_DIMENSIONS.VALUE]: purchaseInt,
-    });
-  },
-  reportEvent: (event: string, params?: { [string]: string | number }) => {
-    sendGaEvent(event, params);
-  },
 };
-
-function sendGaEvent(event: string, params?: { [string]: string | number }) {
-  if (isGaAllowed && window.gtag) {
-    window.gtag('event', event, params);
-  }
-}
-
-// Activate
-if (isGaAllowed && window.gtag) {
-  window.gtag('consent', 'update', {
-    ad_storage: 'granted',
-    analytics_storage: 'granted',
-  });
-}
 
 analytics.setState(IS_WEB);
 export default analytics;

--- a/ui/analytics/apiLog.js
+++ b/ui/analytics/apiLog.js
@@ -1,0 +1,76 @@
+// @flow
+import { Lbryio } from 'lbryinc';
+
+const isProduction = process.env.NODE_ENV === 'production';
+const devInternalApis = process.env.LBRY_API_URL && process.env.LBRY_API_URL.includes('dev');
+
+type LogPublishParams = {
+  uri: string,
+  claim_id: string,
+  outpoint: string,
+  channel_claim_id?: string,
+};
+
+export type ApiLog = {
+  setState: (enable: boolean) => void,
+  view: (string, string, string, ?number, ?() => void) => Promise<any>,
+  search: () => void,
+  publish: (ChannelClaim | StreamClaim) => void,
+};
+
+let gApiLogOn = false;
+
+export const apiLog: ApiLog = {
+  setState: (enable: boolean) => {
+    gApiLogOn = enable;
+  },
+
+  view: (uri, outpoint, claimId, timeToStart) => {
+    return new Promise((resolve, reject) => {
+      if (gApiLogOn && (isProduction || devInternalApis)) {
+        const params: {
+          uri: string,
+          outpoint: string,
+          claim_id: string,
+          time_to_start?: number,
+        } = {
+          uri,
+          outpoint,
+          claim_id: claimId,
+        };
+
+        if (timeToStart && !IS_WEB) {
+          params.time_to_start = timeToStart;
+        }
+
+        resolve(Lbryio.call('file', 'view', params));
+      } else {
+        resolve();
+      }
+    });
+  },
+
+  search: () => {
+    if (gApiLogOn && isProduction) {
+      Lbryio.call('event', 'search');
+    }
+  },
+
+  publish: (claimResult: ChannelClaim | StreamClaim) => {
+    // Don't check if this is production so channels created on localhost are still linked to user
+    if (gApiLogOn) {
+      const { permanent_url: uri, claim_id: claimId, txid, nout, signing_channel: signingChannel } = claimResult;
+      let channelClaimId;
+      if (signingChannel) {
+        channelClaimId = signingChannel.claim_id;
+      }
+      const outpoint = `${txid}:${nout}`;
+      const params: LogPublishParams = { uri, claim_id: claimId, outpoint };
+      if (channelClaimId) {
+        params['channel_claim_id'] = channelClaimId;
+      }
+
+      Lbryio.call('event', 'publish', params);
+    }
+  },
+};

--- a/ui/analytics/events.js
+++ b/ui/analytics/events.js
@@ -1,0 +1,218 @@
+// @flow
+import * as RENDER_MODES from 'constants/file_render_modes';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+// --- GA ---
+// - Events: 500 max (cannot be deleted).
+// - Dimensions: 25 max (cannot be deleted, but can be "archived"). Usually
+//               tied to an event parameter for reporting purposes.
+//
+// Given the limitations above, we need to plan ahead before adding new Events
+// and Parameters.
+//
+// Events:
+// - Find a Recommended Event that is closest to what you need.
+//   https://support.google.com/analytics/answer/9267735?hl=en
+// - If doesn't exist, use a Custom Event.
+//
+// Parameters:
+// - Custom parameters don't appear in automated reports until they are tied to
+//   a Dimension.
+// - Add your entry to GA_DIMENSIONS below -- tt allows us to keep track so that
+//   we don't exceed the limit. Re-use existing parameters if possible.
+// - Register the Dimension in GA Console to make it visible in reports.
+export const GA_DIMENSIONS = {
+  TYPE: 'type',
+  ACTION: 'action',
+  VALUE: 'value',
+  START_TIME_MS: 'start_time_ms',
+  DURATION_MS: 'duration_ms',
+  END_TIME_MS: 'end_time_ms',
+};
+
+let gAppStartTime = 0;
+let gStartTimeByEvent = {};
+let gGoogleAnalyticsOn = false;
+
+export type Events = {
+  setState: (enable: boolean) => void,
+  setUser: (userId: string) => void,
+  // ------
+  report: (string, any) => void,
+  // ------
+  adsFetched: () => void,
+  emailProvided: () => void,
+  emailVerified: () => void,
+  openUrl: (string) => void,
+  playerLoaded: (string, ?boolean) => void,
+  playerVideoStarted: (?boolean) => void,
+  purchase: (number) => void,
+  rewardEligible: () => void,
+  startup: (time: number) => void,
+  tagFollow: (string, boolean, ?string) => void,
+  trendingAlgorithm: (trendingAlgorithm: string) => void,
+  // ------
+  initAppStartTime: (startTime: number) => void,
+  // ------
+  eventStarted: (name: string, time: number, id?: string) => void,
+  eventCompleted: (name: string, time: number, id?: string) => void,
+};
+
+export const events: Events = {
+  setState: (enable: boolean) => {
+    gGoogleAnalyticsOn = enable && isProduction && window.gtag;
+
+    if (gGoogleAnalyticsOn) {
+      window.gtag('consent', 'update', {
+        ad_storage: 'granted',
+        analytics_storage: 'granted',
+      });
+    }
+
+    // TODO: If we turn off at runtime, do we need to toggle window.gtag?
+    // Not thinking about it now since we are removing GA anyway.
+  },
+
+  setUser: (userId: string) => {
+    if (gGoogleAnalyticsOn && userId) {
+      window.gtag('set', { user_id: userId });
+    }
+  },
+
+  // --------------------------------------------------------------------------
+  // --------------------------------------------------------------------------
+
+  report: (event: string, params?: { [string]: string | number }) => {
+    sendGaEvent(event, params);
+  },
+
+  // --------------------------------------------------------------------------
+  // --------------------------------------------------------------------------
+
+  adsFetched: () => {
+    sendGaEvent('ad_fetched');
+  },
+
+  emailProvided: () => {
+    sendGaEvent('engagement', {
+      [GA_DIMENSIONS.TYPE]: 'email_provided',
+    });
+  },
+
+  emailVerified: () => {
+    sendGaEvent('engagement', {
+      [GA_DIMENSIONS.TYPE]: 'email_verified',
+    });
+  },
+
+  openUrl: (url: string) => {
+    sendGaEvent('engagement', {
+      [GA_DIMENSIONS.TYPE]: 'open_url',
+      url,
+    });
+  },
+
+  playerLoaded: (renderMode, embedded) => {
+    const RENDER_MODE_TO_EVENT = (renderMode) => {
+      switch (renderMode) {
+        case RENDER_MODES.VIDEO:
+          return 'loaded_video';
+        case RENDER_MODES.AUDIO:
+          return 'loaded_audio';
+        case RENDER_MODES.MARKDOWN:
+          return 'loaded_markdown';
+        case RENDER_MODES.IMAGE:
+          return 'loaded_image';
+        case 'livestream':
+          return 'loaded_livestream';
+        default:
+          return 'loaded_misc';
+      }
+    };
+
+    sendGaEvent('player', {
+      [GA_DIMENSIONS.ACTION]: RENDER_MODE_TO_EVENT(renderMode),
+      [GA_DIMENSIONS.TYPE]: embedded ? 'embedded' : 'onsite',
+    });
+  },
+
+  playerVideoStarted: (embedded) => {
+    sendGaEvent('player', {
+      [GA_DIMENSIONS.ACTION]: 'started_video',
+      [GA_DIMENSIONS.TYPE]: embedded ? 'embedded' : 'onsite',
+    });
+  },
+
+  purchase: (purchaseInt: number) => {
+    sendGaEvent('purchase', {
+      // https://developers.google.com/analytics/devguides/collection/ga4/reference/events#purchase
+      [GA_DIMENSIONS.VALUE]: purchaseInt,
+    });
+  },
+
+  rewardEligible: () => {
+    sendGaEvent('engagement', {
+      [GA_DIMENSIONS.TYPE]: 'reward_eligible',
+    });
+  },
+
+  startup: (time: number) => {
+    if (gAppStartTime !== 0) {
+      sendGaEvent('diag_app_ready', {
+        [GA_DIMENSIONS.DURATION_MS]: time - gAppStartTime,
+      });
+    }
+  },
+
+  tagFollow: (tag, following) => {
+    sendGaEvent('tags', {
+      [GA_DIMENSIONS.ACTION]: following ? 'follow' : 'unfollow',
+      [GA_DIMENSIONS.VALUE]: tag,
+    });
+  },
+
+  trendingAlgorithm: (trendingAlgorithm: string) => {
+    sendGaEvent('engagement', {
+      [GA_DIMENSIONS.TYPE]: 'trending_algorithm',
+      trending_algorithm: trendingAlgorithm,
+    });
+  },
+
+  // --------------------------------------------------------------------------
+  // --------------------------------------------------------------------------
+
+  initAppStartTime: (startTime: number) => {
+    gAppStartTime = startTime;
+  },
+
+  // --------------------------------------------------------------------------
+  // --------------------------------------------------------------------------
+
+  eventStarted: (name: string, time: number, id?: string) => {
+    const key = id || name;
+    gStartTimeByEvent[key] = time;
+  },
+
+  eventCompleted: (name: string, time: number, id?: string) => {
+    const key = id || name;
+    if (gStartTimeByEvent[key]) {
+      sendGaEvent(name, {
+        [GA_DIMENSIONS.START_TIME_MS]: gStartTimeByEvent[key] - gAppStartTime,
+        [GA_DIMENSIONS.DURATION_MS]: time - gStartTimeByEvent[key],
+        [GA_DIMENSIONS.END_TIME_MS]: time - gAppStartTime,
+      });
+
+      delete gStartTimeByEvent[key];
+    }
+  },
+};
+
+// ****************************************************************************
+// ****************************************************************************
+
+function sendGaEvent(event: string, params?: { [string]: string | number }) {
+  if (gGoogleAnalyticsOn) {
+    window.gtag('event', event, params);
+  }
+}

--- a/ui/analytics/overview.md
+++ b/ui/analytics/overview.md
@@ -1,0 +1,3 @@
+- Submodules for the global `ui/analytics.js` object.
+- Ensure submodules do not import the primary interface directly to avoid circular-dependencies.
+  - Pass states and values through the interface (e.g. `setState`). 

--- a/ui/analytics/watchman.js
+++ b/ui/analytics/watchman.js
@@ -1,0 +1,206 @@
+// @flow
+import { SDK_API_PATH } from 'config';
+
+const isProduction = process.env.NODE_ENV === 'production';
+const WATCHMAN_BACKEND_ENDPOINT = 'https://watchman.na-backend.odysee.com/reports/playback';
+const SEND_DATA_TO_WATCHMAN_INTERVAL = 10; // in seconds
+
+let gWatchmanAnalyticsEnabled = false;
+
+// variables initialized for watchman
+let amountOfBufferEvents = 0;
+let amountOfBufferTimeInMS = 0;
+let videoType, userId, claimUrl, playerPoweredBy, videoPlayer, bitrateAsBitsPerSecond, isLivestream;
+let lastSentTime;
+
+// calculate data for backend, send them, and reset buffer data for next interval
+async function sendAndResetWatchmanData() {
+  if (!userId) {
+    return 'Can only be used with a user id';
+  }
+
+  if (!videoPlayer) {
+    return 'Video player not initialized';
+  }
+
+  let timeSinceLastIntervalSend = new Date() - lastSentTime;
+  lastSentTime = new Date();
+
+  let protocol;
+  if (videoType === 'application/x-mpegURL' && !isLivestream) {
+    protocol = 'hls';
+    // get bandwidth if it exists from the texttrack (so it's accurate if user changes quality)
+    // $FlowFixMe
+    bitrateAsBitsPerSecond = videoPlayer.tech(true).vhs?.playlists?.media?.().attributes?.BANDWIDTH;
+  } else if (isLivestream) {
+    protocol = 'lvs';
+    // $FlowFixMe
+    bitrateAsBitsPerSecond = videoPlayer.tech(true).vhs?.playlists?.media?.().attributes?.BANDWIDTH;
+  } else {
+    protocol = 'stb';
+  }
+
+  // current position in video in MS
+  const positionInVideo = isLivestream ? 0 : videoPlayer && Math.round(videoPlayer.currentTime()) * 1000;
+
+  // get the duration marking the time in the video for relative position calculation
+  const totalDurationInSeconds = isLivestream ? 0 : videoPlayer && Math.round(videoPlayer.duration());
+
+  // temp: if buffering over the interval, the duration doesn't reset since we don't get an event
+  if (amountOfBufferTimeInMS > timeSinceLastIntervalSend) amountOfBufferTimeInMS = timeSinceLastIntervalSend;
+
+  // build object for watchman backend
+  const objectToSend = {
+    rebuf_count: amountOfBufferEvents,
+    rebuf_duration: amountOfBufferTimeInMS,
+    url: claimUrl.replace('lbry://', ''),
+    device: 'web',
+    duration: timeSinceLastIntervalSend,
+    protocol,
+    player: playerPoweredBy,
+    user_id: userId.toString(),
+    position: isLivestream ? 0 : Math.round(positionInVideo),
+    rel_position: isLivestream ? 0 : Math.round((positionInVideo / (totalDurationInSeconds * 1000)) * 100),
+    bitrate: bitrateAsBitsPerSecond,
+    bandwidth: undefined,
+    // ...(userDownloadBandwidthInBitsPerSecond && {bandwidth: userDownloadBandwidthInBitsPerSecond}), // add bandwidth if populated
+  };
+
+  // post to watchman
+  await sendWatchmanData(objectToSend);
+
+  // reset buffer data
+  amountOfBufferEvents = 0;
+  amountOfBufferTimeInMS = 0;
+}
+
+let watchmanInterval;
+// clear watchman interval and mark it as null (when video paused)
+function stopWatchmanInterval() {
+  clearInterval(watchmanInterval);
+  watchmanInterval = null;
+}
+
+// creates the setInterval that will run send to watchman on recurring basis
+function startWatchmanIntervalIfNotRunning() {
+  if (!watchmanInterval) {
+    // instantiate the first time to calculate duration from
+    lastSentTime = new Date();
+
+    // only set an interval if analytics are enabled and is prod
+    if (isProduction && gWatchmanAnalyticsEnabled) {
+      watchmanInterval = setInterval(sendAndResetWatchmanData, 1000 * SEND_DATA_TO_WATCHMAN_INTERVAL);
+    }
+  }
+}
+
+// post data to the backend
+async function sendWatchmanData(body) {
+  try {
+    const response = await fetch(WATCHMAN_BACKEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    return response;
+  } catch (err) {}
+}
+
+// ****************************************************************************
+// ****************************************************************************
+
+export type Watchman = {
+  setState: (enable: boolean) => void,
+  videoStartEvent: (?string, number, string, ?number, string, any, ?number, boolean) => void,
+  videoIsPlaying: (boolean, any) => void,
+  videoBufferEvent: (
+    StreamClaim,
+    {
+      timeAtBuffer: number,
+      bufferDuration: number,
+      bitRate: number,
+      duration: number,
+      userId: string,
+      playerPoweredBy: string,
+      readyState: number,
+      isLivestream: boolean,
+    }
+  ) => Promise<any>,
+};
+
+export const watchman: Watchman = {
+  setState: (enable: boolean) => {
+    gWatchmanAnalyticsEnabled = enable;
+  },
+  /**
+   * Is told whether video is being started or paused, and adjusts interval accordingly
+   * @param {boolean} isPlaying - Whether video was started or paused
+   * @param {object} passedPlayer - VideoJS Player object
+   */
+  videoIsPlaying: (isPlaying, passedPlayer) => {
+    let playerIsSeeking = false;
+    // have to use this because videojs pauses/unpauses during seek
+    // sometimes the seeking function isn't populated yet so check for it as well
+    if (passedPlayer && passedPlayer.seeking) {
+      playerIsSeeking = passedPlayer.seeking();
+    }
+
+    // if being paused, and not seeking, send existing data and stop interval
+    if (!isPlaying && !playerIsSeeking) {
+      sendAndResetWatchmanData();
+      stopWatchmanInterval();
+      // if being told to pause, and seeking, send and restart interval
+    } else if (!isPlaying && playerIsSeeking) {
+      sendAndResetWatchmanData();
+      stopWatchmanInterval();
+      startWatchmanIntervalIfNotRunning();
+      // is being told to play, and seeking, don't do anything,
+      // assume it's been started already from pause
+    } else if (isPlaying && playerIsSeeking) {
+      // start but not a seek, assuming a start from paused content
+    } else if (isPlaying && !playerIsSeeking) {
+      startWatchmanIntervalIfNotRunning();
+    }
+  },
+  // receive buffer events from tracking plugin and save buffer amounts and times for backend call
+  videoBufferEvent: async (claim, data) => {
+    amountOfBufferEvents = amountOfBufferEvents + 1;
+    amountOfBufferTimeInMS = amountOfBufferTimeInMS + data.bufferDuration;
+  },
+  videoStartEvent: (
+    claimId,
+    timeToStartVideo,
+    poweredBy,
+    passedUserId,
+    canonicalUrl,
+    passedPlayer,
+    videoBitrate,
+    isLivestreamClaim
+  ) => {
+    // populate values for watchman when video starts
+    userId = passedUserId;
+    claimUrl = canonicalUrl;
+    playerPoweredBy = poweredBy;
+    isLivestream = isLivestreamClaim;
+
+    videoType = passedPlayer.currentSource().type;
+    videoPlayer = passedPlayer;
+    bitrateAsBitsPerSecond = videoBitrate;
+    !isLivestreamClaim && sendPromMetric('time_to_start', timeToStartVideo, playerPoweredBy);
+  },
+  onDispose: () => {
+    stopWatchmanInterval();
+  },
+};
+
+function sendPromMetric(name: string, value?: number, player: string) {
+  if (gWatchmanAnalyticsEnabled) {
+    let url = new URL(SDK_API_PATH + '/metric/ui');
+    const params = { name: name, value: value ? value.toString() : '', player: player };
+    url.search = new URLSearchParams(params).toString();
+    return fetch(url, { method: 'post' }).catch(function (error) {});
+  }
+}

--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -383,13 +383,13 @@ function App(props: Props) {
     // Check that previousHasVerifiedEmail was not undefined instead of just not truthy
     // This ensures we don't fire the emailVerified event on the initial user fetch
     if (previousHasVerifiedEmail === false && hasVerifiedEmail) {
-      analytics.emailVerifiedEvent();
+      analytics.event.emailVerified();
     }
   }, [previousHasVerifiedEmail, hasVerifiedEmail, signIn]);
 
   useEffect(() => {
     if (previousRewardApproved === false && isRewardApproved) {
-      analytics.rewardEligibleEvent();
+      analytics.event.rewardEligible();
     }
   }, [previousRewardApproved, isRewardApproved]);
 

--- a/ui/component/channelEdit/view.jsx
+++ b/ui/component/channelEdit/view.jsx
@@ -232,7 +232,7 @@ function ChannelForm(props: Props) {
     } else {
       createChannel(params).then((success) => {
         if (success) {
-          analytics.apiLogPublish(success);
+          analytics.apiLog.publish(success);
           onDone();
         }
       });

--- a/ui/component/creatorAnalytics/view.jsx
+++ b/ui/component/creatorAnalytics/view.jsx
@@ -49,7 +49,7 @@ export default function CreatorAnalytics(props: Props) {
           if (error.response.status === 401) {
             setError(UNAUTHENTICATED_ERROR);
             const channelToSend = JSON.parse(channelForEffect);
-            analytics.apiLogPublish(channelToSend);
+            analytics.apiLog.publish(channelToSend);
           } else {
             setError(GENERIC_ERROR);
           }

--- a/ui/component/fileRender/view.jsx
+++ b/ui/component/fileRender/view.jsx
@@ -49,7 +49,7 @@ class FileRender extends React.PureComponent<Props> {
   componentDidMount() {
     const { renderMode, embedded } = this.props;
     window.addEventListener('keydown', this.escapeListener, true);
-    analytics.playerLoadedEvent(renderMode, embedded);
+    analytics.event.playerLoaded(renderMode, embedded);
   }
 
   componentWillUnmount() {

--- a/ui/component/inviteNew/view.jsx
+++ b/ui/component/inviteNew/view.jsx
@@ -39,7 +39,7 @@ function InviteNew(props: Props) {
       // TODO: keep track of this in an array?
       const matchingChannel = channels && channels.find((ch) => ch.name === code);
       if (matchingChannel) {
-        analytics.apiLogPublish(matchingChannel);
+        analytics.apiLog.publish(matchingChannel);
       }
     },
     [setReferralSource]

--- a/ui/component/repostCreate/view.jsx
+++ b/ui/component/repostCreate/view.jsx
@@ -265,7 +265,7 @@ function RepostCreate(props: Props) {
         claim_id: repostClaimId,
       }).then((repostClaim: StreamClaim) => {
         doCheckPendingClaims();
-        analytics.apiLogPublish(repostClaim);
+        analytics.apiLog.publish(repostClaim);
         doToast({
           message: __('Woohoo! Successfully reposted this claim.'),
           linkText: __('Uploads'),

--- a/ui/component/tagsSearch/view.jsx
+++ b/ui/component/tagsSearch/view.jsx
@@ -148,7 +148,7 @@ export default function TagsSearch(props: Props) {
     } else {
       const wasFollowing = followedTags.map((t) => t.name).includes(tag);
       doToggleTagFollowDesktop(tag);
-      analytics.tagFollowEvent(tag, !wasFollowing);
+      analytics.event.tagFollow(tag, !wasFollowing);
     }
   }
   function handleUtilityTagCheckbox(tag: string) {

--- a/ui/component/tagsSelect/view.jsx
+++ b/ui/component/tagsSelect/view.jsx
@@ -66,7 +66,7 @@ export default function TagsSelect(props: Props) {
 
       const wasFollowing = followedTags.map((tag) => tag.name).includes(tag.name);
       const nowFollowing = !wasFollowing;
-      analytics.tagFollowEvent(tag.name, nowFollowing, 'tag-select');
+      analytics.event.tagFollow(tag.name, nowFollowing, 'tag-select');
     }
   }
 

--- a/ui/component/userEmailNew/view.jsx
+++ b/ui/component/userEmailNew/view.jsx
@@ -63,7 +63,7 @@ function UserEmailNew(props: Props) {
     setShareDiagnosticData(true);
     // @endif
     doSignUp(email, password === '' ? undefined : password).then(() => {
-      analytics.emailProvidedEvent();
+      analytics.event.emailProvided();
     });
   }
 

--- a/ui/component/userFirstChannel/view.jsx
+++ b/ui/component/userFirstChannel/view.jsx
@@ -107,7 +107,7 @@ function UserFirstChannel(props: Props) {
       languages: primaryLanguage,
     }).then((channelClaim) => {
       if (channelClaim) {
-        analytics.apiLogPublish(channelClaim);
+        analytics.apiLog.publish(channelClaim);
       }
     });
   }

--- a/ui/component/viewers/videoViewer/internal/videojs-events.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs-events.jsx
@@ -75,7 +75,7 @@ const VideoJsEvents = ({
       }
 
       // populates data for watchman, sends prom and matomo event
-      analytics.videoStartEvent(
+      analytics.video.videoStartEvent(
         claimId,
         timeToStartVideo,
         playerPoweredBy,
@@ -87,7 +87,7 @@ const VideoJsEvents = ({
       );
     } else {
       // populates data for watchman, sends prom and matomo event
-      analytics.videoStartEvent(
+      analytics.video.videoStartEvent(
         claimId,
         0,
         playerPoweredBy,

--- a/ui/component/viewers/videoViewer/internal/videojs-events.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs-events.jsx
@@ -62,7 +62,7 @@ const VideoJsEvents = ({
     // how long until the video starts
     let timeToStartVideo = data.secondsToLoad;
 
-    analytics.playerVideoStartedEvent(embedded);
+    analytics.event.playerVideoStarted(embedded);
 
     // don't send this data on livestream
     if (!isLivestreamClaim) {

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -330,7 +330,7 @@ function VideoViewer(props: Props) {
   React.useEffect(() => {
     if (!ended) return;
 
-    analytics.videoIsPlaying(false);
+    analytics.video.videoIsPlaying(false);
 
     if (adUrl) {
       setAdUrl(null);
@@ -375,18 +375,18 @@ function VideoViewer(props: Props) {
     setShowAutoplayCountdown(false);
     setIsEndedEmbed(false);
     setDoNavigate(false);
-    analytics.videoIsPlaying(true, player);
+    analytics.video.videoIsPlaying(true, player);
   }
 
   function onPause(event, player) {
     setIsPlaying(false);
     handlePosition(player);
-    analytics.videoIsPlaying(false, player);
+    analytics.video.videoIsPlaying(false, player);
   }
 
   function onPlayerClosed(event, player) {
     handlePosition(player);
-    analytics.videoIsPlaying(false, player);
+    analytics.video.videoIsPlaying(false, player);
   }
 
   function handlePosition(player) {

--- a/ui/component/wunderbarSuggestions/index.js
+++ b/ui/component/wunderbarSuggestions/index.js
@@ -19,7 +19,7 @@ const perform = (dispatch, ownProps) => ({
   navigateToSearchPage: (query) => {
     let encodedQuery = encodeURIComponent(query);
     ownProps.history.push({ pathname: `/$/search`, search: `?q=${encodedQuery}` });
-    analytics.apiLogSearch();
+    analytics.apiLog.search();
   },
   doShowSnackBar: (message) => dispatch(doToast({ isError: true, message })),
   doCloseMobileSearch: () => dispatch(doHideModal()),

--- a/ui/effects/use-get-ads.js
+++ b/ui/effects/use-get-ads.js
@@ -21,7 +21,7 @@ export function useGetAds(approvedVideo: boolean, adsEnabled: boolean): [?string
       return;
     }
 
-    analytics.adsFetchedEvent();
+    analytics.event.adsFetched();
     const encodedHref = encodeURI(window.location.href);
     const url = `${PRE_ROLL_ADS_PROVIDER}${encodedHref}`;
     // Used for testing on local dev

--- a/ui/index.jsx
+++ b/ui/index.jsx
@@ -84,7 +84,7 @@ Lbry.setOverride(
 );
 // @endif
 
-analytics.initAppStartTime(Date.now());
+analytics.event.initAppStartTime(Date.now());
 
 // @if TARGET='app'
 const { autoUpdater } = remote.require('electron-updater');
@@ -148,7 +148,7 @@ ipcRenderer.on('open-uri-requested', (event, url, newSession) => {
 
   if (isURIValid(url)) {
     const formattedUrl = formatLbryUrlForWeb(url);
-    analytics.openUrlEvent(formattedUrl);
+    analytics.event.openUrl(formattedUrl);
     return app.store.dispatch(push(formattedUrl));
   }
 
@@ -259,7 +259,7 @@ function AppWrapper() {
         app.store.dispatch(doMinVersionSubscribe());
       }, 5000);
 
-      analytics.startupEvent(Date.now());
+      analytics.event.startup(Date.now());
 
       return () => {
         clearTimeout(timer);

--- a/ui/page/collection/internal/collectionPublish/view.jsx
+++ b/ui/page/collection/internal/collectionPublish/view.jsx
@@ -111,7 +111,7 @@ function CollectionForm(props: Props) {
       doCollectionPublishUpdate(finalParams).then((pendingClaim) => {
         if (pendingClaim) {
           const claimId = pendingClaim.claim_id;
-          analytics.apiLogPublish(pendingClaim);
+          analytics.apiLog.publish(pendingClaim);
           onDone(claimId);
         }
       });
@@ -120,7 +120,7 @@ function CollectionForm(props: Props) {
       doCollectionPublish(finalParams, collectionId).then((pendingClaim) => {
         if (pendingClaim) {
           const claimId = pendingClaim.claim_id;
-          analytics.apiLogPublish(pendingClaim);
+          analytics.apiLog.publish(pendingClaim);
           onDone(claimId);
         }
       });

--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -220,7 +220,7 @@ function DiscoverPage(props: Props) {
     if (tag) {
       doToggleTagFollowDesktop(tag);
       const nowFollowing = !isFollowing;
-      analytics.tagFollowEvent(tag, nowFollowing, 'tag-page');
+      analytics.event.tagFollow(tag, nowFollowing, 'tag-page');
     }
   }
 

--- a/ui/page/livestream/view.jsx
+++ b/ui/page/livestream/view.jsx
@@ -74,7 +74,7 @@ export default function LivestreamPage(props: Props) {
 
   React.useEffect(() => {
     // TODO: This should not be needed once we unify the livestream player (?)
-    analytics.playerLoadedEvent('livestream', false);
+    analytics.event.playerLoaded('livestream', false);
   }, []);
 
   const { signing_channel: channelClaim } = claim || {};

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -394,7 +394,7 @@ export function doDaemonReady() {
             status.wallet.connected_features.trending_algorithm;
 
           if (trendingAlgorithm) {
-            analytics.trendingAlgorithmEvent(trendingAlgorithm);
+            analytics.event.trendingAlgorithm(trendingAlgorithm);
           }
         },
         undefined
@@ -547,7 +547,7 @@ export function doAnaltyicsPurchaseEvent(fileInfo) {
     let purchasePrice = fileInfo.purchase_receipt && fileInfo.purchase_receipt.amount;
     if (purchasePrice) {
       const purchaseInt = Number(Number(purchasePrice).toFixed(0));
-      analytics.purchaseEvent(purchaseInt);
+      analytics.event.purchase(purchaseInt);
     }
   };
 }

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -506,7 +506,7 @@ export function doAnalyticsView(uri, timeToStart) {
       return Promise.resolve();
     }
 
-    return analytics.apiLogView(uri, outpoint, claimId, timeToStart);
+    return analytics.apiLog.view(uri, outpoint, claimId, timeToStart);
   };
 }
 

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -528,7 +528,7 @@ export function doAnalyticsBuffer(uri, bufferData) {
     const userId = user && user.id.toString();
     // if there's a logged in user, send buffer event data to watchman
     if (userId) {
-      analytics.videoBufferEvent(claim, {
+      analytics.video.videoBufferEvent(claim, {
         isLivestream,
         timeAtBuffer,
         bufferDuration,

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -230,7 +230,7 @@ export const doPublishDesktop = (filePath: string, preview?: boolean) => (dispat
     const state = getState();
     const myClaims = selectMyClaims(state);
     const pendingClaim = successResponse.outputs[0];
-    analytics.apiLogPublish(pendingClaim);
+    analytics.apiLog.publish(pendingClaim);
     const { permanent_url: url } = pendingClaim;
     const actions = [];
 
@@ -325,7 +325,7 @@ export const doPublishResume = (publishPayload: any) => (dispatch: Dispatch, get
     const pendingClaim = successResponse.outputs[0];
     const { permanent_url: url } = pendingClaim;
 
-    analytics.apiLogPublish(pendingClaim);
+    analytics.apiLog.publish(pendingClaim);
 
     // We have to fake a temp claim until the new pending one is returned by claim_list_mine
     // We can't rely on claim_list_mine because there might be some delay before the new claims are returned

--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -25,7 +25,7 @@ const UPDATE_IS_NIGHT_INTERVAL = 5 * 60 * 1000;
 export function doFetchDaemonSettings() {
   return (dispatch) => {
     Lbry.settings_get().then((settings) => {
-      analytics.toggleInternal(settings.share_usage_data);
+      analytics.setState(settings.share_usage_data);
       dispatch({
         type: ACTIONS.DAEMON_SETTINGS_RECEIVED,
         data: {
@@ -89,7 +89,7 @@ export function doClearDaemonSetting(key) {
       }
     });
     Lbry.settings_get().then((settings) => {
-      analytics.toggleInternal(settings.share_usage_data);
+      analytics.setState(settings.share_usage_data);
       dispatch({
         type: ACTIONS.DAEMON_SETTINGS_RECEIVED,
         data: {
@@ -127,7 +127,7 @@ export function doSetDaemonSetting(key, value, doNotDispatch = false) {
       }
     });
     Lbry.settings_get().then((settings) => {
-      analytics.toggleInternal(settings.share_usage_data);
+      analytics.setState(settings.share_usage_data);
       dispatch({
         type: ACTIONS.DAEMON_SETTINGS_RECEIVED,
         data: {

--- a/ui/redux/middleware/analytics.js
+++ b/ui/redux/middleware/analytics.js
@@ -1,5 +1,6 @@
 // @flow
-import analytics, { GA_DIMENSIONS } from 'analytics';
+import analytics from 'analytics';
+import { GA_DIMENSIONS } from 'analytics/events';
 import * as ACTIONS from 'constants/action_types';
 
 export function createAnalyticsMiddleware() {
@@ -23,7 +24,7 @@ function handleAnalyticsForAction(action: { type: string, data: any }) {
     case ACTIONS.SUPPORT_TRANSACTION_COMPLETED:
       {
         const { amount, type } = action.data;
-        analytics.reportEvent('spend_virtual_currency', {
+        analytics.event.report('spend_virtual_currency', {
           // https://developers.google.com/analytics/devguides/collection/ga4/reference/events#spend_virtual_currency
           value: amount,
           virtual_currency_name: 'lbc',
@@ -33,13 +34,13 @@ function handleAnalyticsForAction(action: { type: string, data: any }) {
       break;
 
     case ACTIONS.COMMENT_CREATE_COMPLETED:
-      analytics.reportEvent('comments', {
+      analytics.event.report('comments', {
         [GA_DIMENSIONS.ACTION]: 'create',
       });
       break;
 
     case ACTIONS.COMMENT_CREATE_FAILED:
-      analytics.reportEvent('comments', {
+      analytics.event.report('comments', {
         [GA_DIMENSIONS.ACTION]: 'create_fail',
       });
       break;
@@ -47,7 +48,7 @@ function handleAnalyticsForAction(action: { type: string, data: any }) {
     case ACTIONS.PUBLISH_SUCCESS:
       {
         const { type } = action.data;
-        analytics.reportEvent('publish', {
+        analytics.event.report('publish', {
           [GA_DIMENSIONS.ACTION]: 'publish_success',
           [GA_DIMENSIONS.TYPE]: type,
         });
@@ -55,17 +56,17 @@ function handleAnalyticsForAction(action: { type: string, data: any }) {
       break;
 
     case ACTIONS.PUBLISH_FAIL:
-      analytics.reportEvent('publish', {
+      analytics.event.report('publish', {
         [GA_DIMENSIONS.ACTION]: 'publish_fail',
       });
       break;
 
     case ACTIONS.AUTHENTICATION_STARTED:
-      analytics.eventStarted('diag_authentication', Date.now());
+      analytics.event.eventStarted('diag_authentication', Date.now());
       break;
 
     case ACTIONS.AUTHENTICATION_SUCCESS:
-      analytics.eventCompleted('diag_authentication', Date.now());
+      analytics.event.eventCompleted('diag_authentication', Date.now());
       break;
 
     default:

--- a/web/component/browserNotificationSettings/use-browser-notifications.js
+++ b/web/component/browserNotificationSettings/use-browser-notifications.js
@@ -6,7 +6,8 @@ import { BrowserNotificationErrorModal } from '$web/component/browserNotificatio
 // @todo: Once we are on Redux 7 we should have proper hooks we can use here for store access.
 import { store } from '$ui/store';
 import { selectUser } from 'redux/selectors/user';
-import analytics, { GA_DIMENSIONS } from 'analytics';
+import analytics from 'analytics';
+import { GA_DIMENSIONS } from 'analytics/events';
 
 export default () => {
   const [pushPermission, setPushPermission] = useState(window.Notification?.permission);
@@ -48,16 +49,16 @@ export default () => {
       }
     } catch {
       setEncounteredError(true);
-      analytics.reportEvent('browser_notification', { [GA_DIMENSIONS.ACTION]: 'subscribe_failed' });
+      analytics.event.report('browser_notification', { [GA_DIMENSIONS.ACTION]: 'subscribe_failed' });
     }
-    analytics.reportEvent('browser_notification', { [GA_DIMENSIONS.ACTION]: 'subscribed' });
+    analytics.event.report('browser_notification', { [GA_DIMENSIONS.ACTION]: 'subscribed' });
   };
 
   const unsubscribe = async () => {
     if (!user) return;
     if (await pushNotifications.unsubscribe(user.id)) {
       setSubscribed(false);
-      analytics.reportEvent('browser_notification', { [GA_DIMENSIONS.ACTION]: 'unsubscribed' });
+      analytics.event.report('browser_notification', { [GA_DIMENSIONS.ACTION]: 'unsubscribed' });
     }
   };
 


### PR DESCRIPTION
No functional change, just re-organizing
Test: `kp`

## Why
- Harder to maintain with events, watchman, api, sentry, etc. all lumped into 1 file -- can't tell which variable is for which component.
  - Swapping out or upgrading sub-components (e.g. sentry revamp) would also be easier if they are organized per file.

## Remarks
- `events` is probably the less critical one to test (but I still tested) since GA is going away ... might route those to sentry later if things go well with the revamp.
- Areas that require a second set of eyes are probably just watchman and api (for the views).
  - Just noticed that watchman faces the same ublock problem, but most likely a known problem.
- Wanted to avoid changing the interface to reduce chances of mistake (e.g. `analytics.reportEvent` to `analytics.event.report`), but ended up still doing so because (1) easier to see which component it goes into (2) easier to code instead of re-routing internally.
