### PR TITLE
doCollectionEdit: fix typo causing description to be incorrect

### DIFF
--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -481,7 +481,7 @@ export const doCollectionEdit = (
         ...(type ? { type } : {}),
         ...(params.name ? { name: params.name } : {}),
         ...(params.description ? { description: params.description } : {}),
-        ...(params.thumbnail ? { description: params.thumbnail } : {}),
+        ...(params.thumbnail ? { thumbnail: params.thumbnail } : {}),
       },
     },
   });


### PR DESCRIPTION
Closes #1972

Open local edit page for some playlist
Update thumbnail there
Opening playlist crashes page

---------------------

Bad typo caused the thumbnail url to become the description, which later couldn't be parsed.

