### PR TITLE
Partial undo of the firefox drag-and-drop fix

### DIFF
--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -400,7 +400,9 @@ export default function ClaimList(props: Props) {
                         Number(
                           playerTransform.substring(playerTransform.indexOf(', ') + 2, playerTransform.indexOf('px)'))
                         );
-                      playerTop -= playerElem.offsetHeight;
+                      if (playerElem && navigator.userAgent.toLowerCase().includes('firefox')) {
+                        playerTop -= playerElem.offsetHeight;
+                      }
 
                       const style = {
                         ...draggableProvided.draggableProps.style,


### PR DESCRIPTION
Closes #1980 -- crash when trying to re-order a playlist

Seems like the update was only needed for DND in modal.
