### PR TITLE
Replace ad-detection script with simple css trigger approach

### DIFF
--- a/web/component/adBlockTester/view.jsx
+++ b/web/component/adBlockTester/view.jsx
@@ -1,9 +1,10 @@
 // @flow
 import React from 'react';
 
-const GOOGLE_AD_URL = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js';
+const TRIGGER_CLASS = 'pub_300x250 pub_300x250m pub_728x90 text-ad textAd text_ad text_ads text-ads adamazon';
 
-let gExecutedOnce = false;
+// ****************************************************************************
+// ****************************************************************************
 
 type Props = {
   doSetAdBlockerFound: (boolean) => void,
@@ -11,24 +12,22 @@ type Props = {
 
 function AdBlockTester(props: Props) {
   const { doSetAdBlockerFound } = props;
+  const ref = React.useRef();
 
   React.useEffect(() => {
-    if (!gExecutedOnce) {
-      fetch(GOOGLE_AD_URL)
-        .then((response) => {
-          doSetAdBlockerFound(response.redirected === true);
-        })
-        .catch(() => {
-          doSetAdBlockerFound(true);
-        })
-        .finally(() => {
-          gExecutedOnce = true;
-        });
+    if (ref.current) {
+      const mountedStyle = getComputedStyle(ref.current);
+      doSetAdBlockerFound(mountedStyle.display === 'none');
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
-  }, []);
+  }, [doSetAdBlockerFound]);
 
-  return null;
+  return (
+    <div
+      ref={ref}
+      className={TRIGGER_CLASS}
+      style={{ height: '1px', width: '1px', position: 'absolute', left: '-1px', top: '-1px' }}
+    />
+  );
 }
 
 export default AdBlockTester;


### PR DESCRIPTION
## Issue
Part of #1983

## Approach
Place a bait div with class names that would trigger ad blockers.

## Flaws
- Does not work 100%, e.g. Privacy Badger blocks bad behavior/scripts and not ads per-se.
- The trigger list might need to be expanded to cover more blockers. This was only tested with uBlock-o.

## Counter arguments
- Now that ad-tiles have a good-looking placeholder, do we even need to detect ad-blockers?
- For the uneven-tile scenario, I'm still seeing that in production anyways even with blockers correctly detected.
  - Seeing the same with competitors as well -- small price to pay for using ad blockers.

Can't recall if there are other reasons we needed that for...