### PR TITLE
(patch) "doCollectionEdit: fix typo causing description to be incorrect"

### DIFF
--- a/ui/component/collectionGeneralTab/view.jsx
+++ b/ui/component/collectionGeneralTab/view.jsx
@@ -160,7 +160,7 @@ function CollectionGeneralTab(props: Props) {
               type="markdown"
               name="collection_description"
               label={__('Description')}
-              value={description || ''}
+              value={(typeof description === 'string' && description) || ''}
               onChange={(text) => updateParams({ description: text || '' })}
               textAreaMaxLength={FF_MAX_CHARS_IN_DESCRIPTION}
             />

--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -209,7 +209,13 @@ export default React.memo<MarkdownProps>(function MarkdownPreview(props: Markdow
     isComment,
     isMinimal,
   } = props;
-  let { content } = props;
+  const { content } = props;
+
+  if (typeof content === 'object') {
+    // Due to an unfortunate typo that corrupted the collection field, we need
+    // to do this so affected users don't keep crashing.
+    return '';
+  }
 
   const strippedContent = content
     ? content.replace(REPLACE_REGEX, (iframeHtml, iframeUrl) => {


### PR DESCRIPTION
Additional changes for 289dadbb

- Make the md component not crash so that users get a chance to fix the field.

The code can be eventually removed later.