### PR TITLE
Temporarily disable sentry

### DIFF
--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -29,14 +29,14 @@ type Analytics = {
 
 const analytics: Analytics = {
   init: () => {
-    sentryWrapper.init();
+    // sentryWrapper.init();
   },
   setState: (enable: boolean) => {
     gAnalyticsEnabled = enable;
     analytics.apiLog.setState(gAnalyticsEnabled);
     analytics.event.setState(gAnalyticsEnabled);
     analytics.video.setState(gAnalyticsEnabled);
-    sentryWrapper.setState(gAnalyticsEnabled);
+    sentryWrapper.setState(false);
   },
   apiLog: apiLog,
   event: events,


### PR DESCRIPTION
It's over-logging, capturing things from other packages like ads.  Almost 4x.

Gotten enough sample data to fine-tune the filtering, so disabling it for now.
