### PR TITLE
(patch) "doCollectionEdit: fix typo causing description to be incorrect"

### DIFF
--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -839,6 +839,10 @@ export function doCollectionPublish(
       params['channel_id'] = options.channel_id;
     }
 
+    if (params.description && typeof params.description !== 'string') {
+      delete params.description;
+    }
+
     return new Promise((resolve, reject) => {
       dispatch({
         type: ACTIONS.COLLECTION_PUBLISH_STARTED,
@@ -950,6 +954,10 @@ export function doCollectionPublishUpdate(
 
     if (options.channel_id) {
       updateParams['channel_id'] = options.channel_id;
+    }
+
+    if (updateParams.description && typeof updateParams.description !== 'string') {
+      delete updateParams.description;
     }
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Was pretty sure I tested the full trip of publishing it, but apparently not. Most likely I did another edit rather than publish.

This addresses the publish that failed because the `description` remained an object instead of string. Typing something on the editor would also purge the corrupted data.
