### PR TITLE
Add `BUILD_REV` + fix `jsBundleId`

### DIFF
--- a/web/bundle-id.js
+++ b/web/bundle-id.js
@@ -1,8 +1,0 @@
-const { v4: uuid } = require('uuid');
-const jsBundleId = uuid();
-
-function getJsBundleId() {
-  return jsBundleId;
-}
-
-module.exports = { getJsBundleId };

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -22,6 +22,11 @@ const isProduction = process.env.NODE_ENV === 'production';
 const hasSentryToken = process.env.SENTRY_AUTH_TOKEN !== undefined;
 const jsBundleId = getJsBundleId();
 
+const BUILD_TIME_UTC = Date.now();
+const BUILD_TIME_STR = new Date(BUILD_TIME_UTC).toISOString().replace(/[-:T]/g, '').slice(0, 12);
+const COMMIT_ID = process.env.COMMIT_ID || '';
+const BUILD_REV = `${BUILD_TIME_STR}${COMMIT_ID ? `.${COMMIT_ID.slice(0, 10)}` : ''}`;
+
 // copy static files to dist folder
 const copyWebpackCommands = [
   {
@@ -121,6 +126,7 @@ let plugins = [
   new DefinePlugin({
     IS_WEB: JSON.stringify(true),
     'process.env.SDK_API_URL': JSON.stringify(process.env.SDK_API_URL || LBRY_WEB_API),
+    'process.env.BUILD_REV': BUILD_REV,
   }),
   new ProvidePlugin({
     __: ['i18n.js', '__'],

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -8,7 +8,6 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const WriteFilePlugin = require('write-file-webpack-plugin');
 const { DefinePlugin, ProvidePlugin } = require('webpack');
 const SentryWebpackPlugin = require('@sentry/webpack-plugin');
-const { getJsBundleId } = require('./bundle-id.js');
 const { insertToHead, buildHead } = require('./src/html');
 const { insertVariableXml, getOpenSearchXml } = require('./src/xml');
 
@@ -20,7 +19,6 @@ const WEB_STATIC_ROOT = path.resolve(__dirname, 'static/');
 const WEB_PLATFORM_ROOT = __dirname;
 const isProduction = process.env.NODE_ENV === 'production';
 const hasSentryToken = process.env.SENTRY_AUTH_TOKEN !== undefined;
-const jsBundleId = getJsBundleId();
 
 const BUILD_TIME_UTC = Date.now();
 const BUILD_TIME_STR = new Date(BUILD_TIME_UTC).toISOString().replace(/[-:T]/g, '').slice(0, 12);
@@ -34,7 +32,7 @@ const copyWebpackCommands = [
     to: `${DIST_ROOT}/index.html`,
     // add javascript script to index.html, generate/insert metatags
     transform(content, path) {
-      return insertToHead(content.toString(), buildHead());
+      return insertToHead(content.toString(), buildHead(), BUILD_REV);
     },
     force: true,
   },
@@ -147,7 +145,7 @@ if (isProduction && hasSentryToken) {
 const webConfig = {
   target: 'web',
   entry: {
-    [`ui-${jsBundleId}`]: '../ui/index.jsx',
+    [`ui-${BUILD_REV}`]: '../ui/index.jsx',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
- 2 issues in 1. 
- Test: `kp`

## (1) Generate BUILD_REV strings

### Will be used by
1. Sentry -- it needs a version number to tie up source-maps.
2. New bundle ID for the `ui.js` file.
    - solves issue_2003
    - easier to determine which commit a particular ui.js is from.

### Format
  `"<YYYYMMDDHHMM>.<commit_id_12_chars>"`

- The time will be in UTC.
- Rationale for format:
  - Putting the date in front allows the string/file to be sortable.
  - Combining both date and commit id covers the case of rebuilding from the same commit, i.e. BUILD_REV would still end up unique.

### Other notes
- `COMMIT_ID` comes from the command line, which it currently does in production. If not provided (e.g. debug), the rev would just be the date string.

## (2) Fix unstable `jsBundleId` reference

Closes #2003

### Root
It's a combination of 2 problems:
(a) `getJsBundleId` houses a file-level variable that would end up in a new context when Node resets (or some action, not sure what), thus returning a different ID from what webpack used.
(b) `insertToHead` is being shared in 2 places -- webpack and `getHtml`.  `getHtml` uses the output of webpack, so we end up inserting the script tag twice, with the second one being the altered id from (a) above.

### Fix
- Now that we have a build rev string, use that as the bundle ID instead randomly generating it.
- The value now also comes directly from the same variable used in webpack, rather than stored at file-level, thus preventing the reset problem.
- `insertToHead` now takes in an optional rev string parameter, so we can control when it needs to inject the script tag or not.

### Related
https://odysee-workspace.slack.com/archives/C02G20Z2AEL/p1634682653336100
