### PR TITLE
Handle null/undefined names in collection sort

### DIFF
--- a/ui/page/playlists/internal/collectionsListMine/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/view.jsx
@@ -143,7 +143,7 @@ export default function CollectionsListMine(props: Props) {
 
       if (sortOption.key === COLS.SORT_KEYS.NAME) {
         // $FlowFixMe
-        return comparisonObj.a.localeCompare(comparisonObj.b);
+        return comparisonObj.a ? comparisonObj.a.localeCompare(comparisonObj.b) : 0;
       }
 
       if ((comparisonObj.a || 0) > (comparisonObj.b || 0)) {


### PR DESCRIPTION
Band-aid for #2007

Still not sure how a null name would propagate here during confirmation (should investigate further), but this would at least prevent the crash and simply retained the order.
