### PR TITLE
Playlist: handle `null` entry and large public collection fetch

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2361,6 +2361,7 @@
   "Queue": "Queue",
   "Your Playlists": "Your Playlists",
   "Default Playlists": "Default Playlists",
+  "Fetching playlists. This may take a while...": "Fetching playlists. This may take a while...",
   "Open": "Open",
   "Support this content": "Support this content",
   "Repost this content": "Repost this content",

--- a/ui/page/playlists/internal/collectionsListMine/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/view.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import CollectionPreview from './internal/collectionPreview';
 import Button from 'component/button';
+import Spinner from 'component/spinner';
 import * as MODALS from 'constants/modal_types';
 import * as COLS from 'constants/collections';
 import Yrbl from 'component/yrbl';
@@ -213,65 +214,73 @@ export default function CollectionsListMine(props: Props) {
 
         <SectionLabel label={__('Your Playlists')} />
 
-        <CollectionsListContext.Provider
-          value={{
-            searchText,
-            setSearchText,
-            totalLength,
-            filteredCollectionsLength,
-          }}
-        >
-          <CollectionListHeader
-            filterType={filterType}
-            isTruncated={totalLength > filteredCollectionsLength}
-            setFilterType={setFilterType}
-            // $FlowFixMe
-            sortOption={sortOption}
-            setSortOption={setSortOption}
-            persistedOption={persistedOption}
-            setPersistedOption={setPersistedOption}
-          />
-        </CollectionsListContext.Provider>
-
-        {/* Playlists: previews */}
-        {hasCollections && !collectionsUnresolved ? (
-          filteredCollectionsLength > 0 ? (
-            <ul className={classnames('ul--no-style claim-list', { playlists: !isMobile })}>
-              {!isMobile && <TableHeader />}
-
-              {paginatedCollections.map((key) => (
-                <CollectionPreview collectionId={key} key={key} />
-              ))}
-
-              {totalPages > 1 && (
-                <PageItemsLabel
-                  totalLength={filteredCollectionsLength}
-                  firstItemIndexForPage={firstItemIndexForPage}
-                  paginatedCollectionsLength={paginatedCollections.length}
-                />
-              )}
-
-              <Paginate totalPages={totalPages} />
-            </ul>
-          ) : (
-            <div className="empty main--empty">{__('No matching playlists')}</div>
-          )
-        ) : (
-          <div className="main--empty">
-            {!isFetchingCollections && !collectionsUnresolved ? (
-              <Yrbl
-                type="sad"
-                title={__('You have no Playlists yet. Better start hoarding!')}
-                actions={
-                  <div className="section__actions">
-                    <Button button="primary" label={__('Create a Playlist')} onClick={handleCreatePlaylist} />
-                  </div>
-                }
-              />
-            ) : (
-              <h2 className="main--empty empty">{__('Loading...')}</h2>
-            )}
+        {isFetchingCollections ? (
+          <div className="main--empty empty">
+            <Spinner text={__('Fetching playlists. This may take a while...')} delayed />
           </div>
+        ) : (
+          <>
+            <CollectionsListContext.Provider
+              value={{
+                searchText,
+                setSearchText,
+                totalLength,
+                filteredCollectionsLength,
+              }}
+            >
+              <CollectionListHeader
+                filterType={filterType}
+                isTruncated={totalLength > filteredCollectionsLength}
+                setFilterType={setFilterType}
+                // $FlowFixMe
+                sortOption={sortOption}
+                setSortOption={setSortOption}
+                persistedOption={persistedOption}
+                setPersistedOption={setPersistedOption}
+              />
+            </CollectionsListContext.Provider>
+
+            {/* Playlists: previews */}
+            {hasCollections && !collectionsUnresolved ? (
+              filteredCollectionsLength > 0 ? (
+                <ul className={classnames('ul--no-style claim-list', { playlists: !isMobile })}>
+                  {!isMobile && <TableHeader />}
+
+                  {paginatedCollections.map((key) => (
+                    <CollectionPreview collectionId={key} key={key} />
+                  ))}
+
+                  {totalPages > 1 && (
+                    <PageItemsLabel
+                      totalLength={filteredCollectionsLength}
+                      firstItemIndexForPage={firstItemIndexForPage}
+                      paginatedCollectionsLength={paginatedCollections.length}
+                    />
+                  )}
+
+                  <Paginate totalPages={totalPages} />
+                </ul>
+              ) : (
+                <div className="empty main--empty">{__('No matching playlists')}</div>
+              )
+            ) : (
+              <div className="main--empty">
+                {!isFetchingCollections && !collectionsUnresolved ? (
+                  <Yrbl
+                    type="sad"
+                    title={__('You have no Playlists yet. Better start hoarding!')}
+                    actions={
+                      <div className="section__actions">
+                        <Button button="primary" label={__('Create a Playlist')} onClick={handleCreatePlaylist} />
+                      </div>
+                    }
+                  />
+                ) : (
+                  <h2 className="main--empty empty">{__('Loading...')}</h2>
+                )}
+              </div>
+            )}
+          </>
         )}
       </div>
     </>

--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -142,11 +142,12 @@ export const doFetchItemsInCollections = (resolveItemsOptions: {
 
   // -- Resolve collections:
   if (collectionIdsToSearch.length) {
-    // TODO: this might fail if there are >50 collections due to the claim_search
-    // limitation. The `useAutoPagination` parameter might slow things down
-    // because it is not parallel, so maybe a `Promise.all` is needed here.
-    // But leaving as-is for now.
-    await dispatch(doClaimSearch({ claim_ids: collectionIdsToSearch, page: 1, page_size: 9999 }));
+    await dispatch(
+      doClaimSearch(
+        { claim_ids: collectionIdsToSearch, page: 1, page_size: 50, no_totals: true },
+        { useAutoPagination: true }
+      )
+    );
     state = getState();
   }
 

--- a/ui/util/url.js
+++ b/ui/util/url.js
@@ -192,9 +192,13 @@ export function parseClaimIdFromPermanentUrl(url, failureId = '0') {
   // where parsing failure is not fatal (e.g. if parsing for ist of IDs to
   // resolve, missing a few wouldn't matter since components can resolve
   // individually).
-  const parts = url.split('#');
-  const id = parts[parts.length - 1];
-  return id && id.length === CLAIM_ID_LENGTH ? id : failureId;
+  if (url) {
+    const parts = url.split('#');
+    const id = parts[parts.length - 1];
+    return id && id.length === CLAIM_ID_LENGTH ? id : failureId;
+  }
+
+  return failureId;
 }
 
 export const getPathForPage = (page) => `/$/${page}/`;


### PR DESCRIPTION
Several issues found while investigating the issue reported from the user with 609 public playlists.
See commit message for details.
Better diff:  https://github.com/OdyseeTeam/odysee-frontend/pull/2036/files?diff=split&w=1