### PR TITLE
Bump rev to rebuild with new sentry token

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -4,7 +4,7 @@
 
 # --- Minimum Version (Format: YYYYMMDDNNN) ---
 # Bump this when we want to nudge the user to refresh.
-MINIMUM_VERSION=20220824001
+MINIMUM_VERSION=20220825001
 
 # This is 'false' in the production instances:
 IGNORE_MINIMUM_VERSION=true


### PR DESCRIPTION
Seems like the token got invalidated (or deleted or restricted) after the reboot last night, as we got a permission error while uploading.

The new errors that came in for that build messed up the grouping -- something to figure out how to handle.

## Change
Switched to new token in production.
