### PR TITLE
Follow-Manage: don't hide blocked & muted channels

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -727,6 +727,7 @@
   "Autocomplete": "Autocomplete",
   "Followed Tags": "Followed Tags",
   "Followed Channels": "Followed Channels",
+  "No followed channels.": "No followed channels.",
   "Manage Tags": "Manage Tags",
   "%selectTagsLabel% (%number% left)": "%selectTagsLabel% (%number% left)",
   "Matching": "Matching",

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -564,7 +564,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
                       actions
                     ) : (
                       <div className="claim-preview__primary-actions">
-                        {isChannelUri && !banState.muted && !claimIsMine && (
+                        {isChannelUri && !claimIsMine && (!banState.muted || showUserBlocked) && (
                           <SubscribeButton
                             uri={repostedChannelUri || (uri.startsWith('lbry://') ? uri : `lbry://${uri}`)}
                           />

--- a/ui/page/channelsFollowingManage/view.jsx
+++ b/ui/page/channelsFollowingManage/view.jsx
@@ -74,7 +74,7 @@ export default function ChannelsFollowingManage(props: Props) {
           <Spinner delayed />
         </div>
       ) : uris && uris.length === 0 ? (
-        <Empty padded text="No followed channels." />
+        <Empty padded text={__('No followed channels.')} />
       ) : (
         <>
           <DebouncedInput icon={ICONS.SEARCH} placeholder={__('Filter')} onChange={setFilterQuery} inline />
@@ -122,6 +122,7 @@ export default function ChannelsFollowingManage(props: Props) {
                 pageSize={FOLLOW_PAGE_SIZE}
                 loading={isLoadingPage}
                 useLoadingSpinner
+                showHiddenByUser
               />
             </>
           )}


### PR DESCRIPTION
Closes #2045

An oversight when re-implementing that page -- a "manage" page should always show full/raw list to allow removals.
