### PR TITLE
Fix broken orderParam persistence

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -270,7 +270,7 @@ function ClaimListDiscover(props: Props) {
   const dynamicPageSize = isLargeScreen ? Math.ceil((originalPageSize / 2) * 6) : Math.ceil((originalPageSize / 2) * 4);
   const historyAction = history.action;
 
-  let orderParam = orderBy || urlParams.get(CS.ORDER_BY_KEY) || defaultOrderBy || orderParamEntry;
+  let orderParam = orderBy || urlParams.get(CS.ORDER_BY_KEY) || defaultOrderBy;
 
   if (!orderParam) {
     if (historyAction === 'POP') {
@@ -292,7 +292,7 @@ function ClaimListDiscover(props: Props) {
       setOrderParamEntry(orderParam);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [historyAction, setOrderParamEntry]);
+  }, []);
 
   let options: {
     page_size: number,


### PR DESCRIPTION
The following 2 commits introduced some errors:
- 0cc3af28: "flow fixes"
  - Seems like a misintepretation of lint warning, as the effect is meant to be a one-off.
- dfc013d4: "more recon"
  - Seems like a merge error, as `orderParamEntry` should only be used in a `POP` action.

The 2 broken scenarios are:

## Scenario 1
1. Enter /$/popculture. Assuming the current order is "Trending" as an example...
2. Click "New"
3. Click "Top"
4. Click Back -- order must be "New"
5. Click Back -- order must be "Trending"

## Scenario 2
1. Click "PopCulture" in the sidebar
2. Change the order, e.g. to "New"
3. Click "Playlists" in the sidebar
4. Click "PopCulture" in the sidebar -- order must be "New"
