### PR TITLE
(patch) show blocked mature channels on block list

### DIFF
--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -289,11 +289,9 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
     onAuxClick: handleNavLinkClick,
   };
 
-  // do not block abandoned and nsfw claims if showUserBlocked is passed
   let shouldHide =
     placeholder !== 'loading' &&
-    !showUserBlocked &&
-    ((abandoned && !showUnresolvedClaim) || (!claimIsMine && obscureNsfw && nsfw));
+    ((abandoned && !showUnresolvedClaim) || (!claimIsMine && obscureNsfw && nsfw && !showUserBlocked));
 
   // This will be replaced once blocking is done at the wallet server level
   if (!shouldHide && !claimIsMine && (banState.blacklisted || banState.filtered)) {


### PR DESCRIPTION
## Issue
Deleted channels aren't showing up properly in the Following-Manage page

## Change
Redo 080a36c5 a bit by not making `showUserBlock` cover both abandoned and nsfw -- there is `showUnresolvedClaim` for the former already.

Technically, even this solution is wrong because `obscureNfsw` is available for that, but unfortunately this needs to fan out to `ClaimList`, `ClaimListDiscover`, etc., which is a pain to test. There is a ticket for that major refactoring.

080a36c5 just wanted to display abandoned and nsfw in the Blocklist page, so this solution still achieves that since the block list page is already passing in `showUnresolvedClaim`
