### PR TITLE
Fix exit-fullscreen unhandled exception

### DIFF
--- a/ui/component/fileRender/view.jsx
+++ b/ui/component/fileRender/view.jsx
@@ -65,7 +65,9 @@ class FileRender extends React.PureComponent<Props> {
   }
 
   exitFullscreen() {
+    // @if TARGET='app'
     remote.getCurrentWindow().setFullScreen(false);
+    // @endif
   }
 
   renderViewer() {


### PR DESCRIPTION
## Issue
<img width="355" alt="image" src="https://user-images.githubusercontent.com/64950861/186802945-b3317c1e-9dc4-4b85-aeee-e5acaf3286bd.png">

## Change
Just skip the call for web, which the browser already handles.
An alternative fix is to provide a proper exit-fullscreen stub that does nothing.
