### PR TITLE
user/language: handle "could not authenticate user"

### DIFF
--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -412,9 +412,12 @@ export function doSetLanguage(language) {
           LocalStorage.setItem(SETTINGS.LANGUAGE, language);
           dispatch(doSetClientSetting(SETTINGS.LANGUAGE, languageSetting));
           if (isSharingData) {
-            Lbryio.call('user', 'language', {
-              language: language,
-            });
+            const USER_INIT_DELAY_MS = 1000;
+            setTimeout(() => {
+              Lbryio.call('user', 'language', { language: language }).catch((e) =>
+                analytics.log(e, { tags: { language } })
+              );
+            }, USER_INIT_DELAY_MS);
           }
         })
         .catch((e) => {


### PR DESCRIPTION
## Issue
`user/language` being called before `user` is populated.
One of the highest hits in Sentry.

## Change
Not the cleanest/robust of solutions, but this avoids polluting all clients with checks on `user !== undefined`.
