### PR TITLE
Fix logging of videojs media errors

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -477,9 +477,9 @@ function VideoViewer(props: Props) {
       playerEndedDuration.current = true;
     };
     const onError = () => {
-      const error = player.error();
-      if (error) {
-        analytics.log(error, {}, ERR_GRP.VIDEOJS);
+      const mediaError = player.error();
+      if (mediaError) {
+        analytics.log(`[${mediaError.code}] ${mediaError.message}`, {}, ERR_GRP.VIDEOJS);
       }
     };
     const onRateChange = () => {


### PR DESCRIPTION
## Issue
`error()` returns a `MediaError`-like object, not `Error`-like object. Sentry mishandles it.

## Change
Log the individual media errors in a way that Sentry accepts.

We could now get a count for loading issues like "The media could not be loaded, either because the server or network failed or because the format is not supported.", etc.  But I assume the backend would be logging a similar thing, so not sure if the front-end needs to do the same. 
