### PR TITLE
Sentry: consolidate videojs error with variable values

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -479,7 +479,13 @@ function VideoViewer(props: Props) {
     const onError = () => {
       const mediaError = player.error();
       if (mediaError) {
-        analytics.log(`[${mediaError.code}] ${mediaError.message}`, {}, ERR_GRP.VIDEOJS);
+        let fingerprint;
+        if (mediaError.message.match(/^(.*) video append of (.*) failed for segment (.*) in playlist (.*).m3u8$/)) {
+          fingerprint = ['videojs-media-segment-append'];
+        }
+
+        const options = { ...(fingerprint ? { fingerprint } : {}) };
+        analytics.log(`[${mediaError.code}] ${mediaError.message}`, options, ERR_GRP.VIDEOJS);
       }
     };
     const onRateChange = () => {


### PR DESCRIPTION
Server-side rule didn't work, so handling it from the SDK...