### PR TITLE
Video: ignore seek shortcut while video is still loading

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs-shortcuts.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs-shortcuts.jsx
@@ -46,6 +46,11 @@ function seekVideo(stepSize: number, playerRef, containerRef, jumpTo?: boolean) 
 
   const duration = videoNode.duration;
   const currentTime = videoNode.currentTime;
+
+  if (isNaN(duration) || isNaN(currentTime)) {
+    return;
+  }
+
   const newDuration = jumpTo ? duration * stepSize : currentTime + stepSize;
   if (newDuration < 0) {
     videoNode.currentTime = 0;


### PR DESCRIPTION
## Issue
"HTMLMediaElement.currentTime setter: Value being assigned is not a finite floating-point value."

S_23723
