### PR TITLE
Fix thumbnail fetch for reposted image (without `thumbnail.url`)

### DIFF
--- a/ui/component/claimPreview/index.js
+++ b/ui/component/claimPreview/index.js
@@ -29,6 +29,7 @@ const select = (state, props) => {
   const media = claim && claim.value && (claim.value.video || claim.value.audio);
   const mediaDuration = media && media.duration && formatMediaDuration(media.duration, { screenReader: true });
   const isLivestream = isStreamPlaceholderClaim(claim);
+  const repostSrcUri = claim && claim.repost_url && claim.canonical_url;
 
   return {
     claim,
@@ -46,7 +47,7 @@ const select = (state, props) => {
     geoRestriction: selectGeoRestrictionForUri(state, props.uri),
     hasVisitedUri: props.uri && makeSelectHasVisitedUri(props.uri)(state),
     isSubscribed: props.uri && selectIsSubscribedForUri(state, props.uri),
-    streamingUrl: props.uri && makeSelectStreamingUrlForUri(props.uri)(state),
+    streamingUrl: (repostSrcUri || props.uri) && makeSelectStreamingUrlForUri(repostSrcUri || props.uri)(state),
     isLivestream,
     isLivestreamActive: isLivestream && selectIsActiveLivestreamForUri(state, props.uri),
     livestreamViewerCount: isLivestream && claim ? selectViewersForId(state, claim.claim_id) : undefined,

--- a/ui/component/claimPreviewTile/index.js
+++ b/ui/component/claimPreviewTile/index.js
@@ -10,6 +10,7 @@ import {
 import { doFileGet } from 'redux/actions/file';
 import { doResolveUri } from 'redux/actions/claims';
 import { selectViewCountForUri, selectBanStateForUri } from 'lbryinc';
+import { makeSelectStreamingUrlForUri } from 'redux/selectors/file_info';
 import { selectIsActiveLivestreamForUri, selectViewersForId } from 'redux/selectors/livestream';
 import { selectShowMatureContent } from 'redux/selectors/settings';
 import { isClaimNsfw, isStreamPlaceholderClaim, getThumbnailFromClaim } from 'util/claim';
@@ -21,6 +22,7 @@ const select = (state, props) => {
   const media = claim && claim.value && (claim.value.video || claim.value.audio);
   const mediaDuration = media && media.duration && formatMediaDuration(media.duration, { screenReader: true });
   const isLivestream = isStreamPlaceholderClaim(claim);
+  const repostSrcUri = claim && claim.repost_url && claim.canonical_url;
 
   return {
     claim,
@@ -32,6 +34,7 @@ const select = (state, props) => {
     title: props.uri && selectTitleForUri(state, props.uri),
     banState: selectBanStateForUri(state, props.uri),
     geoRestriction: selectGeoRestrictionForUri(state, props.uri),
+    streamingUrl: (repostSrcUri || props.uri) && makeSelectStreamingUrlForUri(repostSrcUri || props.uri)(state),
     showMature: selectShowMatureContent(state),
     isMature: claim ? isClaimNsfw(claim) : false,
     isLivestream,

--- a/ui/effects/use-get-thumbnail.js
+++ b/ui/effects/use-get-thumbnail.js
@@ -17,6 +17,7 @@ export default function useGetThumbnail(
   const isFree = claim && claim.value && (!claim.value.fee || Number(claim.value.fee.amount) <= 0);
   const isCollection = claim && claim.value_type === 'collection';
   const thumbnailInClaim = claim && claim.value && claim.value.thumbnail && claim.value.thumbnail.url;
+  const repostSrcUri = claim && claim.repost_url && claim.canonical_url;
   let shouldFetchFileInfo = false;
 
   if (thumbnailInClaim) {
@@ -35,9 +36,9 @@ export default function useGetThumbnail(
 
   React.useEffect(() => {
     if (shouldFetchFileInfo) {
-      getFile(uri);
+      getFile(repostSrcUri || uri);
     }
-  }, [shouldFetchFileInfo, uri]);
+  }, [shouldFetchFileInfo, repostSrcUri, uri]);
 
   React.useEffect(() => {
     setThumbnail(thumbnailToUse);


### PR DESCRIPTION
## Issue
If an image file does not contain `thumbnail.url`, the fallback is to fetch the image itself as the thumbnail. But for the case of a reposted image file, the `get` API ends up throwing a "stream doesn't have source data" error because the repost uri was used.

Also, `claimPreviewTile` was missing the `streamingUrl` selector like it's `claimPreview` counterpart.

## Fix
1. Use the repost src uri when doing `get`.
2. `claimPreviewTile`: get `streamingUrl` prop.
3. Change the `streamingUrl` prop to look at the repost src instead.
