### PR TITLE
Fix adSticky failures on older browsers

### DIFF
--- a/web/component/adsSticky/view.jsx
+++ b/web/component/adsSticky/view.jsx
@@ -58,9 +58,9 @@ export default function AdsSticky(props: Props) {
 
       try {
         const head = document.head || document.getElementsByTagName('head')[0];
-        head.append(gScript); // Vendor's desired location, although I don't think location matters.
+        head.appendChild(gScript); // Vendor's desired location, although I don't think location matters.
       } catch (e) {
-        analytics.log(e, {}, 'adsSticky-missing-head');
+        analytics.log(e, { fingerprint: ['adsSticky::scriptAppendFailed'] }, 'adsSticky::scriptAppendFailed');
       }
     }
   }, [shouldLoadSticky]);


### PR DESCRIPTION
Copy/pasted from vendor -- but we don't need to use the newer `append` function ... `appendChild` works fine.
