### PR TITLE
Fix one/other plural format in livestream replays

### DIFF
--- a/ui/component/publish/livestream/publishLivestream/view.jsx
+++ b/ui/component/publish/livestream/publishLivestream/view.jsx
@@ -438,7 +438,7 @@ function PublishLivestream(props: Props) {
                                         {item.data.fileDuration && isNaN(item.data.fileDuration)
                                           ? item.data.fileDuration
                                           : `${Math.floor(item.data.fileDuration / 60)} ${
-                                              Math.floor(item.data.fileDuration / 60) > 1 ? __('minutes') : __('minute')
+                                              Math.floor(item.data.fileDuration / 60) === 1 ? __('minute') : __('minutes')
                                             }`}
                                         <div className="table__item-label">
                                           {`${moment(item.data.uploadedAt).from(moment())}`}


### PR DESCRIPTION
## Fixes

Issue Number: N/A

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Replays zero minutes long shown as "0 minute" (no plural)

## What is the new behavior?

Shown as "0 minutes".
One minute long replays are shown as "1 minute".
Longer are shown as "x minutes".

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change

</details>

**Note:** I haven't tested this change, but I think it's simple enough that nothing should break.
