### PR TITLE
Sentry: `whitelistUrls` doesn't work; `allowUrls` does

### DIFF
--- a/ui/analytics/sentryWrapper.js
+++ b/ui/analytics/sentryWrapper.js
@@ -46,7 +46,7 @@ export const sentryWrapper: SentryWrapper = {
         maxBreadcrumbs: 50,
         release: process.env.BUILD_REV,
         tracesSampleRate: 0.0,
-        whitelistUrls: [/https:\/\/((.*)\.)?odysee\.(com|tv)/, 'http://localhost:9090'],
+        allowUrls: [/https:\/\/((.*)\.)?odysee\.(com|tv)/],
       });
 
       gSentryInitialized = true;
@@ -85,15 +85,7 @@ export const sentryWrapper: SentryWrapper = {
 // Private
 // ****************************************************************************
 
-function handleBeforeSend(event) {
-  if (event.message === 'ResizeObserver loop limit exceeded') {
-    // This is coming from the ads, but unfortunately there's no data linking
-    // to ads for us to filter exactly. It's apparently an ignorable browser
-    // message, and usually there should be an accompanying exception (we'll
-    // capture that instead).
-    return null;
-  }
-
+function handleBeforeSend(event, hints) {
   try {
     const ev = event.exception?.values || [];
     const frames = ev[0]?.stacktrace?.frames || [];


### PR DESCRIPTION
Documentation uses `whitelistUrls`, but saw folks mentioning in threads that it is now `allowUrls`. Tried it, and sure enough it prevented ad errors from being sent. No wonder it hasn't work since lbry.tv.

Note that it will no longer send entries in development build, because that is served by `webpack://`. Not sure whether it's wise to add that at this point.
