### PR TITLE
Fix crash in `/$/top` with empty query

### DIFF
--- a/ui/page/top/index.js
+++ b/ui/page/top/index.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 import TopPage from './view';
 // import { doClearPublish, doPrepareEdit } from 'redux/actions/publish';
 import { doClearPublish } from 'redux/actions/publish';
-import { doResolveUris } from 'redux/actions/claims';
 import { doOpenModal } from 'redux/actions/app';
 import { push } from 'connected-react-router';
 import * as PAGES from 'constants/pages';
@@ -23,7 +22,6 @@ const perform = (dispatch) => ({
     // dispatch(doPrepareEdit({ name }));
     dispatch(push(`/$/${PAGES.UPLOAD}`));
   },
-  doResolveUris: (uris) => dispatch(doResolveUris(uris)),
   doOpenModal: (id, props) => dispatch(doOpenModal(id, props)),
 });
 

--- a/ui/page/top/view.jsx
+++ b/ui/page/top/view.jsx
@@ -20,7 +20,16 @@ function TopPage(props: Props) {
   const { name, beginPublish, doOpenModal } = props;
   const [channelActive, setChannelActive] = React.useState(false);
   // if the query was actually '@name', still offer repost for 'name'
-  const queryName = name[0] === '@' ? name.slice(1) : name;
+  const queryName = name && name[0] === '@' ? name.slice(1) : name;
+
+  if (!name) {
+    return (
+      <Page className="topPage-wrapper">
+        <div className="empty empty--centered">{__('No results')}</div>
+      </Page>
+    );
+  }
+
   return (
     <Page className="topPage-wrapper">
       <SearchTopClaim query={name} hideLink setChannelActive={setChannelActive} />


### PR DESCRIPTION
Seems like we are redirecting to empty top page from `/$/signin` and `channel/new`

#2083 will be required for the full fix, but handle the crash for now.

Removed unused prop while at it.
