### PR TITLE
`channel/stats`: not all error responses come with `status`

### DIFF
--- a/ui/component/creatorAnalytics/view.jsx
+++ b/ui/component/creatorAnalytics/view.jsx
@@ -46,7 +46,7 @@ export default function CreatorAnalytics(props: Props) {
           setStats(res);
         })
         .catch((error) => {
-          if (error.response.status === 401) {
+          if (error.response?.status === 401) {
             setError(UNAUTHENTICATED_ERROR);
             const channelToSend = JSON.parse(channelForEffect);
             analytics.apiLog.publish(channelToSend);


### PR DESCRIPTION
https://sentry.lbry.tech/organizations/odysee/issues/22608

Double-checked with the iapi repo
