### PR TITLE
Record internal api failure count

### DIFF
--- a/ui/analytics/sentryWrapper.js
+++ b/ui/analytics/sentryWrapper.js
@@ -94,10 +94,6 @@ function handleBeforeSend(event, hints) {
     if (lastFrame?.filename && lastFrame.filename.match(/([a-z]*)-extension:\/\//)) {
       return null;
     }
-
-    if (frames.every((f) => f.filename === '<anonymous>')) {
-      event.fingerprint = ['all-anonymous-frames'];
-    }
   } catch {}
 
   return event;


### PR DESCRIPTION
- This will end up capturing trivial network errors as well, so it is expected to be noisy. But the idea is to allow creation of a custom spike alert that's specific to iapi.
- It currently groups up all methods into a single entry. To isolate them, use the "Tags" or "Open in Discover" feature in the dashboard.
    - :question: Can spread it out to per-method if that's easier to detect issues from specific commands.  But my guess is it's usually all or nothing when downtime occurrs
- This does not change the existing code flow -- it only sends out analytics on failure and re-throws the error.
