### PR TITLE
Ignore `customer/status errors`

### DIFF
--- a/extras/lbryinc/lbryio.js
+++ b/extras/lbryinc/lbryio.js
@@ -262,6 +262,11 @@ function sendCallAnalytics(resource, action, params) {
 }
 
 function sendFailedCallAnalytics(resource, action, params, error) {
+  if ((resource === 'customer' && action === 'status') || (resource === 'user' && action === 'referral')) {
+    // Ignore commands that we use the error as a value, or don't care if it fails.
+    return;
+  }
+
   const options = {
     fingerprint: 'internal-api-failures',
     tags: { analytics: true, method: `${resource}/${action}` },


### PR DESCRIPTION
## Issue
- In addition to uncaught exceptions, a prior PR attempted to log all error responses from the internal api.
- But `customer/status` returns an error for users without a card, instead of returning it as a valid response (e.g. "no card").

## Change
Just ignore that command for now.

## Debate
Not sure if Sentry will hold as a metric collector ... might need to turn this off entirely.