### PR TITLE
SignOut: prevent infinite loop from 'beforeUnload' listener

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2466,5 +2466,7 @@
   "Hand signals": "Hand signals",
   "Smilies": "Smilies",
   "Symbols": "Symbols",
+  "There are pending actions.": "There are pending actions.",
+  "Do you want to proceed with signing out?": "Do you want to proceed with signing out?",
   "--end--": "--end--"
 }

--- a/ui/constants/modal_types.js
+++ b/ui/constants/modal_types.js
@@ -37,6 +37,7 @@ export const WALLET_PASSWORD_UNSAVE = 'wallet_password_unsave';
 export const CREATE_CHANNEL = 'create_channel';
 export const YOUTUBE_WELCOME = 'youtube_welcome';
 export const SET_REFERRER = 'set_referrer';
+export const SIGN_OUT = 'sign_out';
 export const LIQUIDATE_SUPPORTS = 'liquidate_supports';
 export const MASS_TIP_UNLOCK = 'mass_tip_unlock';
 export const CONFIRM_AGE = 'confirm_age';

--- a/ui/modal/modalRouter/view.jsx
+++ b/ui/modal/modalRouter/view.jsx
@@ -48,6 +48,7 @@ const MAP = Object.freeze({
   [MODALS.REWARD_GENERATED_CODE]: lazyImport(() => import('modal/modalRewardCode' /* webpackChunkName: "modalRewardCode" */)),
   [MODALS.SEND_TIP]: lazyImport(() => import('modal/modalSendTip' /* webpackChunkName: "modalSendTip" */)),
   [MODALS.SET_REFERRER]: lazyImport(() => import('modal/modalSetReferrer' /* webpackChunkName: "modalSetReferrer" */)),
+  [MODALS.SIGN_OUT]: lazyImport(() => import('modal/modalSignOut' /* webpackChunkName: "modalSignOut" */)),
   [MODALS.SOCIAL_SHARE]: lazyImport(() => import('modal/modalSocialShare' /* webpackChunkName: "modalSocialShare" */)),
   [MODALS.SYNC_ENABLE]: lazyImport(() => import('modal/modalSyncEnable' /* webpackChunkName: "modalSyncEnable" */)),
   [MODALS.TRANSACTION_FAILED]: lazyImport(() => import('modal/modalTransactionFailed' /* webpackChunkName: "modalTransactionFailed" */)),

--- a/ui/modal/modalSignOut/index.js
+++ b/ui/modal/modalSignOut/index.js
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+import { doHideModal } from 'redux/actions/app';
+import ModalSignOut from './view';
+
+const perform = {
+  doHideModal,
+};
+
+export default connect(null, perform)(ModalSignOut);

--- a/ui/modal/modalSignOut/view.jsx
+++ b/ui/modal/modalSignOut/view.jsx
@@ -1,0 +1,59 @@
+// @flow
+import React from 'react';
+import Button from 'component/button';
+import Card from 'component/common/card';
+import Spinner from 'component/spinner';
+import { Modal } from 'modal/modal';
+
+type Props = {
+  pendingActions: Array<string>,
+  onConfirm: () => void,
+  // --- perform ---
+  doHideModal: () => void,
+};
+
+export default function ModalSignOut(props: Props) {
+  const { pendingActions, onConfirm, doHideModal } = props;
+
+  const [isBusy, setIsBusy] = React.useState(false);
+
+  function handleOnClick() {
+    if (onConfirm) {
+      setIsBusy(true);
+      onConfirm();
+    }
+  }
+
+  return (
+    <Modal isOpen type="custom">
+      <Card
+        title={__('Sign Out')}
+        body={
+          <div>
+            <p className="section__subtitle">{__('There are pending actions.')}</p>
+            <div className="section section--padded-small border-std">
+              <ul>
+                {pendingActions.map((x) => (
+                  <li key={x}>{x}</li>
+                ))}
+              </ul>
+            </div>
+            <p className="section__subtitle">{__('Do you want to proceed with signing out?')}</p>
+          </div>
+        }
+        actions={
+          <div className="section__actions">
+            <Button
+              button="primary"
+              label={isBusy ? <Spinner type="small" /> : __('Sign Out')}
+              disabled={isBusy}
+              onClick={handleOnClick}
+            />
+
+            <Button button="link" label={__('Cancel')} disabled={isBusy} onClick={doHideModal} />
+          </div>
+        }
+      />
+    </Modal>
+  );
+}

--- a/ui/util/beforeUnload.js
+++ b/ui/util/beforeUnload.js
@@ -1,0 +1,23 @@
+window.beforeUnloadMap = window.beforeUnloadMap || {};
+
+export const Unload = {
+  register: (cb) => {
+    window.addEventListener('unload', cb);
+  },
+
+  unregister: (cb) => {
+    window.removeEventListener('unload', cb);
+  },
+};
+
+export const BeforeUnload = {
+  register: (cb, msg) => {
+    window.addEventListener('beforeunload', cb);
+    window.beforeUnloadMap[cb] = { cb, msg };
+  },
+
+  unregister: (cb) => {
+    window.removeEventListener('beforeunload', cb);
+    delete window.beforeUnloadMap[cb];
+  },
+};


### PR DESCRIPTION
## Ticket
Closes #419 

## Issue
We use `beforeUnload` to invoke the browser's alert message when there are pending actions like Uploading or unsaved Settings.

The sign out code have no idea this is going on, so when it tries to reload, the alert appears in a recursion.

## Approach
- Add a wrapper for the `beforeUnload` functionality, so we can keep track of it.
- Before signout out, open a modal and list out all the pending actions,
    - This also solves the problem of the browser alert not saying anything useful to the user (all browsers no longer relay the msg param and just show a generic one to avoid spam abuse).
- If OK is pressed, we unregister the listeners and proceed as normal.

## Caveats
It would be nice if we could show the same modal on an F5 case, but I don't know how to intercept that case. Maybe in the future.
