### PR TITLE
Claim*Discover - ability to exclude members-only content

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -7,6 +7,7 @@ import { withRouter } from 'react-router';
 import { MATURE_TAGS } from 'constants/tags';
 import { resolveLangForClaimSearch } from 'util/default-languages';
 import { createNormalizedClaimSearchKey } from 'util/claim';
+import { CsOptions } from 'util/claim-search';
 import { splitBySeparator } from 'util/lbryURI';
 import Button from 'component/button';
 import moment from 'moment';
@@ -36,6 +37,7 @@ type Props = {
   hasSource?: boolean,
   hideAdvancedFilter?: boolean,
   hideFilters?: boolean,
+  hideMembersOnlyContent?: boolean,
   includeSupportAction?: boolean,
   infiniteScroll?: Boolean,
   isChannel?: boolean,
@@ -156,6 +158,7 @@ function ClaimListDiscover(props: Props) {
     includeSupportAction,
     repostedClaimId,
     hideAdvancedFilter,
+    hideMembersOnlyContent,
     infiniteScroll = true,
     followedTags,
     injectedItem,
@@ -304,7 +307,7 @@ function ClaimListDiscover(props: Props) {
     // it's faster, but we will need to remove it if we start using total_pages
     no_totals: true,
     not_channel_ids: isChannel ? undefined : mutedAndBlockedChannelIds,
-    not_tags: !showNsfw ? MATURE_TAGS : [],
+    not_tags: CsOptions.not_tags(notTags, showNsfw, hideMembersOnlyContent),
     order_by: resolveOrderByOption(orderParam, sortByParam),
     remove_duplicates: isChannel ? undefined : true,
   };
@@ -345,10 +348,6 @@ function ClaimListDiscover(props: Props) {
         options.any_tags = tagsParam.split(',');
       }
     }
-  }
-
-  if (notTags) {
-    options.not_tags = options.not_tags.concat(notTags);
   }
 
   if (repostedClaimId) {

--- a/ui/component/claimTilesDiscover/index.js
+++ b/ui/component/claimTilesDiscover/index.js
@@ -10,12 +10,12 @@ import {
 import { doClaimSearch, doResolveClaimIds, doResolveUris } from 'redux/actions/claims';
 import { doFetchOdyseeMembershipForChannelIds } from 'redux/actions/memberships';
 import * as SETTINGS from 'constants/settings';
-import { MATURE_TAGS } from 'constants/tags';
 import { doFetchViewCount } from 'lbryinc';
 import { selectClientSetting, selectShowMatureContent } from 'redux/selectors/settings';
 import { selectMutedAndBlockedChannelIds } from 'redux/selectors/blocked';
 import { ENABLE_NO_SOURCE_CLAIMS, SIMPLE_SITE } from 'config';
 import { createNormalizedClaimSearchKey } from 'util/claim';
+import { CsOptions } from 'util/claim-search';
 
 import ClaimListDiscover from './view';
 
@@ -87,11 +87,13 @@ function resolveSearchOptions(props) {
     showNsfw,
     hideReposts,
     forceShowReposts,
+    hideMembersOnlyContent,
     mutedAndBlockedChannelIds,
     location,
     pageSize,
     claimType,
     tags,
+    notTags,
     languages,
     channelIds,
     orderBy,
@@ -124,7 +126,7 @@ function resolveSearchOptions(props) {
     // it's faster, but we will need to remove it if we start using total_pages
     no_totals: true,
     any_tags: tags || [],
-    not_tags: !showNsfw ? MATURE_TAGS : [],
+    not_tags: CsOptions.not_tags(notTags, showNsfw, hideMembersOnlyContent),
     any_languages: languages,
     channel_ids: channelIds || [],
     not_channel_ids: mutedAndBlockedChannelIds,

--- a/ui/component/claimTilesDiscover/view.jsx
+++ b/ui/component/claimTilesDiscover/view.jsx
@@ -37,6 +37,7 @@ type Props = {
   fetchViewCount?: boolean,
   // claim search options are below
   tags: Array<string>,
+  notTags?: Array<string>,
   claimIds?: Array<string>,
   channelIds?: Array<string>,
   pageSize: number,
@@ -51,6 +52,7 @@ type Props = {
   hasSource?: boolean,
   hasNoSource?: boolean,
   forceShowReposts?: boolean, // overrides SETTINGS.HIDE_REPOSTS
+  hideMembersOnlyContent?: boolean,
   loading: boolean,
   // --- select ---
   location: { search: string },

--- a/ui/constants/tags.js
+++ b/ui/constants/tags.js
@@ -34,7 +34,7 @@ export const SYSTEM_TAGS = [SCHEDULED_LIVESTREAM_TAG, LBRY_FIRST_TAG];
 
 export const INTERNAL_TAGS = [...CONTROL_TAGS, ...SYSTEM_TAGS];
 
-export const MATURE_TAGS = [
+export const MATURE_TAGS = Object.freeze([
   'porn',
   'porno',
   'nsfw',
@@ -55,7 +55,7 @@ export const MATURE_TAGS = [
   'ass',
   'fuck',
   'hentai',
-];
+]);
 
 const DEFAULT_ENGLISH_KNOWN_TAGS = [
   'free speech',

--- a/ui/page/discover/livestreamSection.jsx
+++ b/ui/page/discover/livestreamSection.jsx
@@ -30,6 +30,7 @@ type Props = {
   languageSetting?: string,
   searchInLanguage?: boolean,
   langParam?: string | null,
+  hideMembersOnlyContent?: boolean,
 };
 
 export default function LivestreamSection(props: Props) {
@@ -43,6 +44,7 @@ export default function LivestreamSection(props: Props) {
     languageSetting,
     searchInLanguage,
     langParam,
+    hideMembersOnlyContent,
   } = props;
 
   const [liveSectionStore, setLiveSectionStore] = usePersistedState('discover:lsSection', SECTION.COLLAPSED);
@@ -99,6 +101,7 @@ export default function LivestreamSection(props: Props) {
           useSkeletonScreen={false}
           showHeader={false}
           hideFilters
+          hideMembersOnlyContent={hideMembersOnlyContent}
           infiniteScroll={false}
           loading={false}
           showNoSourceClaims={ENABLE_NO_SOURCE_CLAIMS}
@@ -121,6 +124,7 @@ export default function LivestreamSection(props: Props) {
         infiniteScroll={false}
         loading={false}
         showNoSourceClaims={ENABLE_NO_SOURCE_CLAIMS}
+        hideMembersOnlyContent={hideMembersOnlyContent}
       />
 
       {liveTilesOverLimit && liveSection === SECTION.COLLAPSED && (

--- a/ui/page/discover/view.jsx
+++ b/ui/page/discover/view.jsx
@@ -70,6 +70,7 @@ function DiscoverPage(props: Props) {
   const tags = tagsQuery ? tagsQuery.split(',') : null;
   const repostedClaimIsResolved = repostedUri && repostedClaim;
   const hideRepostRibbon = isCategory && !isWildWest;
+  const hideMembersOnlyContent = isCategory && !isWildWest;
 
   // Eventually allow more than one tag on this page
   // Restricting to one to make follow/unfollow simpler
@@ -139,6 +140,7 @@ function DiscoverPage(props: Props) {
           languageSetting={languageSetting}
           searchInLanguage={searchInLanguage}
           langParam={langParam}
+          hideMembersOnlyContent={hideMembersOnlyContent}
         />
       );
     }
@@ -272,6 +274,7 @@ function DiscoverPage(props: Props) {
           meta={getMeta()}
           hasSource
           hideRepostsOverride={dynamicRouteProps ? false : undefined}
+          hideMembersOnlyContent={hideMembersOnlyContent}
           searchLanguages={dynamicRouteProps?.options?.searchLanguages}
         />
       </ClaimSearchFilterContext.Provider>

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -135,6 +135,7 @@ function HomePage(props: Props) {
       <ClaimTilesDiscover
         {...options}
         showNoSourceClaims={ENABLE_NO_SOURCE_CLAIMS}
+        hideMembersOnlyContent
         hasSource
         prefixUris={getLivestreamUris(activeLivestreams, options.channelIds).slice(
           0,

--- a/ui/util/claim-search.js
+++ b/ui/util/claim-search.js
@@ -1,0 +1,18 @@
+// @flow
+import { MATURE_TAGS, MEMBERS_ONLY_CONTENT_TAG } from 'constants/tags';
+
+/**
+ * Helper functions to derive the ClaimSearch option payload.
+ */
+export const CsOptions = {
+  not_tags: (notTags: ?Array<string>, showNsfw: ?boolean, hideMembersOnlyContent: ?boolean) => {
+    const not_tags = !showNsfw ? MATURE_TAGS.slice() : [];
+    if (notTags) {
+      not_tags.push(...notTags);
+    }
+    if (hideMembersOnlyContent) {
+      not_tags.push(MEMBERS_ONLY_CONTENT_TAG);
+    }
+    return not_tags;
+  },
+};


### PR DESCRIPTION
## Ticket
#2159
```
- hide member only content on categories, and homepage categories.
- Leave on following / wild west.
- Do this by appending the c: members only tag to not tags claim searches.
```

## Others
- Protect `MATURE_TAGS` array from unintended edits (e.g. pointed to directly by a variable, and then `push` or `splice` is called).
