### PR TITLE
Fix <li> margin symmetry

### DIFF
--- a/ui/modal/modalSignOut/style.scss
+++ b/ui/modal/modalSignOut/style.scss
@@ -1,0 +1,7 @@
+.modal-sign-out {
+  li {
+    position: relative;
+    list-style-position: outside;
+    margin: var(--spacing-xs) var(--spacing-m) var(--spacing-xs) var(--spacing-l);
+  }
+}

--- a/ui/modal/modalSignOut/view.jsx
+++ b/ui/modal/modalSignOut/view.jsx
@@ -1,5 +1,7 @@
 // @flow
 import React from 'react';
+
+import './style.scss';
 import Button from 'component/button';
 import Card from 'component/common/card';
 import Spinner from 'component/spinner';
@@ -25,7 +27,7 @@ export default function ModalSignOut(props: Props) {
   }
 
   return (
-    <Modal isOpen type="custom">
+    <Modal isOpen type="custom" className="modal-sign-out">
       <Card
         title={__('Sign Out')}
         body={


### PR DESCRIPTION
When a ul-li is used within a bordered box, the asymmetrical margin causes the list to be "shifted" downwards.

<img width="307" alt="image" src="https://user-images.githubusercontent.com/64950861/191237484-88637d90-45ff-42ff-bb5d-e34abaa5e113.png">  -----> <img width="305" alt="image" src="https://user-images.githubusercontent.com/64950861/191237384-d7c2954f-bac2-4324-96e8-b3f84109e472.png">

Taking a risk by making a global change rather than a wrapped one. This will cause the list to have a bottom margin instead of zero in Posts, for example, but I think the symmetry looks better anyways, unless there is a specific case that doesn't want that.
