### PR TITLE
ClaimListHeader: style fixes to prep for more "Hide xxx" actions

### DIFF
--- a/ui/component/claimListHeader/internal/additionalFilters/index.js
+++ b/ui/component/claimListHeader/internal/additionalFilters/index.js
@@ -1,0 +1,5 @@
+import AdditionalFilters from './view';
+
+// Placeholder: anticipating redux map in the future
+
+export default AdditionalFilters;

--- a/ui/component/claimListHeader/internal/additionalFilters/style.scss
+++ b/ui/component/claimListHeader/internal/additionalFilters/style.scss
@@ -1,0 +1,39 @@
+@import '~ui/scss/init/breakpoints';
+
+$OPTIONS_MIN_WIDTH: 250px;
+
+.additional-filters {
+  // Additional 'fieldset' nesting is only needed to due to our current css
+  // situation, and to avoid using !important. Can remove after we flatten things.
+  fieldset {
+    .checkbox {
+      height: var(--height-input);
+      justify-content: center;
+      padding: 0 var(--spacing-s);
+      background-color: var(--color-input-bg);
+      border-radius: var(--border-radius);
+
+      margin-top: 1px;
+
+      @media (min-width: $breakpoint-small) {
+        width: $OPTIONS_MIN_WIDTH;
+      }
+
+      label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+
+        padding-top: 2px; // todo: remove when checkbox-centering problem is solved.
+      }
+
+      label::before {
+        top: 0; // override the "-1" default, which was clipping the top edge.
+      }
+
+      label::after {
+        top: 7px; // compensation due to the override above.
+      }
+    }
+  }
+}

--- a/ui/component/claimListHeader/internal/additionalFilters/view.jsx
+++ b/ui/component/claimListHeader/internal/additionalFilters/view.jsx
@@ -1,0 +1,39 @@
+// @flow
+import React from 'react';
+
+import './style.scss';
+import { FormField } from 'component/common/form';
+import * as CS from 'constants/claim_search';
+
+type Props = {
+  filterCtx: any,
+  contentType: string,
+};
+
+function AdditionalFilters(props: Props) {
+  const { filterCtx, contentType } = props;
+
+  if (!filterCtx?.repost) {
+    return null;
+  }
+
+  return (
+    <div className="additional-filters">
+      <fieldset>
+        <label>{__('Additional Filters')}</label>
+        {filterCtx?.repost && (
+          <FormField
+            label={__('Hide reposts')}
+            name="hide_reposts"
+            type="checkbox"
+            checked={filterCtx.repost.hideReposts}
+            disabled={contentType === CS.CLAIM_REPOST}
+            onChange={() => filterCtx.repost.setHideReposts((prev) => !prev)}
+          />
+        )}
+      </fieldset>
+    </div>
+  );
+}
+
+export default AdditionalFilters;

--- a/ui/component/claimListHeader/style.scss
+++ b/ui/component/claimListHeader/style.scss
@@ -1,3 +1,17 @@
+@import '~ui/scss/init/breakpoints';
+
+$OPTIONS_MIN_WIDTH: 250px;
+
+.clh__wrapper {
+  // These changes should be done in the main file, but no time to test
+  // the collection's claim list header (which shares the same selector),
+  // hence the wrapper.
+
+  .claim-search__menus {
+    padding: 0;
+  }
+}
+
 .clh-tag-search {
   display: flex;
   margin-left: var(--spacing-s);
@@ -33,4 +47,26 @@
 
 .clh-tag-search__input--hidden {
   display: none;
+}
+
+.claim-search__menus.duration {
+  // Customizations to make "Duration" the same length as "Additional Filters"
+  // for the typical case. Localization could still extend the width.
+
+  .claim-search__input-container {
+    @media (min-width: $breakpoint-small) {
+      min-width: $OPTIONS_MIN_WIDTH;
+    }
+
+    padding-right: 0;
+  }
+
+  .claim-search__input-container:nth-child(2) {
+    // In Mobile, this padding would also automatically serve as an indent.
+    padding-left: var(--spacing-s);
+  }
+
+  .claim-search__dropdown {
+    padding-right: 0;
+  }
 }

--- a/ui/component/claimListHeader/view.jsx
+++ b/ui/component/claimListHeader/view.jsx
@@ -1,5 +1,6 @@
 // @flow
 import './style.scss';
+import AdditionalFilters from './internal/additionalFilters';
 import * as CS from 'constants/claim_search';
 import * as ICONS from 'constants/icons';
 import * as SETTINGS from 'constants/settings';
@@ -132,27 +133,6 @@ function ClaimListHeader(props: Props) {
     CS.ORDER_BY_TRENDING
   );
 
-  function getHideRepostsElem(filterCtx, contentType) {
-    if (filterCtx?.repost) {
-      return (
-        <div className={classnames(`card claim-search__menus`)}>
-          <FormField
-            label={__('Hide reposts')}
-            name="hide_reposts"
-            type="checkbox"
-            checked={filterCtx.repost.hideReposts}
-            disabled={contentType === CS.CLAIM_REPOST}
-            onChange={() => {
-              filterCtx.repost.setHideReposts((prev) => !prev);
-            }}
-          />
-        </div>
-      );
-    } else {
-      return null;
-    }
-  }
-
   React.useEffect(() => {
     if (hideAdvancedFilter) {
       setExpanded(false);
@@ -254,7 +234,7 @@ function ClaimListHeader(props: Props) {
 
   return (
     <>
-      <div className="claim-search__wrapper">
+      <div className="claim-search__wrapper clh__wrapper">
         <div className="claim-search__top">
           {!hideFilters && (
             <div className="claim-search__menu-group">
@@ -350,7 +330,7 @@ function ClaimListHeader(props: Props) {
         </div>
         {expanded && (
           <>
-            <div className={classnames(`card claim-search__menus`)}>
+            <div className={classnames('claim-search__menus')}>
               {/* FRESHNESS FIELD */}
               {orderParam === CS.ORDER_BY_TOP && (
                 <div className="claim-search__input-container">
@@ -535,7 +515,7 @@ function ClaimListHeader(props: Props) {
 
             {/* DURATIONS FIELD */}
             {showDuration && (
-              <div className={classnames(`card claim-search__menus`)}>
+              <div className={classnames('claim-search__menus duration')}>
                 <div className={'claim-search__input-container'}>
                   <FormField
                     className={classnames('claim-search__dropdown', {
@@ -588,7 +568,7 @@ function ClaimListHeader(props: Props) {
               </div>
             )}
 
-            {getHideRepostsElem(filterCtx, contentTypeParam)}
+            <AdditionalFilters filterCtx={filterCtx} contentType={contentTypeParam} />
           </>
         )}
       </div>


### PR DESCRIPTION
## Why
- To prep for more "Hide xxx" actions
- The "Hide Repost" checkbox was a eyesore as it doesn't look integrated with the rest.

## Changes
See individual commits for details

<img width="266" alt="image" src="https://user-images.githubusercontent.com/64950861/191462697-e85717c9-14b1-49fc-8f35-5360e7ef19fe.png">

## Meh
Localization will break the "even width" sizing with Duration -- will come back to that later when there is a good solution. At minimum, a hover tooltip was added if the string ends up truncated with ellipsis.
