### PR TITLE
Tag: Freshness fixes

### DIFF
--- a/ui/util/search.js
+++ b/ui/util/search.js
@@ -2,6 +2,7 @@
 
 import { isNameValid, isURIValid, normalizeURI, parseURI } from 'util/lbryURI';
 import { URL as SITE_URL, URL_LOCAL, URL_DEV, SIMPLE_SITE } from 'config';
+import * as CS from 'constants/claim_search';
 import { SEARCH_OPTIONS } from 'constants/search';
 import { getSearchQueryString } from 'util/query-params';
 
@@ -143,7 +144,10 @@ export function tagSearchCsOptionsHook(options: any) {
   if (options.any_tags && options.any_tags.length > 0) {
     // -- When doing a specific tag search, these restrictions should be lifted to make sense.
     delete options.limit_claims_per_channel;
-    delete options.release_time;
+
+    if (JSON.stringify(options.order_by) !== JSON.stringify(CS.ORDER_BY_TOP_VALUE)) {
+      delete options.release_time;
+    }
   }
   return options;
 }


### PR DESCRIPTION
## Issue
https://odysee-workspace.slack.com/archives/C02F638TB0T/p1663945340034239?thread_ts=1663779156.006539&cid=C02F638TB0T

## Notes
See commit messages. I went off-script in the second commit, but I think that behavior is better?

:warning: Homepage team needs to remove `9999` still for the non-Top case.