### PR TITLE
Skip "auto: ???p" label-override when algo returns nothing

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-http-streaming--override/playlist-selectors.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-http-streaming--override/playlist-selectors.js
@@ -203,9 +203,8 @@ export const lastBandwidthSelector = function() {
 
   const player = this.player_;
   const hlsQualitySelector = player.hlsQualitySelector;
-  const originalHeight = hlsQualitySelector.config.originalHeight;
 
-  if (hlsQualitySelector?.getCurrentQuality() === 'auto') {
+  if (selectedBandwidth && hlsQualitySelector?.getCurrentQuality() === 'auto') {
     const qualityLabel = selectedBandwidth.attributes.RESOLUTION.height + 'p';
     hlsQualitySelector._qualityButton.menuButton_.$('.vjs-icon-placeholder').innerHTML = `<span>${__('Auto --[Video quality. Short form]--')}<span>${qualityLabel}</span></span>`;
   }


### PR DESCRIPTION
null access violation

It's just doing label-override, so nothing crucial