### PR TITLE
FileDrop: temporarily disable for Firefox

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -22,6 +22,7 @@ import useConnectionStatus from 'effects/use-connection-status';
 import Spinner from 'component/spinner';
 import LANGUAGES from 'constants/languages';
 import { BeforeUnload, Unload } from 'util/beforeUnload';
+import { platform } from 'util/platform';
 import AdBlockTester from 'web/component/adBlockTester';
 import AdsSticky from 'web/component/adsSticky';
 import YoutubeWelcome from 'web/component/youtubeReferralWelcome';
@@ -162,7 +163,7 @@ function App(props: Props) {
   const hasMyChannels = myChannelClaimIds && myChannelClaimIds.length > 0;
   const hasNoChannels = myChannelClaimIds && myChannelClaimIds.length === 0;
   const shouldMigrateLanguage = LANGUAGE_MIGRATIONS[language];
-  const renderFiledrop = !isMobile && isAuthenticated;
+  const renderFiledrop = !isMobile && isAuthenticated && !platform.isFirefox();
   const connectionStatus = useConnectionStatus();
 
   const urlPath = pathname + hash;


### PR DESCRIPTION
## Issue
The file-drop area gets stuck in a loop on Firefox

## Notes
The `event.dataTransfer.files` mysteriously gets set to 0 in Chrome at some point during the drag operation. The Firefox behavior actually makes more sense, where `event.dataTransfer.files` is retained since we did not explicitly clear it.

The code seems to depend on the weird behavior, and several hacks to emulate that wasn't successful. The fix should probably be something small, I just couldn't get it right.

Just disable for Firefox since it isn't functional anyway.
