### PR TITLE
Channel not found: fix perpetual spinner

### DIFF
--- a/ui/page/show/view.jsx
+++ b/ui/page/show/view.jsx
@@ -248,7 +248,7 @@ export default function ShowPage(props: Props) {
           isResolvingUri ||
           isResolvingCollection || // added for collection
           (isCollection && !urlForCollectionZero) || // added for collection - make sure we accept urls = []
-          creatorSettings === undefined) && (
+          (creatorSettings === undefined && channelClaimId)) && (
           <div className="main--empty">
             <Spinner />
           </div>


### PR DESCRIPTION
## Ticket
Closes #2203

## Change
Patch for 0823653f "Fix: disabled comments setting."
Only show the spinner only if `creatorSettings` is unfetched and fetchable.
