### PR TITLE
(regression) Block encoded thumbnail URLs ('data:image')

### DIFF
--- a/ui/component/selectThumbnail/view.jsx
+++ b/ui/component/selectThumbnail/view.jsx
@@ -73,7 +73,10 @@ function SelectThumbnail(props: Props) {
     if (updateThumbnailParams) {
       updateThumbnailParams({ thumbnail_url: newThumbnail });
     } else {
-      updatePublishForm({ thumbnail: newThumbnail });
+      updatePublishForm({
+        thumbnail: newThumbnail,
+        thumbnailError: newThumbnail.startsWith('data:image'),
+      });
     }
   }
 
@@ -115,7 +118,7 @@ function SelectThumbnail(props: Props) {
         }
         onLoad={() =>
           publishForm
-            ? updatePublishForm({ thumbnailError: !isUrlInput })
+            ? updatePublishForm({ thumbnailError: !isUrlInput || (thumbnail && thumbnail.startsWith('data:image')) })
             : updateThumbnailParams({ thumbnail_error: !isUrlInput })
         }
       />


### PR DESCRIPTION
Ticket: Closes #2205

We still need to block `data:image` because:
- Our CDN still doesn't handle it, so claim previews all fail.
- Potentially maxes out the claim meta size limit.
- Google Videos doesn't accept it (although we could wrap with CDN if supported later).

Check was removed in 69def916

@saltrafael, take a quick peek?  I'm just concerned I'm not seeing the full picture and broke something else instead.
