### PR TITLE
Restricted Content: handle publish timeout case

### DIFF
--- a/ui/constants/errors.js
+++ b/ui/constants/errors.js
@@ -4,6 +4,7 @@ export const PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL = 'There was a network error,
 export const SDK_FETCH_TIMEOUT = 'Your action timed out, but may have been completed.';
 export const SDK_LEDGER_TRANSACTION_TIMEOUT = 'Timed out waiting for transaction.';
 export const FETCH_TIMEOUT = 'promise timeout';
+export const RESTRICTED_CONTENT_PUBLISHING_FAILED = 'There was a network error, but the publish may have been completed. Wait a few minutes, then check your Uploads or Wallet page to confirm.\n\nIf the publish was successful, please verify the member restrictions (e.g. through Incognito), as it might not be applied correctly. If so, please re-upload (Edit) the content.';
 
 export const ERR_GRP = {
   TUS: 'publish-v2',

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -250,6 +250,8 @@ export const doPublishDesktop = (filePath: string, preview?: boolean) => (dispat
   const state = getState();
   const editingUri = selectPublishFormValue(state, 'editingURI') || '';
   const remoteUrl = selectPublishFormValue(state, 'remoteFileUrl');
+  const restrictedToMemberships = selectPublishFormValue(state, 'restrictedToMemberships');
+
   const claim = makeSelectClaimForUri(editingUri)(state) || {};
   const hasSourceFile = claim.value && claim.value.source;
   const redirectToLivestream = noFileParam && !hasSourceFile && !remoteUrl;
@@ -322,6 +324,10 @@ export const doPublishDesktop = (filePath: string, preview?: boolean) => (dispat
 
     if (message.endsWith(ERRORS.SDK_FETCH_TIMEOUT)) {
       message = ERRORS.PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL;
+    }
+
+    if (restrictedToMemberships && message === ERRORS.PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL) {
+      message = ERRORS.RESTRICTED_CONTENT_PUBLISHING_FAILED;
     }
 
     actions.push(doError({ message, cause: error.cause }));


### PR DESCRIPTION
_:warning: This goes into memberships, not master._

This is what happens when I hardcode a 1s timeout on `v1`, and the Post actually got through.

You looking for something like this?

![image](https://user-images.githubusercontent.com/64950861/193024681-4e2282ea-f19d-4d0e-9d01-1d2e24d4d700.png)
