### PR TITLE
Publish: put back `notify` delay + more logs

### DIFF
--- a/web/setup/publish-v3.js
+++ b/web/setup/publish-v3.js
@@ -32,6 +32,12 @@ function inStatusCategory(status, category) {
 }
 
 function isTusStillInProcess(xhr) {
+  try {
+    if (xhr?.response?.error?.message) {
+      analytics.log(xhr.response.error.message, { extra: { xhr } }, 'notify-error-msg');
+    }
+  } catch {}
+
   return xhr?.response?.error?.message === 'upload is still in process'; // String needs to match backend (not good).
 }
 
@@ -220,7 +226,8 @@ export function makeResumableUploadRequest(
           xhr.send(jsonPayload);
         }
 
-        makeNotifyRequest();
+        // Server needs time to process the upload before we can send `notify`.
+        setTimeout(() => makeNotifyRequest(), 15000);
       },
     });
 


### PR DESCRIPTION
Can't say for sure, but it seems like the comparison with `upload is still in process` error message no longer works to reliably determine the wait time.

Restore the old hardcoded 15s for now.  Hardcoded stuff will not work 100%, but let's see if this lowers the "does not exists" error even further.
