### PR TITLE
No need to clear Publish Form on success for now

### DIFF
--- a/ui/modal/modalPublish/index.js
+++ b/ui/modal/modalPublish/index.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
 import ModalPublishSuccess from './view';
 import { makeSelectClaimForUri } from 'redux/selectors/claims';
-import { doClearPublish } from 'redux/actions/publish';
 import { push } from 'connected-react-router';
 
 const select = (state, props) => ({
@@ -11,7 +10,6 @@ const select = (state, props) => ({
 
 const perform = (dispatch) => ({
   closeModal: () => dispatch(doHideModal()),
-  clearPublish: () => dispatch(doClearPublish()),
   navigate: (path) => dispatch(push(path)),
 });
 

--- a/ui/modal/modalPublish/view.jsx
+++ b/ui/modal/modalPublish/view.jsx
@@ -9,7 +9,6 @@ import Nag from 'component/nag';
 
 type Props = {
   closeModal: () => void,
-  clearPublish: () => void,
   navigate: (string) => void,
   uri: string,
   isEdit: boolean,
@@ -19,12 +18,8 @@ type Props = {
 };
 
 class ModalPublishSuccess extends React.PureComponent<Props> {
-  componentDidMount() {
-    const { clearPublish } = this.props;
-    clearPublish();
-  }
   render() {
-    const { closeModal, clearPublish, navigate, uri, isEdit, filePath, lbryFirstError, claim } = this.props;
+    const { closeModal, navigate, uri, isEdit, filePath, lbryFirstError, claim } = this.props;
     //   $FlowFixMe
     const livestream = claim && claim.value && claim.value_type === 'stream' && !claim.value.source;
     let contentLabel;
@@ -80,7 +75,6 @@ class ModalPublishSuccess extends React.PureComponent<Props> {
                   button="primary"
                   label={__('View My Uploads')}
                   onClick={() => {
-                    clearPublish();
                     navigate(`/$/${PAGES.UPLOADS}`);
                     closeModal();
                   }}
@@ -91,7 +85,6 @@ class ModalPublishSuccess extends React.PureComponent<Props> {
                   button="primary"
                   label={__('View Livestream Settings')}
                   onClick={() => {
-                    clearPublish();
                     navigate(`/$/${PAGES.LIVESTREAM}?t=Setup`);
                     closeModal();
                   }}


### PR DESCRIPTION
## Issue
#401 - publish-success modal clears Post while you are still editing.

## Notes
The original version tried to keep the form's data until Success so that we can re-upload the Post in the event of a failure.

But recent changes have introduced a `beginPublish` hook which clears the form every time you enter it. This makes the "clear on success" action no longer necessary, and fixes the annoying issue mentioned in 401.

## New Issue
The problem now becomes "data loss on page re-entry" for Post that you haven't submitted yet.

Pushing this first since it's no worse thatn status quo, and that the new issue requires a bigger change.
