### PR TITLE
Fix incoming "Tip Location" link

### DIFF
--- a/flow-typed/stripe.js
+++ b/flow-typed/stripe.js
@@ -64,6 +64,7 @@ declare type StripeTransaction = {
   channel_name: string,
   channel_claim_id: string,
   source_claim_id: string,
+  target_claim_id?: string,
   tipped_amount: number,
   transaction_fee: number,
   application_fee: number,

--- a/ui/component/walletFiatAccountHistory/view.jsx
+++ b/ui/component/walletFiatAccountHistory/view.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import Button from 'component/button';
 import moment from 'moment';
+import PAGES from 'constants/pages';
 import * as STRIPE from 'constants/stripe';
 
 type Props = {
@@ -38,6 +39,7 @@ const WalletFiatAccountHistory = (props: Props) => {
           {accountTransactions &&
             accountTransactions.map((transaction) => {
               const { symbol: currencySymbol } = STRIPE.CURRENCY[transaction.currency.toUpperCase()] || {};
+              const targetClaimId = transaction.target_claim_id;
 
               return (
                 <tr key={transaction.name + transaction.created_at}>
@@ -52,14 +54,14 @@ const WalletFiatAccountHistory = (props: Props) => {
                   </td>
                   <td>
                     <Button
-                      className=""
-                      navigate={'/' + transaction.channel_name + ':' + transaction.source_claim_id}
+                      navigate={targetClaimId ? `/$/${PAGES.SEARCH}?q=${targetClaimId}` : undefined}
                       label={
                         transaction.channel_claim_id === transaction.source_claim_id
                           ? __('Channel Page')
                           : __('Content Page')
                       }
                       button="link"
+                      target="_blank"
                     />
                   </td>
                   <td>


### PR DESCRIPTION
Closes #2229 

Downside to using `/$/search` is that it generates a bunch of redirects in the history, so back navigation becomes confusing (looks stuck).  Maybe the number of redirects itself is another bug.

<img width="111" alt="image" src="https://user-images.githubusercontent.com/64950861/194537052-c0e9969b-e63f-497e-9fa6-4d6fd79f890d.png">

Reduce the impact by spewing it into a new tab. The history actually becomes even longer there (don't know why), but at least the overall behavior is better that way (user just closes tab to "go back").
