### PR TITLE
fix: remove tooltip wrapper due children not accessible

### DIFF
--- a/ui/component/button/view.jsx
+++ b/ui/component/button/view.jsx
@@ -174,6 +174,8 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
         onClick={onClick}
         aria-label={ariaLabel}
         disabled={disabled} // is there a reason this wasn't here before?
+        ref={combinedRef}
+        {...otherProps}
       >
         {content}
       </a>
@@ -228,6 +230,8 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
         className={combinedClassName}
         activeClassName={activeClass}
         aria-label={ariaLabel}
+        ref={combinedRef}
+        {...otherProps}
       >
         {content}
       </NavLink>
@@ -249,6 +253,7 @@ const Button = forwardRef<any, {}>((props: Props, ref: any) => {
       className={combinedClassName}
       activeClassName={activeClass}
       aria-label={ariaLabel}
+      ref={combinedRef}
       {...otherProps}
     >
       {content}

--- a/ui/component/common/file-action-button.jsx
+++ b/ui/component/common/file-action-button.jsx
@@ -16,29 +16,6 @@ type Props = {
 
 function FileActionButton(props: Props) {
   const { title, iconSize, noStyle, className, ...buttonProps } = props;
-  const { navigate, requiresAuth, requiresChannel } = buttonProps;
-
-  if (navigate || requiresAuth || requiresChannel) {
-    return (
-      <Tooltip title={title} arrow={false} enterDelay={100}>
-        <div className="button--file-action--tooltip-wrapper">
-          <Button
-            button={noStyle ? 'alt' : undefined}
-            className={
-              noStyle
-                ? className || undefined
-                : classnames('button--file-action', {
-                    'button--file-action--tooltip': !className,
-                    [className || '']: Boolean(className),
-                  })
-            }
-            iconSize={iconSize || 16}
-            {...buttonProps}
-          />
-        </div>
-      </Tooltip>
-    );
-  }
 
   return (
     <Tooltip title={title} arrow={false} enterDelay={100}>

--- a/ui/scss/component/_channel.scss
+++ b/ui/scss/component/_channel.scss
@@ -513,8 +513,7 @@ $actions-z-index: 2;
   }
 
   > .button,
-  > .button-group,
-  > .button--file-action--tooltip-wrapper {
+  > .button-group {
     &:not(:last-child) {
       margin-right: var(--spacing-s);
     }

--- a/ui/scss/component/_media.scss
+++ b/ui/scss/component/_media.scss
@@ -241,20 +241,6 @@
     }
   }
 
-  .button--file-action--tooltip-wrapper {
-    display: inline;
-    margin: 0;
-
-    .button--file-action--tooltip {
-      padding: 0px var(--spacing-xxs);
-    }
-    @media (max-width: $breakpoint-small) {
-      button.button:not(.button-like):not(.button-dislike) {
-        width: 100%;
-      }
-    }
-  }
-
   .icon--DollarSign {
     stroke-width: 1.5;
     transform: scale(0.8);
@@ -273,10 +259,6 @@
     }
 
     .button--file-action {
-      &:not(.button--file-action--tooltip) {
-        padding: 0 !important;
-      }
-
       .button__content {
         justify-content: space-between;
 
@@ -331,11 +313,7 @@
       flex-basis: 0;
       min-width: 0;
     }
-    .button--file-action--tooltip-wrapper {
-      flex-basis: 0 !important;
-      min-width: 0;
-      flex: unset;
-    }
+
     .button--file-action--menu {
       flex-grow: 0.4;
       flex-basis: 0;
@@ -357,26 +335,6 @@
         margin-left: var(--spacing-xxs);
         .button {
           margin-right: 0;
-        }
-      }
-    }
-
-    .button--file-action--tooltip-wrapper {
-      display: flex;
-      flex: auto;
-      padding: 0 !important;
-
-      .button--file-action--tooltip {
-        width: 100%;
-      }
-    }
-    .ratio-wrapper {
-      .button--file-action--tooltip-wrapper {
-        display: inline;
-        margin: 0;
-
-        .button--file-action--tooltip {
-          padding: 0px var(--spacing-xxs);
         }
       }
     }


### PR DESCRIPTION
- all was needed was passing other props and ref to returned button components

## Fixes

Issue Number: n/a

fixes weirdness and inconsistencies around file action buttons

- by removing the wrapper element for `link` cases, all file action buttons are handled and behave the same on the CSS