### PR TITLE
(patch) No need to clear Publish Form on success for now

### DIFF
--- a/ui/modal/modalPublish/index.js
+++ b/ui/modal/modalPublish/index.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
 import ModalPublishSuccess from './view';
 import { makeSelectClaimForUri } from 'redux/selectors/claims';
+import { doClearPublish } from 'redux/actions/publish';
 import { push } from 'connected-react-router';
 
 const select = (state, props) => ({
@@ -10,6 +11,7 @@ const select = (state, props) => ({
 
 const perform = (dispatch) => ({
   closeModal: () => dispatch(doHideModal()),
+  clearPublish: () => dispatch(doClearPublish()),
   navigate: (path) => dispatch(push(path)),
 });
 

--- a/ui/modal/modalPublish/view.jsx
+++ b/ui/modal/modalPublish/view.jsx
@@ -9,6 +9,7 @@ import Nag from 'component/nag';
 
 type Props = {
   closeModal: () => void,
+  clearPublish: () => void,
   navigate: (string) => void,
   uri: string,
   isEdit: boolean,
@@ -18,6 +19,11 @@ type Props = {
 };
 
 class ModalPublishSuccess extends React.PureComponent<Props> {
+  componentDidMount() {
+    const { clearPublish } = this.props;
+    clearPublish();
+  }
+
   render() {
     const { closeModal, navigate, uri, isEdit, filePath, lbryFirstError, claim } = this.props;
     //   $FlowFixMe


### PR DESCRIPTION
5d2c9676

Removed too many things. We still need to clear the publish form on 'submission', just not on 'success'.
