### PR TITLE
Purchase fetch and validation fixes

### DIFF
--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -953,9 +953,8 @@ export const selectMyPurchasedClaims = createSelector(selectState, (state) => st
 
 export const selectPurchaseMadeForClaimId = (state: State, claimId: string) => {
   const purchasedClaims = selectMyPurchasedClaims(state);
-
   return purchasedClaims.some(
-    (p) => (p.reference_claim_id === claimId || p.target_claim_id === claimId) && p.type !== 'rental'
+    (p) => (p.reference_claim_id === claimId || p.target_claim_id === claimId) && p.type === 'purchase'
   );
 };
 


### PR DESCRIPTION
## Issue
- The stripe response for type could be `tip | rental | purchase | ???`, so someone who sent a tip could be gaining a purchase.
    - Backend doesn't check?
- Fix `myPurchasedClaims` growing indefinitely with duplicate data for each `customer/list` with the same payload.
    - Cannot de-dupe an array of Objects using the set method since each Object reference is always different regardless of content.
    - I assume that the transaction data could change, but the `id` does not change, so using `id` for the comparison.
