### PR TITLE
Stripe outgoing txo: remove the reverse sort

### DIFF
--- a/ui/redux/actions/stripe.js
+++ b/ui/redux/actions/stripe.js
@@ -55,9 +55,6 @@ export const doTipAccountStatus = () => async (dispatch: Dispatch) =>
 export const doCustomerListPaymentHistory = () => async (dispatch: Dispatch) =>
   await Lbryio.call('customer', 'list', { environment: stripeEnvironment }, 'post')
     .then((customerTransactionResponse: StripeTransactions) => {
-      // reverse so order is from most recent to latest
-      if (Number.isInteger(customerTransactionResponse?.length)) customerTransactionResponse.reverse();
-
       // TODO: remove this once pagination is implemented
       if (customerTransactionResponse?.length && customerTransactionResponse.length > 100) {
         customerTransactionResponse.length = 100;


### PR DESCRIPTION
## Issue
Outgoing was showing "oldest first".

## Change
Remove the `reverse()`.  
- Did the backend flip the order at one point?
