### PR TITLE
Fetch fiat receipt on `doClaimSearch`

### DIFF
--- a/flow-typed/claimSearch.js
+++ b/flow-typed/claimSearch.js
@@ -2,4 +2,5 @@
 
 declare type DoClaimSearchSettings = {
   useAutoPagination?: boolean,
+  fetchStripeTransactions?: boolean,
 };

--- a/flow-typed/stripe.js
+++ b/flow-typed/stripe.js
@@ -63,6 +63,14 @@ declare type StripeCustomerPurchaseCostResponse = {
   odysee_cut: number,
 };
 
+declare type StripeCustomerListParams = {
+  environment?: ?string,
+  type_filter?: string,
+  target_claim_id_filter?: string,
+  reference_claim_id_filter?: string,
+  claim_id_filter?: string, // csv
+};
+
 declare type StripeTransaction = {
   name: string,
   currency: string,

--- a/ui/redux/actions/stripe.js
+++ b/ui/redux/actions/stripe.js
@@ -75,6 +75,29 @@ export const doCheckIfPurchasedClaimId = (claimId: string) => async (dispatch: D
     .catch((e) => dispatch({ type: ACTIONS.CHECK_IF_PURCHASED_FAILED, data: { error: e.message } }));
 };
 
+export const doCheckIfPurchasedClaimIds = (claimIds: ClaimIds) => {
+  // TODO:
+  // - This is a separate function for now to reduce churn. There should just be
+  // a single doCustomerList(...) that can do different actions based on function
+  // parameters, so we'll update everything then.
+  // - 'myPurchasedClaims' is an unnecessary duplicate of 'customerTransactionResponse'.
+  // Just share the storage and do a fetch-all when viewing transaction history.
+  // - Move the reducer to the stripe slice.
+
+  return (dispatch: Dispatch) => {
+    const params: StripeCustomerListParams = {
+      environment: stripeEnvironment,
+      claim_id_filter: claimIds.join(','),
+    };
+
+    dispatch({ type: ACTIONS.CHECK_IF_PURCHASED_STARTED });
+
+    return Lbryio.call('customer', 'list', params, 'post')
+      .then((response) => dispatch({ type: ACTIONS.CHECK_IF_PURCHASED_COMPLETED, data: response }))
+      .catch((e) => dispatch({ type: ACTIONS.CHECK_IF_PURCHASED_FAILED, data: e.message }));
+  };
+};
+
 export const doCustomerPurchaseCost = (cost: number) => (
   dispatch: Dispatch
 ): Promise<StripeCustomerPurchaseCostResponse> => {

--- a/ui/util/tags.js
+++ b/ui/util/tags.js
@@ -24,3 +24,17 @@ export function removeInternalTags(tags: Array<Tag>): Array<Tag> {
     );
   });
 }
+
+export function hasFiatTags(claim: Claim) {
+  const tags = claim.value?.tags;
+  if (tags) {
+    return tags.some(
+      (t) =>
+        t.includes(PURCHASE_TAG) ||
+        t.startsWith(PURCHASE_TAG_OLD) ||
+        t.includes(RENTAL_TAG) ||
+        t.startsWith(RENTAL_TAG_OLD)
+    );
+  }
+  return false;
+}


### PR DESCRIPTION
:warning: This goes into the rentals PR.

Not sure if we should include this now. The conservative side in me doesn't want to invalidate QA too much, while the yolo side says just do it.

It's also not perfect, but a easier to remove later if odysee-api is able to give us the details in one shot in the future?
- Currently, it will "always fetch receipt on `claim_search`" by default. Can be flipped -- default to false, then find each `doClaimSearch` calls that we want to include the receipt.