### PR TITLE
Snapshot button

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
@@ -53,12 +53,8 @@ function onPlayerReady(player: Player, options: Options) {
   videojs.registerComponent('snapshotButton', snapshotButton);
 
   player.one('canplay', function () {
-    player.getChild('controlBar').addChild('snapshotButton', {});
-  });
-
-  // TODO: this is particular to Odysee, since we don't necessarily dispose, better to use something universal
-  player.on('playerClosed', function () {
     player.getChild('controlBar').removeChild('snapshotButton');
+    player.getChild('controlBar').addChild('snapshotButton', {});
   });
 }
 

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
@@ -12,7 +12,6 @@ type Options = {
 
 function onPlayerReady(player: Player, options: Options) {
   // this doesn't work, but it should
-  // player.children()[0].setAttribute('crossorigin', 'anonymous');
   const button = videojs.getComponent('Button');
   const snapshotButton = videojs.extend(button, {
     constructor: function () {
@@ -50,7 +49,12 @@ function onPlayerReady(player: Player, options: Options) {
   });
   videojs.registerComponent('snapshotButton', snapshotButton);
 
-  player.getChild('controlBar').addChild('snapshotButton', {});
+  player.one('canplay', function () {
+    // need this for canvas to work
+    // $FlowIssue
+    player.children()[0].setAttribute('crossorigin', 'anonymous');
+    player.getChild('controlBar').addChild('snapshotButton', {});
+  });
 
   // TODO: this is particular to Odysee, since we don't necessarily dispose, better to use something universal
   player.on('playerClosed', function () {

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
@@ -7,6 +7,7 @@ const defaultOptions = {};
 
 type Options = {
   fileTitle: string,
+  poster: string,
 };
 
 function onPlayerReady(player: Player, options: Options) {
@@ -18,8 +19,12 @@ function onPlayerReady(player: Player, options: Options) {
       button.apply(this, arguments);
       this.controlText('Take A Snapshot');
       this.addClass('vjs-snapshot-button');
+      // camera svg
       this.el_.innerHTML =
-        '<svg style="fill:#d1d1d1;height:25px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M149.1 64.8L138.7 96H64C28.7 96 0 124.7 0 160V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V160c0-35.3-28.7-64-64-64H373.3L362.9 64.8C356.4 45.2 338.1 32 317.4 32H194.6c-20.7 0-39 13.2-45.5 32.8zM256 384c-53 0-96-43-96-96s43-96 96-96s96 43 96 96s-43 96-96 96z"/></svg>';
+        '<svg style="fill:#d1d1d1;height:25px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">' +
+        '<path d="M149.1 64.8L138.7 96H64C28.7 96 0 124.7 0 160V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7' +
+        ' 64-64V160c0-35.3-28.7-64-64-64H373.3L362.9 64.8C356.4 45.2 338.1 32 317.4 32H194.6c-20.7 0-39 13.' +
+        '2-45.5 32.8zM256 384c-53 0-96-43-96-96s43-96 96-96s96 43 96 96s-43 96-96 96z"/></svg>';
       this.el_.style.fill = 'white;';
       this.el_.style.height = '20px;';
     },
@@ -27,9 +32,7 @@ function onPlayerReady(player: Player, options: Options) {
       const link = document.createElement('a');
       const video = document.querySelector('video');
 
-      // $FlowIssue
       const width = player.videoWidth();
-      // $FlowIssue
       const height = player.videoHeight();
 
       const canvas = Object.assign(document.createElement('canvas'), { width, height });
@@ -49,13 +52,17 @@ function onPlayerReady(player: Player, options: Options) {
 
   player.getChild('controlBar').addChild('snapshotButton', {});
 
+  // TODO: this is particular to Odysee, since we don't necessarily dispose, better to use something universal
   player.on('playerClosed', function () {
     player.getChild('controlBar').removeChild('snapshotButton');
   });
 }
 
 function snapshotButton(options: Options) {
-  this.ready(() => onPlayerReady(this, videojs.mergeOptions(defaultOptions, options)));
+  const IS_MOBILE = videojs.browser.IS_ANDROID || videojs.browser.IS_IOS;
+  if (!IS_MOBILE) {
+    this.ready(() => onPlayerReady(this, videojs.mergeOptions(defaultOptions, options)));
+  }
 }
 
 videojs.registerPlugin('snapshotButton', snapshotButton);

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
@@ -1,0 +1,64 @@
+// @flow
+import videojs from 'video.js';
+import type { Player } from '../../videojs';
+
+const VERSION = '1.0.0';
+const defaultOptions = {};
+
+type Options = {
+  fileTitle: string,
+};
+
+function onPlayerReady(player: Player, options: Options) {
+  // this doesn't work, but it should
+  // player.children()[0].setAttribute('crossorigin', 'anonymous');
+  const button = videojs.getComponent('Button');
+  const snapshotButton = videojs.extend(button, {
+    constructor: function () {
+      button.apply(this, arguments);
+      this.controlText('Take A Snapshot');
+      this.addClass('vjs-snapshot-button');
+      this.el_.innerHTML =
+        '<svg style="fill:#d1d1d1;height:25px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M149.1 64.8L138.7 96H64C28.7 96 0 124.7 0 160V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V160c0-35.3-28.7-64-64-64H373.3L362.9 64.8C356.4 45.2 338.1 32 317.4 32H194.6c-20.7 0-39 13.2-45.5 32.8zM256 384c-53 0-96-43-96-96s43-96 96-96s96 43 96 96s-43 96-96 96z"/></svg>';
+      this.el_.style.fill = 'white;';
+      this.el_.style.height = '20px;';
+    },
+    handleClick: function () {
+      const link = document.createElement('a');
+      const video = document.querySelector('video');
+
+      // $FlowIssue
+      const width = player.videoWidth();
+      // $FlowIssue
+      const height = player.videoHeight();
+
+      const canvas = Object.assign(document.createElement('canvas'), { width, height });
+      // $FlowIssue
+      canvas.getContext('2d').drawImage(video, 0, 0, width, height);
+
+      link.href = canvas.toDataURL();
+      link.download = options.fileTitle;
+
+      link.click();
+
+      link.remove();
+      canvas.remove();
+    },
+  });
+  videojs.registerComponent('snapshotButton', snapshotButton);
+
+  player.getChild('controlBar').addChild('snapshotButton', {});
+
+  player.on('playerClosed', function () {
+    player.getChild('controlBar').removeChild('snapshotButton');
+  });
+}
+
+function snapshotButton(options: Options) {
+  this.ready(() => onPlayerReady(this, videojs.mergeOptions(defaultOptions, options)));
+}
+
+videojs.registerPlugin('snapshotButton', snapshotButton);
+snapshotButton.VERSION = VERSION;
+
+export default snapshotButton;

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-snapshot-button/plugin.js
@@ -7,11 +7,13 @@ const defaultOptions = {};
 
 type Options = {
   fileTitle: string,
-  poster: string,
 };
 
 function onPlayerReady(player: Player, options: Options) {
-  // this doesn't work, but it should
+  // needed for canvas to work with cors
+  // $FlowFixMe
+  player.el().childNodes[0].setAttribute('crossorigin', 'anonymous');
+
   const button = videojs.getComponent('Button');
   const snapshotButton = videojs.extend(button, {
     constructor: function () {
@@ -29,13 +31,14 @@ function onPlayerReady(player: Player, options: Options) {
     },
     handleClick: function () {
       const link = document.createElement('a');
-      const video = document.querySelector('video');
+      const video = document.querySelector('video.vjs-tech');
 
       const width = player.videoWidth();
       const height = player.videoHeight();
 
       const canvas = Object.assign(document.createElement('canvas'), { width, height });
-      // $FlowIssue
+      if (!video) return;
+      // $FlowIssue (when the class is added to the querySelector it errors)
       canvas.getContext('2d').drawImage(video, 0, 0, width, height);
 
       link.href = canvas.toDataURL();
@@ -50,9 +53,6 @@ function onPlayerReady(player: Player, options: Options) {
   videojs.registerComponent('snapshotButton', snapshotButton);
 
   player.one('canplay', function () {
-    // need this for canvas to work
-    // $FlowIssue
-    player.children()[0].setAttribute('crossorigin', 'anonymous');
     player.getChild('controlBar').addChild('snapshotButton', {});
   });
 

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -543,10 +543,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         document.querySelector('.video-js-parent')?.append(window.oldSavedDiv);
       }
 
-      // need this for canvas to work
-      const player = document.querySelector('video.vjs-tech');
-      if (player) player.setAttribute('crossorigin', 'anonymous');
-
       if (!isAudio) {
         vjsPlayer.snapshotButton({ fileTitle: title, poster });
       }

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -80,6 +80,8 @@ export type Player = {
   src: ({ src: string, type: string }) => ?string,
   currentSrc: () => string,
   userActive: (?boolean) => boolean,
+  videoWidth: () => number,
+  videoHeight: () => number,
   volume: (?number) => number,
 };
 
@@ -545,7 +547,9 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       const player = document.querySelector('video.vjs-tech');
       if (player) player.setAttribute('crossorigin', 'anonymous');
 
-      vjsPlayer.snapshotButton({ fileTitle: title });
+      if (!isAudio) {
+        vjsPlayer.snapshotButton({ fileTitle: title, poster });
+      }
 
       // disable right-click (context-menu) for purchased content
       if (isPurchasableContent || isRentableContent || isProtectedContent) {

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -24,6 +24,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import i18n from './plugins/videojs-i18n/plugin';
 import recsys from './plugins/videojs-recsys/plugin';
 import watchdog from './plugins/videojs-watchdog/plugin';
+import snapshotButton from './plugins/videojs-snapshot-button/plugin';
+
 // import runAds from './ads';
 import videojs from 'video.js';
 import { useIsMobile } from 'effects/use-screensize';
@@ -131,6 +133,7 @@ const PLUGIN_MAP = {
   recsys: recsys,
   i18n: i18n,
   watchdog: watchdog,
+  snapshotButton: snapshotButton,
 };
 
 Object.entries(PLUGIN_MAP).forEach(([pluginName, plugin]) => {
@@ -537,6 +540,12 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         // $FlowIssue
         document.querySelector('.video-js-parent')?.append(window.oldSavedDiv);
       }
+
+      // need this for canvas to work
+      const player = document.querySelector('video.vjs-tech');
+      if (player) player.setAttribute('crossorigin', 'anonymous');
+
+      vjsPlayer.snapshotButton({ fileTitle: title });
 
       // disable right-click (context-menu) for purchased content
       if (isPurchasableContent || isRentableContent || isProtectedContent) {

--- a/ui/scss/component/_content.scss
+++ b/ui/scss/component/_content.scss
@@ -294,6 +294,10 @@
   .truncated-text {
     display: inline !important;
   }
+
+  .vjs-snapshot-button {
+    display: none;
+  }
 }
 
 .content__actions {

--- a/ui/scss/component/_videojs.scss
+++ b/ui/scss/component/_videojs.scss
@@ -436,6 +436,9 @@ button.vjs-big-play-button {
 .vjs-subs-caps-button {
   order: 10 !important;
 }
+.vjs-snapshot-button {
+  order: 10 !important;
+}
 .vjs-button--autoplay-next {
   order: 11 !important;
 }

--- a/ui/scss/component/_videojs.scss
+++ b/ui/scss/component/_videojs.scss
@@ -433,23 +433,23 @@ button.vjs-big-play-button {
 .vjs-custom-control-spacer {
   order: 9 !important;
 }
-.vjs-subs-caps-button {
-  order: 10 !important;
-}
 .vjs-snapshot-button {
   order: 10 !important;
 }
-.vjs-button--autoplay-next {
+.vjs-subs-caps-button {
   order: 11 !important;
 }
-.vjs-chapters-button {
+.vjs-button--autoplay-next {
   order: 12 !important;
 }
-.vjs-playback-rate {
+.vjs-chapters-button {
   order: 13 !important;
 }
-.vjs-quality-selector {
+.vjs-playback-rate {
   order: 14 !important;
+}
+.vjs-quality-selector {
+  order: 15 !important;
   display: flex;
 
   .vjs-icon-placeholder {
@@ -459,14 +459,14 @@ button.vjs-big-play-button {
 }
 .vjs-chromecast-button,
 .vjs-airplay-button {
-  order: 15 !important;
+  order: 16 !important;
 }
 
 .vjs-button--theater-mode {
-  order: 16 !important;
+  order: 17 !important;
 }
 .vjs-fullscreen-control {
-  order: 17 !important;
+  order: 18 !important;
 }
 
 // livestream player


### PR DESCRIPTION
Allows users to take a snapshot of the video at a given point

![Screen Shot 2022-10-19 at 7 05 12 PM](https://user-images.githubusercontent.com/7200471/196757746-ee264ca5-0d74-4642-9a8f-964e2e2d7a15.JPG)

Might be interesting to open-source this separately as its own plugin, everything worked for me to do that except that I think the `playerClosed` event is something custom we use and also I couldn't get the `crossorigin` attribute to remain permanent, though perhaps that is due to how we store and reuse the videojs instance? Still uncertain about that