### PR TITLE
ClaimTilesDiscover: handle 0 results case

### DIFF
--- a/ui/component/claimTilesDiscover/index.js
+++ b/ui/component/claimTilesDiscover/index.js
@@ -6,6 +6,7 @@ import {
   selectFetchingClaimSearchByQuery,
   selectClaimsByUri,
   selectById,
+  selectClaimSearchByQueryLastPageReached,
 } from 'redux/selectors/claims';
 import { doClaimSearch, doResolveClaimIds, doResolveUris } from 'redux/actions/claims';
 import { doFetchOdyseeMembershipForChannelIds } from 'redux/actions/memberships';
@@ -45,6 +46,7 @@ const select = (state, props) => {
 
   return {
     claimSearchResults: selectClaimSearchByQuery(state)[searchKey],
+    claimSearchLastPageReached: selectClaimSearchByQueryLastPageReached(state)[searchKey],
     claimsByUri: selectClaimsByUri(state),
     claimsById: selectById(state),
     fetchingClaimSearch: selectFetchingClaimSearchByQuery(state)[searchKey],

--- a/ui/component/claimTilesDiscover/view.jsx
+++ b/ui/component/claimTilesDiscover/view.jsx
@@ -58,6 +58,7 @@ type Props = {
   // --- select ---
   location: { search: string },
   claimSearchResults: Array<string>,
+  claimSearchLastPageReached: ?boolean,
   claimsByUri: { [string]: any },
   claimsById: { [string]: any },
   fetchingClaimSearch: boolean,
@@ -76,6 +77,7 @@ function ClaimTilesDiscover(props: Props) {
   const {
     doClaimSearch,
     claimSearchResults,
+    claimSearchLastPageReached,
     claimsByUri,
     claimsById,
     fetchViewCount,
@@ -108,7 +110,8 @@ function ClaimTilesDiscover(props: Props) {
   const uriBuffer = useRef([]);
 
   const timedOut = claimSearchResults === null;
-  const shouldPerformSearch = !fetchingClaimSearch && !timedOut && claimSearchUris.length === 0;
+  const shouldPerformSearch =
+    !fetchingClaimSearch && !timedOut && claimSearchUris.length === 0 && !claimSearchLastPageReached;
 
   const uris = (prefixUris || []).concat(claimSearchUris);
   if (prefixUris && prefixUris.length) uris.splice(prefixUris.length * -1, prefixUris.length);
@@ -206,6 +209,10 @@ function ClaimTilesDiscover(props: Props) {
         </p>
       </div>
     );
+  }
+
+  if (!timedOut && finalUris && finalUris.length === 0 && !loading && claimSearchLastPageReached) {
+    return <div className="empty empty--centered">{__('No results')}</div>;
   }
 
   return (


### PR DESCRIPTION
## Issue
Closes #2297

The Homepage's Following Section was stuck in an infinite `claim_search` loop when there are no results.

## Root
ClaimTilesDiscover assumes that there will always be results, and since it doesn't do pagination either, it doesn't check for the "last page reached" flag, hence the infinite loop.

## Fix
Brought over some code from ClaimListDiscover/ClaimList.

We really need to consolidate these 2 components soon (#1163). 
