### PR TITLE
Fix missing logo in Firefox 106

### DIFF
--- a/ui/scss/component/_header.scss
+++ b/ui/scss/component/_header.scss
@@ -291,9 +291,6 @@
 
 .header__logo {
   height: var(--height-button);
-  max-width: -webkit-fit-content;
-  max-width: -moz-fit-content;
-  max-width: fit-content;
 
   @media (max-width: $breakpoint-small) {
     height: var(--height-button-mobile);


### PR DESCRIPTION
## Issue
https://odysee-workspace.slack.com/archives/C02G20Z2AEL/p1666259109170879

## Notes
- For Firefox 40 - 105, the logo works with or without `max-width` defined.
- For Firefox 106, the logo does not appear with `max-width` defined.

I don't really understand the full picture, but I believe it's no longer needed after the recent header component changes.

Confirmed with designer that max-width seems unnecessary. 
Tested against Firefox, Opera, Chrome, Safari.

## Related
0214c805 (fix logo size on firefox)

