### PR TITLE
Assume claim is lbc-paywalled until costInfo is fetched

### DIFF
--- a/ui/component/fileRenderInitiator/view.jsx
+++ b/ui/component/fileRenderInitiator/view.jsx
@@ -115,7 +115,7 @@ export default function FileRenderInitiator(props: Props) {
   const urlTimeParam = href && href.indexOf('t=') > -1;
 
   const shouldAutoplay = !forceDisableAutoplay && !embedded && (forceAutoplayParam || urlTimeParam || autoplay);
-  const sdkFeeRequired = costInfo && costInfo.cost !== 0;
+  const sdkFeeRequired = costInfo === undefined || (costInfo && costInfo.cost !== 0);
   const isFree = costInfo && costInfo.cost === 0 && !fiatRequired;
   const isAnonymousFiatContent = fiatRequired && !channelClaimId;
 


### PR DESCRIPTION
#2304

This prevents `viewFile` from being hit too early.


