### PR TITLE
(minor cleanup) Show reactions on own claims

### DIFF
--- a/ui/component/fileActions/view.jsx
+++ b/ui/component/fileActions/view.jsx
@@ -108,9 +108,8 @@ export default function FileActions(props: Props) {
   }
 
   function isAllowedToReact() {
-    // We can relax it a bit by doing OR instead, but for now,
-    // require all restrictions to be cleared in order to react.
-    return (!claimIsMine && (!isFiatRequired || isFiatPaid) && isTierUnlocked) || claimIsMine;
+    const restrictionsCleared = (!isFiatRequired || isFiatPaid) && isTierUnlocked; // should it be OR instead?
+    return claimIsMine || restrictionsCleared;
   }
 
   function handleWebDownload() {
@@ -135,7 +134,6 @@ export default function FileActions(props: Props) {
     doOpenModal(MODALS.REPOST, { uri });
   }
 
-  console.log('isAllowedToReact: ', isAllowedToReact());
   return (
     <div className="media__actions">
       {ENABLE_FILE_REACTIONS && isAllowedToReact() && <FileReactions uri={uri} />}


### PR DESCRIPTION
## Changes
Just some minor removal and shortening

## Discuss
On top of the logic error, I think I implemented the restriction incorrectly. It should always be displayed, but can't be clicked if not paid. Should we do this instead?

Also, the current logic requires both LBC and $ to be cleared. If the claim is paywalled by both (say from Desktop or some other means), the requirement doesn't feel right.
