### PR TITLE
Disable few unmonitored Sentry items

### DIFF
--- a/extras/lbryinc/lbryio.js
+++ b/extras/lbryinc/lbryio.js
@@ -267,6 +267,7 @@ function sendFailedCallAnalytics(resource, action, params, error) {
     return;
   }
 
+  // @if TARGET='DISABLE_FOR_NOW'
   const options = {
     fingerprint: 'internal-api-failures',
     tags: { analytics: true, method: `${resource}/${action}` },
@@ -274,6 +275,7 @@ function sendFailedCallAnalytics(resource, action, params, error) {
   };
 
   analytics.log('Internal API failures', options, 'analytics');
+  // @endif
 }
 
 export default Lbryio;

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -479,6 +479,7 @@ function VideoViewer(props: Props) {
       playerEndedDuration.current = true;
     };
     const onError = () => {
+      // @if TARGET='DISABLE_FOR_NOW'
       const mediaError = player.error();
       if (mediaError) {
         let fingerprint;
@@ -491,6 +492,7 @@ function VideoViewer(props: Props) {
         const options = { ...(fingerprint ? { fingerprint } : {}) };
         analytics.log(`[${mediaError.code}] ${mediaError.message}`, options, ERR_GRP.VIDEOJS);
       }
+      // @endif
     };
     const onRateChange = () => {
       const HAVE_NOTHING = 0; // https://docs.videojs.com/player#readyState


### PR DESCRIPTION
No point collecting if we aren't monitoring these:

- videojs media errors
- iapi failures (we have a separate monitoring tool for that already)
