### PR TITLE
Playlist: `le.scrollTo` is not a function

### DIFF
--- a/ui/component/playlistCard/view.jsx
+++ b/ui/component/playlistCard/view.jsx
@@ -189,7 +189,10 @@ const PlaylistCardComponent = (props: PlaylistCardProps) => {
           topToScroll = bodyRef.scrollHeight;
         }
 
-        bodyRef.scrollTo({ top: topToScroll, behavior: isMediumScreen ? 'instant' : 'smooth' });
+        try {
+          bodyRef.scrollTo({ top: topToScroll, behavior: isMediumScreen ? 'instant' : 'smooth' });
+        } catch (error) {}
+
         setScrolledPast(false);
         scrollRestorePending.current = true;
       }


### PR DESCRIPTION
## Fixes

Issue Number: closes #2061

from https://sentry.lbry.tech/organizations/odysee/issues/29538/?project=2&query=scrollTo&statsPeriod=14d

just don't scroll to currently playing item in those cases