### PR TITLE
Thumbnail: fix `images don't show on previews until loaded directly`

### DIFF
--- a/ui/component/fileThumbnail/internal/thumb.jsx
+++ b/ui/component/fileThumbnail/internal/thumb.jsx
@@ -5,7 +5,7 @@ import type { Node } from 'react';
 import useLazyLoading from 'effects/use-lazy-loading';
 
 type Props = {
-  thumb: string,
+  thumb: ?string,
   fallback: ?string,
   children?: Node,
   className?: string,

--- a/ui/component/fileThumbnail/view.jsx
+++ b/ui/component/fileThumbnail/view.jsx
@@ -16,6 +16,8 @@ import classnames from 'classnames';
 import Thumb from './internal/thumb';
 import PreviewOverlayProtectedContent from '../previewOverlayProtectedContent';
 
+const FALLBACK = MISSING_THUMB_DEFAULT ? getThumbnailCdnUrl({ thumbnail: MISSING_THUMB_DEFAULT }) : undefined;
+
 type Props = {
   uri?: string,
   tileLayout?: boolean,
@@ -25,7 +27,6 @@ type Props = {
   claim: ?StreamClaim,
   className?: string,
   small?: boolean,
-  forcePlaceholder?: boolean,
   // -- redux --
   hasResolvedClaim: ?boolean, // undefined if uri is not given (irrelevant); boolean otherwise.
   thumbnailFromClaim: ?string,
@@ -41,7 +42,6 @@ function FileThumbnail(props: Props) {
     allowGifs = false,
     className,
     small,
-    forcePlaceholder,
     // -- redux --
     hasResolvedClaim,
     thumbnailFromClaim,
@@ -80,9 +80,7 @@ function FileThumbnail(props: Props) {
     );
   }
 
-  const fallback = MISSING_THUMB_DEFAULT ? getThumbnailCdnUrl({ thumbnail: MISSING_THUMB_DEFAULT }) : undefined;
-
-  let url = thumbnail || (hasResolvedClaim ? MISSING_THUMB_DEFAULT : '');
+  let url = thumbnail;
   // Pass image urls through a compression proxy
   if (thumbnail) {
     if (isGif) {
@@ -97,11 +95,11 @@ function FileThumbnail(props: Props) {
     }
   }
 
-  const thumbnailUrl = url ? url.replace(/'/g, "\\'") : '';
+  const thumbnailUrl = url && url.replace(/'/g, "\\'");
 
-  if (hasResolvedClaim || thumbnailUrl || (forcePlaceholder && !uri)) {
+  if (thumbnailUrl !== undefined) {
     return (
-      <Thumb small={small} thumb={thumbnailUrl || MISSING_THUMB_DEFAULT} fallback={fallback} className={className}>
+      <Thumb small={small} thumb={thumbnailUrl} fallback={FALLBACK} className={className}>
         <PreviewOverlayProtectedContent uri={uri} />
         {children}
       </Thumb>

--- a/ui/effects/use-lazy-loading.js
+++ b/ui/effects/use-lazy-loading.js
@@ -46,6 +46,8 @@ export default function useLazyLoading(
         tmpImage.src = target.dataset.backgroundImage;
       }
       target.style.backgroundImage = `url(${target.dataset.backgroundImage})`;
+    } else {
+      target.style.backgroundImage = `url(${backgroundFallback})`;
     }
   }
 

--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/view.jsx
@@ -97,7 +97,7 @@ function CollectionPreview(props: Props) {
     >
       <div className="table-column__thumbnail">
         <NavLink {...navLinkProps}>
-          <FileThumbnail uri={uri || firstCollectionItemUrl} thumbnail={thumbnail} forcePlaceholder>
+          <FileThumbnail uri={firstCollectionItemUrl} thumbnail={thumbnail}>
             <CollectionItemCount count={collectionCount} hasEdits={hasEdits} />
             <CollectionPreviewOverlay collectionId={collectionId} />
           </FileThumbnail>

--- a/ui/util/claim.js
+++ b/ui/util/claim.js
@@ -176,8 +176,11 @@ export const isStreamPlaceholderClaim = (claim: ?StreamClaim) => {
 };
 
 export const getThumbnailFromClaim = (claim: ?Claim) => {
-  const thumbnail = claim && claim.value && claim.value.thumbnail;
-  return thumbnail && thumbnail.url ? thumbnail.url.trim().replace(/^http:\/\//i, 'https://') : undefined;
+  if (!claim) return claim;
+
+  const { thumbnail } = claim.value || {};
+
+  return thumbnail && thumbnail.url ? thumbnail.url.trim().replace(/^http:\/\//i, 'https://') : null;
 };
 
 export const getClaimMeta = (claim: ?Claim) => claim && claim.meta;


### PR DESCRIPTION
## Fixes

Issue Number: closes #2339

- `thumbnailUrl` was being set to the `thumbnail` or `MISSING_THUMB_DEFAULT`, so instead use the resolving state when `undefined`, and use the fallback correctly when:
    - image fails to load
    - returned thumbnail value is `null`