### PR TITLE
Add page that lists all icons

### DIFF
--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -36,6 +36,7 @@ const SeniorAndroidDeveloperPage = lazyImport(() =>
 const SeniorIosDeveloperPage = lazyImport(() =>
   import('web/page/careers/seniorIosDeveloper' /* webpackChunkName: "seniorIosDeveloper" */)
 );
+const IconsViewerPage = lazyImport(() => import('page/iconsViewer' /* webpackChunkName: "iconsViewer" */));
 
 const FypPage = lazyImport(() => import('web/page/fyp' /* webpackChunkName: "fyp" */));
 const YouTubeTOSPage = lazyImport(() => import('web/page/youtubetos' /* webpackChunkName: "youtubetos" */));
@@ -373,6 +374,7 @@ function AppRouter(props: Props) {
         <Route path={`/$/${PAGES.CAREERS_SENIOR_IOS_DEVELOPER}`} exact component={SeniorIosDeveloperPage} />
         <Route path={`/$/${PAGES.FYP}`} exact component={FypPage} />
         <Route path={`/$/${PAGES.YOUTUBE_TOS}`} exact component={YouTubeTOSPage} />
+        <Route path={`/$/${PAGES.ICONS_VIEWER}`} exact component={IconsViewerPage} />
 
         <Route path={`/$/${PAGES.AUTH_VERIFY}`} exact component={SignInVerifyPage} />
         <Route path={`/$/${PAGES.SEARCH}`} exact component={SearchPage} />

--- a/ui/constants/pages.js
+++ b/ui/constants/pages.js
@@ -109,3 +109,4 @@ exports.CAREERS_SENIOR_SYSADMIN = 'careers/senior_sysadmin';
 exports.CAREERS_SOFTWARE_SECURITY_ENGINEER = 'careers/software_security_engineer';
 exports.CAREERS_SENIOR_ANDROID_DEVELOPER = 'careers/senior_android_developer';
 exports.CAREERS_SENIOR_IOS_DEVELOPER = 'careers/senior_ios_developer';
+exports.ICONS_VIEWER = 'icons_viewer';

--- a/ui/page/iconsViewer/index.js
+++ b/ui/page/iconsViewer/index.js
@@ -1,0 +1,6 @@
+import { connect } from 'react-redux';
+import IconsViewer from './view';
+
+const select = (state) => ({});
+
+export default connect(select)(IconsViewer);

--- a/ui/page/iconsViewer/style.scss
+++ b/ui/page/iconsViewer/style.scss
@@ -1,0 +1,11 @@
+.listed-icon {
+  width: 20px;
+  height: 20px;
+  display: inline-block;
+  margin-bottom: -3px;
+}
+
+.icon-display-name {
+  display: inline;
+  margin-left: 7px;
+}

--- a/ui/page/iconsViewer/view.jsx
+++ b/ui/page/iconsViewer/view.jsx
@@ -1,0 +1,28 @@
+// @flow
+import * as ICONS from 'constants/icons';
+import React from 'react';
+import Page from 'component/page';
+import Icon from 'component/common/icon';
+import './style.scss';
+
+type Props = {};
+
+function TagsFollowingPage(props: Props) {
+  return (
+    <Page noFooter fullWidthPage>
+      {Object.keys(ICONS)
+        .sort((a, b) => a.localeCompare(b))
+        .map((tag) => (
+          <>
+            <div style={{ marginBottom: '15px' }}>
+              <Icon icon={ICONS[tag]} size={10} className="listed-icon" />
+              <h2 className="icon-display-name">{tag}</h2>
+              <br />
+            </div>
+          </>
+        ))}
+    </Page>
+  );
+}
+
+export default TagsFollowingPage;


### PR DESCRIPTION
Alphabetical list of all icons for easy viewing/selection at `/$/icons_viewer`

![Screen Shot 2022-11-03 at 4 43 40 PM](https://user-images.githubusercontent.com/7200471/199767718-365727db-93f9-45b6-b1a4-003fa38f34dd.JPG)

