### PR TITLE
Fix: loading Docs page not fully displaying resolved items

### DIFF
--- a/ui/effects/use-fetch-view-count.js
+++ b/ui/effects/use-fetch-view-count.js
@@ -10,7 +10,7 @@ import { useState, useEffect } from 'react';
  */
 export default function useFetchViewCount(
   shouldFetch: ?boolean,
-  uris: Array<string>,
+  uris: ?Array<string>,
   claimsByUri: {},
   doFetchViewCount: (string) => void
 ) {


### PR DESCRIPTION
Simply moved the `let finalUris` into a `setState` and then that whole condition inside its own `useEffect`