### PR TITLE
Playlist: fix dead links

### DIFF
--- a/ui/page/show/index.js
+++ b/ui/page/show/index.js
@@ -11,7 +11,7 @@ import {
 } from 'redux/selectors/claims';
 import {
   selectCollectionForId,
-  selectUrlsForCollectionId,
+  selectFirstItemUrlForCollection,
   selectAreCollectionItemsFetchingForId,
 } from 'redux/selectors/collections';
 import { selectHomepageFetched, selectUserVerifiedEmail } from 'redux/selectors/user';
@@ -27,6 +27,7 @@ import { doFetchChannelLiveStatus } from 'redux/actions/livestream';
 import { doFetchCreatorSettings } from 'redux/actions/comments';
 import { selectSettingsForChannelId } from 'redux/selectors/comments';
 import { PREFERENCE_EMBED } from 'constants/tags';
+import { doFetchItemsInCollection } from 'redux/actions/collections';
 import ShowPage from './view';
 
 const select = (state, props) => {
@@ -64,7 +65,7 @@ const select = (state, props) => {
     isLivestream: isStreamPlaceholderClaim(claim),
     collection: selectCollectionForId(state, collectionId),
     collectionId,
-    collectionUrls: selectUrlsForCollectionId(state, collectionId),
+    collectionFirstItemUri: selectFirstItemUrlForCollection(state, collectionId),
     isResolvingCollection: selectAreCollectionItemsFetchingForId(state, collectionId),
     isAuthenticated: selectUserVerifiedEmail(state),
     geoRestriction: selectGeoRestrictionForUri(state, uri),
@@ -81,6 +82,7 @@ const perform = {
   fetchLatestClaimForChannel: doFetchLatestClaimForChannel,
   fetchChannelLiveStatus: doFetchChannelLiveStatus,
   doFetchCreatorSettings,
+  doFetchItemsInCollection,
 };
 
 export default withRouter(connect(select, perform)(ShowPage));

--- a/ui/page/show/view.jsx
+++ b/ui/page/show/view.jsx
@@ -38,7 +38,7 @@ type Props = {
   isLivestream: boolean,
   collectionId: string,
   collection: Collection,
-  collectionUrls: Array<string>,
+  collectionFirstItemUri: ?string,
   isAuthenticated: boolean,
   geoRestriction: ?GeoRestriction,
   homepageFetched: boolean,
@@ -53,6 +53,7 @@ type Props = {
   doBeginPublish: (name: ?string) => void,
   doResolveClaimId: (claimId: string) => void,
   doOpenModal: (string, {}) => void,
+  doFetchItemsInCollection: (params: { collectionId: string }) => void,
   preferEmbed: boolean,
 };
 
@@ -71,7 +72,7 @@ export default function ShowPage(props: Props) {
     isLivestream,
     collectionId,
     collection,
-    collectionUrls,
+    collectionFirstItemUri,
     isAuthenticated,
     geoRestriction,
     homepageFetched,
@@ -86,6 +87,7 @@ export default function ShowPage(props: Props) {
     doResolveClaimId,
     doBeginPublish,
     doOpenModal,
+    doFetchItemsInCollection,
     preferEmbed,
   } = props;
 
@@ -193,6 +195,13 @@ export default function ShowPage(props: Props) {
     }
   }, [channelClaimId, creatorSettings, doFetchCreatorSettings]);
 
+  React.useEffect(() => {
+    if (claim && isCollection && collectionFirstItemUri === undefined) {
+      // -- We're only interested in the first item to redirect to, and start playing
+      doFetchItemsInCollection({ collectionId, itemCount: 1 });
+    }
+  }, [claim, collectionFirstItemUri, collectionId, doFetchItemsInCollection, isCollection]);
+
   // Wait for latest claim fetch
   if (isNewestPath && latestClaimUrl === undefined) {
     return (
@@ -215,13 +224,11 @@ export default function ShowPage(props: Props) {
     return <Redirect to={newUrl} />;
   }
 
-  let urlForCollectionZero;
-  if (claim && isCollection && collectionUrls && collectionUrls.length) {
+  if (claim && isCollection && collectionFirstItemUri) {
     switch (collection?.type) {
       case COL_TYPES.PLAYLIST:
-        urlForCollectionZero = collectionUrls && collectionUrls[0];
         urlParams.set(COLLECTIONS_CONSTS.COLLECTION_ID, claim.claim_id);
-        const newUrl = formatLbryUrlForWeb(`${urlForCollectionZero}?${urlParams.toString()}`);
+        const newUrl = formatLbryUrlForWeb(`${collectionFirstItemUri}?${urlParams.toString()}`);
         return <Redirect to={newUrl} />;
 
       case COL_TYPES.FEATURED_CHANNELS:


### PR DESCRIPTION
## Fixes

Issue Number: https://github.com/OdyseeTeam/odysee-frontend/issues/2399

- navigating to the playlist canonical claim uri (rather than the `/$/playlist` page) would redirect to the first item and start playing it, but when direct loaded it was missing the fetch items call so at least the first item needs to be resolved so it doesn't show the "download" page 