### PR TITLE
Enable thumbnail CDN for gifs

### DIFF
--- a/ui/component/common/markdown-preview.jsx
+++ b/ui/component/common/markdown-preview.jsx
@@ -4,7 +4,7 @@ import { platform } from 'util/platform';
 import { formattedEmote, inlineEmote } from 'util/remark-emote';
 import { formattedLinks, inlineLinks } from 'util/remark-lbry';
 import { formattedTimestamp, inlineTimestamp } from 'util/remark-timestamp';
-import { getThumbnailCdnUrl, getImageProxyUrl } from 'util/thumbnail';
+import { getThumbnailCdnUrl } from 'util/thumbnail';
 import * as ICONS from 'constants/icons';
 import * as React from 'react';
 import Button from 'component/button';
@@ -259,13 +259,8 @@ export default React.memo<MarkdownProps>(function MarkdownPreview(props: Markdow
       // Workaraund of remarkOptions.Fragment
       div: React.Fragment,
       img: (imgProps) => {
-        const isGif = imgProps.src && imgProps.src.endsWith('gif');
-
         const imageCdnUrl =
-          (isGif
-            ? getImageProxyUrl(imgProps.src)
-            : getThumbnailCdnUrl({ thumbnail: imgProps.src, width: 0, height: 0, quality: 85 })) ||
-          MISSING_THUMB_DEFAULT;
+          getThumbnailCdnUrl({ thumbnail: imgProps.src, width: 0, height: 0, quality: 85 }) || MISSING_THUMB_DEFAULT;
         if (noDataStore) {
           return (
             <div className="file-viewer file-viewer--document">

--- a/ui/scss/component/_livestream-chat.scss
+++ b/ui/scss/component/_livestream-chat.scss
@@ -457,6 +457,10 @@ $recent-msg-button__height: 2rem;
   backdrop-filter: blur(4px);
   border: 1px solid var(--color-text);
 
+  span {
+    margin-top: 0 !important;
+    padding-top: 0 !important;
+  }
   &:hover {
     opacity: 1;
   }


### PR DESCRIPTION
Use thumbnail CDN for GIFs in markdown.