### PR TITLE
Last Updated showing creation time on channel about tab -> change the text to say Created At

### DIFF
--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/aboutTab/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/aboutTab/view.jsx
@@ -95,7 +95,7 @@ function AboutTab(props: Props) {
           <label>{__('Total Uploads')}</label>
           <div className="media__info-text">{claim.meta.claims_in_channel}</div>
 
-          <label>{__('Last Updated')}</label>
+          <label>{__('Created At')}</label>
           <div className="media__info-text">
             <DateTime timeAgo uri={uri} />
           </div>


### PR DESCRIPTION
Fixes this:
Channel page has "Last Updated", but it is showing creation time.  

Updated the text to "Created At"

https://odysee.com/@Odysee:8?view=about
(OLD)
![last-created](https://user-images.githubusercontent.com/34790748/211083548-091f442a-5183-411e-b98a-83c72ad66345.png)
