### PR TITLE
Attempt to combine min/max duration setting to same

### DIFF
--- a/flow-typed/Lbry.js
+++ b/flow-typed/Lbry.js
@@ -122,7 +122,7 @@ declare type ClaimSearchOptions = {
   media_types?: Array<string>, // filter by 'video/mp4', 'image/png', etc
   fee_currency?: string, // specify fee currency: LBC, BTC, USD
   fee_amount?: number | string, // content download fee (supports equality constraints)
-  duration?: number | string, // duration of video or audio in seconds (supports equality constraints)
+  duration?: number | string | Array<string>, // duration of video or audio in seconds (supports equality constraints)
   any_tags?: Array<string>, // find claims containing any of the tags
   all_tags?: Array<string>, // find claims containing every tag
   not_tags?: Array<string>, // find claims not containing any of these tags

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -298,7 +298,8 @@ function ClaimListDiscover(props: Props) {
   }
 
   const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION_ALL], 'durUser', null);
-  const [durationMinutes] = usePersistedState(`durUserMinutes-${location.pathname}`, 5);
+  const [minDurationMinutes] = usePersistedState(`minDurUserMinutes-${location.pathname}`, null);
+  const [maxDurationMinutes] = usePersistedState(`maxDurUserMinutes-${location.pathname}`, null);
   const channelIdsInUrl = urlParams.get(CS.CHANNEL_IDS_KEY);
   const channelIdsParam = channelIdsInUrl ? channelIdsInUrl.split(',') : channelIds;
   const excludedIdsParam = excludedChannelIds;
@@ -407,11 +408,14 @@ function ClaimListDiscover(props: Props) {
       case CS.DURATION_LONG:
         options.duration = '>=1200';
         break;
-      case CS.DURATION_GT_EQ:
-        options.duration = `>=${(durationMinutes || 0) * 60}`;
-        break;
-      case CS.DURATION_LT_EQ:
-        options.duration = `<=${(durationMinutes || 0) * 60}`;
+      case CS.DURATION_CUSTOM:
+        options.duration = [];
+        if (minDurationMinutes) {
+          options.duration.push(`>=${minDurationMinutes * 60}`);
+        }
+        if (maxDurationMinutes) {
+          options.duration.push(`<=${maxDurationMinutes * 60}`);
+        }
         break;
       default:
         console.error('Unhandled duration: ' + durationParam);

--- a/ui/component/claimListHeader/view.jsx
+++ b/ui/component/claimListHeader/view.jsx
@@ -89,10 +89,16 @@ function ClaimListHeader(props: Props) {
   const showDuration = !(claimType && claimType === CS.CLAIM_CHANNEL && claimType === CS.CLAIM_COLLECTION);
 
   const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION_ALL], 'durUser', null);
-  const [durationMinutes, setDurationMinutes] = usePersistedState(`durUserMinutes-${location.pathname}`, 5);
-  const [minutes, setMinutes] = React.useState(durationMinutes);
-  const setDurationMinutesDebounced = React.useCallback(
-    debounce((m) => setDurationMinutes(m), 750),
+  const [minDurationMinutes, setMinDurationMinutes] = usePersistedState(`minDurUserMinutes-${location.pathname}`, null);
+  const [maxDurationMinutes, setMaxDurationMinutes] = usePersistedState(`maxDurUserMinutes-${location.pathname}`, null);
+  const [minMinutes, setMinMinutes] = React.useState(minDurationMinutes);
+  const [maxMinutes, setMaxMinutes] = React.useState(maxDurationMinutes);
+  const setMinDurationMinutesDebounced = React.useCallback(
+    debounce((m) => setMinDurationMinutes(m), 750),
+    []
+  );
+  const setMaxDurationMinutesDebounced = React.useCallback(
+    debounce((m) => setMaxDurationMinutes(m), 750),
     []
   );
 
@@ -403,24 +409,37 @@ function ClaimListHeader(props: Props) {
                           {dur === CS.DURATION_SHORT && __('Short (< 4 minutes)')}
                           {dur === CS.DURATION_LONG && __('Long (> 20 min)')}
                           {dur === CS.DURATION_ALL && __('Any')}
-                          {dur === CS.DURATION_GT_EQ && __('Longer than')}
-                          {dur === CS.DURATION_LT_EQ && __('Shorter than')}
+                          {dur === CS.DURATION_CUSTOM && __('Custom')}
                         </option>
                       ))}
                     </FormField>
                   </div>
-                  {(durationParam === CS.DURATION_GT_EQ || durationParam === CS.DURATION_LT_EQ) && (
-                    <div className={'claim-search__input-container'}>
-                      <FormField
-                        label={__('Minutes')}
-                        type="number"
-                        name="duration__minutes"
-                        value={minutes}
-                        onChange={(e) => {
-                          setMinutes(e.target.value);
-                          setDurationMinutesDebounced(e.target.value);
-                        }}
-                      />
+                  {(durationParam === CS.DURATION_CUSTOM) && (
+                    <div className={'claim-search__duration-inputs-container'}>
+                      <div className={'claim-search__input-container'}>
+                        <FormField
+                          label={__('Min Minutes')}
+                          type="number"
+                          name="min_duration__minutes"
+                          value={minMinutes}
+                          onChange={(e) => {
+                            setMinMinutes(e.target.value);
+                            setMinDurationMinutesDebounced(e.target.value);
+                          }}
+                        />
+                      </div>
+                      <div className={'claim-search__input-container'}>
+                        <FormField
+                          label={__('Max Minutes')}
+                          type="number"
+                          name="max_duration__minutes"
+                          value={maxMinutes}
+                          onChange={(e) => {
+                            setMaxMinutes(e.target.value);
+                            setMaxDurationMinutesDebounced(e.target.value);
+                          }}
+                        />
+                      </div>
                     </div>
                   )}
                 </>

--- a/ui/constants/claim_search.js
+++ b/ui/constants/claim_search.js
@@ -48,9 +48,8 @@ export const ORDER_BY_TYPES = [ORDER_BY_NEW, ORDER_BY_TRENDING, ORDER_BY_TOP];
 export const DURATION_SHORT = 'short';
 export const DURATION_LONG = 'long';
 export const DURATION_ALL = 'all';
-export const DURATION_GT_EQ = 'longer_than';
-export const DURATION_LT_EQ = 'shorter_than';
-export const DURATION_TYPES = [DURATION_ALL, DURATION_SHORT, DURATION_LONG, DURATION_GT_EQ, DURATION_LT_EQ];
+export const DURATION_CUSTOM = 'custom';
+export const DURATION_TYPES = [DURATION_ALL, DURATION_SHORT, DURATION_LONG, DURATION_CUSTOM];
 
 export const SORT_BY = {
   // key: Enumeration; can be anything as long as unique. Also used as URLParam.

--- a/ui/scss/component/_claim-search.scss
+++ b/ui/scss/component/_claim-search.scss
@@ -108,6 +108,13 @@
   }
 }
 
+.claim-search__duration-inputs-container {
+  display: flex;
+  column-gap: var(--spacing-xxs);
+  padding-right: var(--spacing-xl);
+  align-content: flex-start;
+}
+
 .claim-search__filter-button {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Attempt to merge min/max duration filter to one setting

## What is the current behavior?
Separate longer and shorter duration filter settings

## What is the new behavior?
One duration filter setting, allowing min and max duration.

## Other information
![custom-duration](https://user-images.githubusercontent.com/34790748/211099749-8a0fd938-7eef-4e73-917c-2aafcbccd493.png)

----
Need some help with styling. (Assuming this is good otherwise)
This line makes setting look bad on mobile, but don't know what's it needed for, or proper way to avoid. https://github.com/OdyseeTeam/odysee-frontend/blob/master/ui/scss/component/_claim-search.scss#L84  
![custom-duration-mobile](https://user-images.githubusercontent.com/34790748/211100542-27724b3f-33a5-4ce0-b5c3-05930f85cdf5.png)

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
