### PR TITLE
Attempt to use page language when formating release date

### DIFF
--- a/ui/component/dateTime/index.js
+++ b/ui/component/dateTime/index.js
@@ -7,6 +7,6 @@ import DateTime from './view';
 const select = (state, props) => ({
   date: props.date || selectDateForUri(state, props.uri),
   clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
-  appLanguage: selectLanguage(state)
+  appLanguage: selectLanguage(state),
 });
 export default connect(select)(DateTime);

--- a/ui/component/dateTime/index.js
+++ b/ui/component/dateTime/index.js
@@ -1,11 +1,12 @@
 import { connect } from 'react-redux';
 import { selectDateForUri } from 'redux/selectors/claims';
 import * as SETTINGS from 'constants/settings';
-import { selectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage } from 'redux/selectors/settings';
 import DateTime from './view';
 
 const select = (state, props) => ({
   date: props.date || selectDateForUri(state, props.uri),
   clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
+  language: selectLanguage(state)
 });
 export default connect(select)(DateTime);

--- a/ui/component/dateTime/index.js
+++ b/ui/component/dateTime/index.js
@@ -7,6 +7,6 @@ import DateTime from './view';
 const select = (state, props) => ({
   date: props.date || selectDateForUri(state, props.uri),
   clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
-  language: selectLanguage(state)
+  language: selectLanguage(state),
 });
 export default connect(select)(DateTime);

--- a/ui/component/dateTime/index.js
+++ b/ui/component/dateTime/index.js
@@ -7,6 +7,6 @@ import DateTime from './view';
 const select = (state, props) => ({
   date: props.date || selectDateForUri(state, props.uri),
   clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
-  language: selectLanguage(state),
+  appLanguage: selectLanguage(state)
 });
 export default connect(select)(DateTime);

--- a/ui/component/dateTime/view.jsx
+++ b/ui/component/dateTime/view.jsx
@@ -61,7 +61,7 @@ class DateTime extends React.Component<Props, State> {
   }
 
   render() {
-    const { clock24h, date, genericSeconds, showFutureDate, timeAgo, type, language, } = this.props;
+    const { clock24h, date, genericSeconds, showFutureDate, timeAgo, type, language } = this.props;
 
     const clockFormat = clock24h ? 'HH:mm' : 'hh:mm A';
     return (

--- a/ui/component/dateTime/view.jsx
+++ b/ui/component/dateTime/view.jsx
@@ -3,7 +3,6 @@ import { getTimeAgoStr } from 'util/time';
 import moment from 'moment/min/moment-with-locales';
 import React from 'react';
 
-
 const DEFAULT_MIN_UPDATE_DELTA_MS = 60 * 1000;
 
 type State = {
@@ -62,7 +61,7 @@ class DateTime extends React.Component<Props, State> {
   }
 
   render() {
-    const { clock24h, date, genericSeconds, showFutureDate, timeAgo, type, language } = this.props;
+    const { clock24h, date, genericSeconds, showFutureDate, timeAgo, type, language, } = this.props;
 
     const clockFormat = clock24h ? 'HH:mm' : 'hh:mm A';
     return (

--- a/ui/component/dateTime/view.jsx
+++ b/ui/component/dateTime/view.jsx
@@ -1,7 +1,8 @@
 // @flow
 import { getTimeAgoStr } from 'util/time';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 import React from 'react';
+
 
 const DEFAULT_MIN_UPDATE_DELTA_MS = 60 * 1000;
 
@@ -12,6 +13,7 @@ type State = {
 type Props = {
   clock24h?: boolean,
   date?: any,
+  language?: string,
   genericSeconds?: boolean,
   minUpdateDeltaMs?: number,
   showFutureDate?: boolean,
@@ -60,15 +62,15 @@ class DateTime extends React.Component<Props, State> {
   }
 
   render() {
-    const { clock24h, date, genericSeconds, showFutureDate, timeAgo, type } = this.props;
+    const { clock24h, date, genericSeconds, showFutureDate, timeAgo, type, language } = this.props;
 
     const clockFormat = clock24h ? 'HH:mm' : 'hh:mm A';
     return (
-      <span className="date_time" title={timeAgo && moment(date).format(`MMMM Do, YYYY ${clockFormat}`)}>
+      <span className="date_time" title={timeAgo && moment(date).format(`LL ${clockFormat}`)}>
         {date
           ? timeAgo
             ? getTimeAgoStr(date, showFutureDate, genericSeconds)
-            : moment(date).format(type === 'date' ? 'MMMM Do, YYYY' : clockFormat)
+            : moment(date).locale(language).format(type === 'date' ? 'LL' : clockFormat)
           : '...'}
       </span>
     );

--- a/ui/component/dateTime/view.jsx
+++ b/ui/component/dateTime/view.jsx
@@ -12,7 +12,7 @@ type State = {
 type Props = {
   clock24h?: boolean,
   date?: any,
-  language?: string,
+  appLanguage?: string,
   genericSeconds?: boolean,
   minUpdateDeltaMs?: number,
   showFutureDate?: boolean,
@@ -61,15 +61,15 @@ class DateTime extends React.Component<Props, State> {
   }
 
   render() {
-    const { clock24h, date, genericSeconds, showFutureDate, timeAgo, type, language } = this.props;
+    const { clock24h, date, genericSeconds, showFutureDate, timeAgo, type, appLanguage } = this.props;
 
     const clockFormat = clock24h ? 'HH:mm' : 'hh:mm A';
     return (
-      <span className="date_time" title={timeAgo && moment(date).format(`LL ${clockFormat}`)}>
+      <span className="date_time" title={timeAgo && moment(date).locale(appLanguage).format(`LL ${clockFormat}`)}>
         {date
           ? timeAgo
             ? getTimeAgoStr(date, showFutureDate, genericSeconds)
-            : moment(date).locale(language).format(type === 'date' ? 'LL' : clockFormat)
+            : moment(date).locale(appLanguage).format(type === 'date' ? 'LL' : clockFormat)
           : '...'}
       </span>
     );

--- a/ui/component/publish/livestream/publishLivestream/index.js
+++ b/ui/component/publish/livestream/publishLivestream/index.js
@@ -3,6 +3,7 @@ import { selectBalance } from 'redux/selectors/wallet';
 import { selectIsStillEditing, selectPublishFormValue } from 'redux/selectors/publish';
 import { doUpdatePublishForm } from 'redux/actions/publish';
 import { doToast } from 'redux/actions/notifications';
+import { selectLanguage } from 'redux/selectors/settings';
 import PublishLivestream from './view';
 
 const select = (state) => ({
@@ -15,6 +16,7 @@ const select = (state) => ({
   size: selectPublishFormValue(state, 'fileSize'),
   duration: selectPublishFormValue(state, 'fileDur'),
   isVid: selectPublishFormValue(state, 'fileVid'),
+  appLanguage: selectLanguage(state),
 });
 
 const perform = {

--- a/ui/component/publish/livestream/publishLivestream/view.jsx
+++ b/ui/component/publish/livestream/publishLivestream/view.jsx
@@ -10,7 +10,7 @@ import * as PUBLISH_MODES from 'constants/publish_types';
 import PublishName from '../../shared/publishName';
 import CopyableText from 'component/copyableText';
 import Empty from 'component/common/empty';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 import classnames from 'classnames';
 import ReactPaginate from 'react-paginate';
 import FileSelector from 'component/common/file-selector';
@@ -39,6 +39,7 @@ type Props = {
   size: number,
   duration: number,
   isVid: boolean,
+  appLanguage: string,
   doUpdatePublishForm: ({}) => void,
   doToast: ({ message: string, isError?: boolean }) => void,
 };
@@ -57,6 +58,7 @@ function PublishLivestream(props: Props) {
     size,
     duration,
     isVid,
+    appLanguage,
     disabled,
     livestreamData,
     isCheckingLivestreams,
@@ -431,7 +433,7 @@ function PublishLivestream(props: Props) {
                                                 : __('minutes')
                                             }`}
                                         <div className="table__item-label">
-                                          {`${moment(item.data.uploadedAt).from(moment())}`}
+                                          {`${moment(item.data.uploadedAt).locale(appLanguage).from(moment())}`}
                                         </div>
                                       </td>
                                       <td>

--- a/ui/component/rewardListClaimed/index.js
+++ b/ui/component/rewardListClaimed/index.js
@@ -1,9 +1,11 @@
 import { connect } from 'react-redux';
 import { selectClaimedRewards } from 'redux/selectors/rewards';
+import { selectLanguage } from 'redux/selectors/settings';
 import RewardListClaimed from './view';
 
 const select = state => ({
   rewards: selectClaimedRewards(state),
+  appLanguage: selectLanguage(state)
 });
 
 export default connect(select, null)(RewardListClaimed);

--- a/ui/component/rewardListClaimed/index.js
+++ b/ui/component/rewardListClaimed/index.js
@@ -5,7 +5,7 @@ import RewardListClaimed from './view';
 
 const select = state => ({
   rewards: selectClaimedRewards(state),
-  appLanguage: selectLanguage(state)
+  appLanguage: selectLanguage(state),
 });
 
 export default connect(select, null)(RewardListClaimed);

--- a/ui/component/rewardListClaimed/view.jsx
+++ b/ui/component/rewardListClaimed/view.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import ButtonTransaction from 'component/common/transaction-link';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 import LbcSymbol from 'component/common/lbc-symbol';
 import Card from 'component/common/card';
 
@@ -15,10 +15,11 @@ type Reward = {
 
 type Props = {
   rewards: Array<Reward>,
+  appLanguage: string,
 };
 
 const RewardListClaimed = (props: Props) => {
-  const { rewards } = props;
+  const { rewards, appLanguage } = props;
 
   if (!rewards || !rewards.length) {
     return null;
@@ -54,7 +55,7 @@ const RewardListClaimed = (props: Props) => {
                   <td>{reward.reward_title}</td>
                   <td>{reward.reward_amount}</td>
                   <td>{reward.transaction_id && <ButtonTransaction id={reward.transaction_id} />}</td>
-                  <td>{moment(reward.created_at).format('LLL')}</td>
+                  <td>{moment(reward.created_at).locale(appLanguage).format('LLL')}</td>
                 </tr>
               ))}
             </tbody>

--- a/ui/modal/modalPublishPreview/view.jsx
+++ b/ui/modal/modalPublishPreview/view.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 import classnames from 'classnames';
 
 import './style.scss';
@@ -305,7 +305,7 @@ const ModalPublishPreview = (props: Props) => {
       try {
         return new Date(time * 1000).toLocaleString(appLanguage);
       } catch {
-        return moment(new Date(time * 1000)).format('MMMM Do, YYYY - h:mm a');
+        return moment(new Date(time * 1000)).locale(appLanguage).format('LLL');
       }
     } else {
       return '';

--- a/ui/page/creatorMemberships/creatorArea/internal/supportersTab/index.js
+++ b/ui/page/creatorMemberships/creatorArea/internal/supportersTab/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
 import { selectMySupportersList, selectMembershipTiersForCreatorId } from 'redux/selectors/memberships';
 import { doResolveClaimIds } from 'redux/actions/claims';
+import { selectLanguage } from 'redux/selectors/settings';
 
 import SupportersTab from './view';
 
@@ -12,6 +13,7 @@ const select = (state) => {
   return {
     channelMembershipTiers: activeChannelClaim && selectMembershipTiersForCreatorId(state, activeChannelClaim.claim_id),
     supportersList: selectMySupportersList(state),
+    appLanguage: selectLanguage(state),
   };
 };
 

--- a/ui/page/creatorMemberships/creatorArea/internal/supportersTab/view.jsx
+++ b/ui/page/creatorMemberships/creatorArea/internal/supportersTab/view.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 
 import { buildURI } from 'util/lbryURI';
 
@@ -16,6 +16,7 @@ type Props = {
   // -- redux --
   supportersList: ?SupportersList,
   channelMembershipTiers: ?CreatorMemberships,
+  appLanguage: string,
   doResolveClaimIds: (claimIds: Array<string>) => void,
 };
 
@@ -26,6 +27,7 @@ const SupportersTab = (props: Props) => {
     // -- redux --
     supportersList,
     channelMembershipTiers,
+    appLanguage,
     doResolveClaimIds,
   } = props;
 
@@ -136,7 +138,7 @@ const SupportersTab = (props: Props) => {
                               </td>
                               <td>{supporter.MembershipName}</td>
                               <td>${supporter.Price / 100} USD / Month</td>
-                              <td>{moment(new Date(supporter.JoinedAtTime)).format('MMMM Do YYYY')}</td>
+                              <td>{moment(new Date(supporter.JoinedAtTime)).locale(appLanguage).format('LL')}</td>
                               <td>
                                 {Math.ceil(moment(new Date()).diff(new Date(supporter.JoinedAtTime), 'months', true))}
                               </td>

--- a/ui/page/listBlocked/index.js
+++ b/ui/page/listBlocked/index.js
@@ -14,6 +14,7 @@ import {
 } from 'redux/selectors/comments';
 import { selectMyChannelClaimIds } from 'redux/selectors/claims';
 import { doResolveClaimIds, doResolveUris } from 'redux/actions/claims';
+import { selectLanguage } from 'redux/selectors/settings';
 import ListBlocked from './view';
 
 const select = (state) => ({
@@ -28,6 +29,7 @@ const select = (state) => ({
   delegatorsById: selectModerationDelegatorsById(state),
   myChannelClaimIds: selectMyChannelClaimIds(state),
   fetchingModerationBlockList: selectFetchingModerationBlockList(state),
+  appLanguage: selectLanguage(state),
 });
 
 const perform = (dispatch) => ({

--- a/ui/page/listBlocked/view.jsx
+++ b/ui/page/listBlocked/view.jsx
@@ -3,7 +3,7 @@ import * as ICONS from 'constants/icons';
 import { BLOCK_LEVEL } from 'constants/comment';
 import React from 'react';
 import classnames from 'classnames';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 import humanizeDuration from 'humanize-duration';
 import BlockList from 'component/blockList';
 import ClaimPreview from 'component/claimPreview';
@@ -31,6 +31,7 @@ type Props = {
   moderatorTimeoutMap: { [uri: string]: { blockedAt: string, bannedFor: number, banRemaining: number } },
   moderatorBlockListDelegatorsMap: { [string]: Array<string> },
   fetchingModerationBlockList: boolean,
+  appLanguage: string,
   fetchModBlockedList: () => void,
   fetchModAmIList: () => void,
   delegatorsById: { [string]: { global: boolean, delegators: { name: string, claimId: string } } },
@@ -49,6 +50,7 @@ function ListBlocked(props: Props) {
     moderatorTimeoutMap,
     moderatorBlockListDelegatorsMap: delegatorsMap,
     fetchingModerationBlockList,
+    appLanguage,
     fetchModBlockedList,
     fetchModAmIList,
     delegatorsById,
@@ -98,7 +100,7 @@ function ListBlocked(props: Props) {
         <div>
           <div className="help">
             <blockquote>
-              {moment(timeoutInfo.blockedAt).format('MMMM Do, YYYY @ HH:mm')}
+              {moment(timeoutInfo.blockedAt).locale(appLanguage).format('LLL')}
               <br />
               {getDurationStr(timeoutInfo.bannedFor)}{' '}
               {__('(Remaining: %duration%) --[timeout ban duration]--', {

--- a/ui/page/wallet/walletFiatAccountHistory/index.js
+++ b/ui/page/wallet/walletFiatAccountHistory/index.js
@@ -1,3 +1,10 @@
+import { connect } from 'react-redux'
 import WalletFiatAccountHistory from './view';
+import { selectLanguage } from 'redux/selectors/settings';
 
-export default WalletFiatAccountHistory;
+const select = (state) => ({
+  appLanguage: selectLanguage(state),
+});
+
+
+export default connect(select)(WalletFiatAccountHistory);

--- a/ui/page/wallet/walletFiatAccountHistory/index.js
+++ b/ui/page/wallet/walletFiatAccountHistory/index.js
@@ -1,10 +1,9 @@
-import { connect } from 'react-redux'
+import { connect } from 'react-redux';
 import WalletFiatAccountHistory from './view';
 import { selectLanguage } from 'redux/selectors/settings';
 
 const select = (state) => ({
   appLanguage: selectLanguage(state),
 });
-
 
 export default connect(select)(WalletFiatAccountHistory);

--- a/ui/page/wallet/walletFiatAccountHistory/view.jsx
+++ b/ui/page/wallet/walletFiatAccountHistory/view.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import Button from 'component/button';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 import PAGES from 'constants/pages';
 import * as STRIPE from 'constants/stripe';
 import { toCapitalCase } from 'util/string';
@@ -9,9 +9,11 @@ import { toCapitalCase } from 'util/string';
 type Props = {
   transactions: StripeTransactions,
   transactionType: string,
+  appLanguage: string,
 };
 
 const WalletFiatAccountHistory = (props: Props) => {
+  const { appLanguage } = props;
   // receive transactions from parent component
   let { transactions: accountTransactions, transactionType } = props;
 
@@ -65,7 +67,7 @@ const WalletFiatAccountHistory = (props: Props) => {
 
               return (
                 <tr key={transaction.name + transaction.created_at}>
-                  <td>{moment(transaction.created_at).format('LLL')}</td>
+                  <td>{moment(transaction.created_at).locale(appLanguage).format('LLL')}</td>
                   <td>
                     <Button
                       navigate={'/' + transaction.channel_name + ':' + transaction.channel_claim_id}

--- a/ui/page/wallet/walletFiatPaymentHistory/index.js
+++ b/ui/page/wallet/walletFiatPaymentHistory/index.js
@@ -2,9 +2,11 @@ import { connect } from 'react-redux';
 import { doGetCustomerStatus } from 'redux/actions/stripe';
 import { selectLastFour } from 'redux/selectors/stripe';
 import WalletFiatPaymentHistory from './view';
+import { selectLanguage } from 'redux/selectors/settings';
 
 const select = (state) => ({
   lastFour: selectLastFour(state),
+  appLanguage: selectLanguage(state),
 });
 
 const perform = {

--- a/ui/page/wallet/walletFiatPaymentHistory/view.jsx
+++ b/ui/page/wallet/walletFiatPaymentHistory/view.jsx
@@ -1,20 +1,21 @@
 // @flow
 import React from 'react';
 import Button from 'component/button';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 import * as STRIPE from 'constants/stripe';
 import { toCapitalCase } from 'util/string';
 
 type Props = {
   transactions: StripeTransactions,
   lastFour: ?any,
+  appLanguage: string,
   doGetCustomerStatus: () => void,
   transactionType: string,
 };
 
 const WalletFiatPaymentHistory = (props: Props) => {
   // receive transactions from parent component
-  let { transactions: accountTransactions, lastFour, doGetCustomerStatus, transactionType } = props;
+  let { transactions: accountTransactions, lastFour, appLanguage, doGetCustomerStatus, transactionType } = props;
 
   const tipsBranch = transactionType === 'tips';
   const rentalsAndPurchasesBranch = transactionType === 'rentals-purchases';
@@ -63,7 +64,7 @@ const WalletFiatPaymentHistory = (props: Props) => {
                 accountTransactions.map((transaction) => (
                   <tr key={transaction.name + transaction.created_at}>
                     {/* date */}
-                    <td>{moment(transaction.created_at).format('LLL')}</td>
+                    <td>{moment(transaction.created_at).locale(appLanguage).format('LLL')}</td>
                     {/* receiving channel name */}
                     <td>
                       <Button


### PR DESCRIPTION
## Fixes
Release date always being in English despite the language setting.

## What is the current behavior?
Release date shown under the video is always in English

## What is the new behavior?
Release date under the video tries to get the format based on language.  
(Defaults to English when language doesn't match any locale in `moment`.)

## Other information
For English language using `LL` changes the format from: `December 7th, 2022` to `December 7, 2022`
But `MMMM Do, YYYY` doesn't work well with other languages

## Screenshot
Release date for German language new vs current
![release-date-comp](https://user-images.githubusercontent.com/34790748/211155399-ad6a6f7d-3855-4ed7-8b91-5fe85a6e68a6.png)


## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
