### PR TITLE
Attempt to make built-in playlist titles use translations

### DIFF
--- a/ui/component/fileWatchLaterLink/view.jsx
+++ b/ui/component/fileWatchLaterLink/view.jsx
@@ -4,7 +4,7 @@ import React, { useRef } from 'react';
 import Button from 'component/button';
 import useHover from 'effects/use-hover';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
-import { getLocalisedVersionForCollectionName } from 'util/collections'
+import { getLocalisedVersionForCollectionName } from 'util/collections';
 
 type Props = {
   uri: string,

--- a/ui/component/fileWatchLaterLink/view.jsx
+++ b/ui/component/fileWatchLaterLink/view.jsx
@@ -4,6 +4,7 @@ import React, { useRef } from 'react';
 import Button from 'component/button';
 import useHover from 'effects/use-hover';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
+import { getLocalisedVersionForCollectionName } from 'util/collections'
 
 type Props = {
   uri: string,
@@ -23,7 +24,7 @@ function FileWatchLaterLink(props: Props) {
 
     doPlaylistAddAndAllowPlaying({
       uri,
-      collectionName: COLLECTIONS_CONSTS.WATCH_LATER_NAME,
+      collectionName: getLocalisedVersionForCollectionName(COLLECTIONS_CONSTS.WATCH_LATER_NAME),
       collectionId: COLLECTIONS_CONSTS.WATCH_LATER_ID,
     });
   }

--- a/ui/component/playlistCard/index.js
+++ b/ui/component/playlistCard/index.js
@@ -12,6 +12,7 @@ import {
   selectCollectionForId,
   selectCollectionSavedForId,
   selectCollectionHasEditsForId,
+  selectIsCollectionBuiltInForId,
 } from 'redux/selectors/collections';
 import { selectPlayingUri } from 'redux/selectors/content';
 import { doCollectionEdit, doClearQueueList, doToggleCollectionSavedForId } from 'redux/actions/collections';
@@ -44,6 +45,7 @@ const select = (state, props) => {
     hasCollectionById: collectionId && Boolean(selectCollectionForId(state, collectionId)),
     playingCollectionId,
     collectionSavedForId: selectCollectionSavedForId(state, collectionId),
+    isBuiltin: selectIsCollectionBuiltInForId(state, collectionId),
   };
 };
 

--- a/ui/component/playlistCard/view.jsx
+++ b/ui/component/playlistCard/view.jsx
@@ -25,6 +25,7 @@ import usePersistedState from 'effects/use-persisted-state';
 import { HEADER_HEIGHT_MOBILE } from 'constants/player';
 import { getMaxLandscapeHeight } from 'util/window';
 import { useIsMobile, useIsMediumScreen } from 'effects/use-screensize';
+import { getLocalisedVersionForCollectionName } from 'util/collections';
 
 type Props = {
   id: ?string,
@@ -45,6 +46,7 @@ type Props = {
   isFloating?: boolean,
   playingCollectionId: ?string,
   collectionSavedForId: boolean,
+  isBuiltin: boolean,
   createUnpublishedCollection: (string, Array<any>, ?string) => void,
   doCollectionEdit: (string, CollectionEditParams) => void,
   doDisablePlayerDrag?: (disable: boolean) => void,
@@ -55,7 +57,7 @@ type Props = {
 };
 
 export default function PlaylistCard(props: Props) {
-  const { collectionName, useDrawer, hasCollectionById, playingItemIndex, collectionLength, collectionEmpty } = props;
+  const { collectionName, useDrawer, hasCollectionById, playingItemIndex, collectionLength, collectionEmpty, isBuiltin } = props;
 
   const [showEdit, setShowEdit] = React.useState(false);
 
@@ -64,6 +66,8 @@ export default function PlaylistCard(props: Props) {
   const currentIndexLabel = ` - ${Number.isInteger(playingItemIndex) ? playingItemIndex + 1 : 0}/${collectionLength} `;
   const playlistCardProps = { showEdit, setShowEdit, currentIndexLabel, ...props };
 
+  const usedCollectionName = isBuiltin ? getLocalisedVersionForCollectionName(collectionName) : collectionName;
+
   if (useDrawer) {
     return (
       <>
@@ -71,7 +75,7 @@ export default function PlaylistCard(props: Props) {
           fixed
           icon={ICONS.PLAYLIST_PLAYBACK}
           label={
-            __('Now playing: --[Which Playlist is currently playing]--') + ' ' + collectionName + currentIndexLabel
+            __('Now playing: --[Which Playlist is currently playing]--') + ' ' + usedCollectionName + currentIndexLabel
           }
           type={DRAWERS.PLAYLIST}
         />
@@ -133,6 +137,7 @@ const PlaylistCardComponent = (props: PlaylistCardProps) => {
     playingCurrentPlaylist,
     isFloating,
     playingCollectionId,
+    isBuiltin,
     doClearPlayingCollection,
     doOpenModal,
     doClearQueueList,
@@ -155,6 +160,8 @@ const PlaylistCardComponent = (props: PlaylistCardProps) => {
   const [bodyRef, setBodyRef] = React.useState();
   const [hasActive, setHasActive] = React.useState();
   const [scrolledPastActive, setScrolledPast] = React.useState();
+
+  const usedCollectionName = isBuiltin ? getLocalisedVersionForCollectionName(collectionName) : collectionName;
 
   function closePlaylist() {
     if (collectionEmpty) {
@@ -353,13 +360,13 @@ const PlaylistCardComponent = (props: PlaylistCardProps) => {
                 <>
                   <Icon icon={ICONS.PLAYLIST_PLAYBACK} size={40} />
                   <span className="text-ellipsis">
-                    {__('Now playing: --[Which Playlist is currently playing]--') + ' ' + collectionName}
+                    {__('Now playing: --[Which Playlist is currently playing]--') + ' ' + usedCollectionName}
                   </span>
                 </>
               ) : (
                 <>
                   <Icon icon={COLLECTIONS_CONSTS.PLAYLIST_ICONS[id] || ICONS.PLAYLIST} className="icon--margin-right" />
-                  <span className="text-ellipsis">{collectionName}</span>
+                  <span className="text-ellipsis">{usedCollectionName}</span>
                 </>
               )}
 

--- a/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/index.js
+++ b/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/index.js
@@ -1,5 +1,9 @@
 import { connect } from 'react-redux';
-import { selectCollectionForId, selectCollectionForIdHasClaimUrl } from 'redux/selectors/collections';
+import {
+  selectCollectionForId,
+  selectCollectionForIdHasClaimUrl,
+  selectIsCollectionBuiltInForId
+} from 'redux/selectors/collections';
 import { makeSelectClaimIsPending } from 'redux/selectors/claims';
 import { doPlaylistAddAndAllowPlaying } from 'redux/actions/content';
 import CollectionSelectItem from './view';
@@ -11,6 +15,7 @@ const select = (state, props) => {
     collection: selectCollectionForId(state, collectionId),
     collectionHasClaim: selectCollectionForIdHasClaimUrl(state, collectionId, uri),
     collectionPending: makeSelectClaimIsPending(collectionId)(state),
+    isBuiltin: selectIsCollectionBuiltInForId(state, collectionId),
   };
 };
 

--- a/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/index.js
+++ b/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import {
   selectCollectionForId,
   selectCollectionForIdHasClaimUrl,
-  selectIsCollectionBuiltInForId
+  selectIsCollectionBuiltInForId,
 } from 'redux/selectors/collections';
 import { makeSelectClaimIsPending } from 'redux/selectors/claims';
 import { doPlaylistAddAndAllowPlaying } from 'redux/actions/content';

--- a/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/view.jsx
+++ b/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/view.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { FormField } from 'component/common/form';
 import { COL_TYPES } from 'constants/collections';
-import { getLocalisedVersionForCollectionName } from 'util/collections'
+import { getLocalisedVersionForCollectionName } from 'util/collections';
 import Icon from 'component/common/icon';
 
 type Props = {

--- a/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/view.jsx
+++ b/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/view.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { FormField } from 'component/common/form';
 import { COL_TYPES } from 'constants/collections';
+import { getLocalisedVersionForCollectionName } from 'util/collections'
 import Icon from 'component/common/icon';
 
 type Props = {
@@ -11,12 +12,14 @@ type Props = {
   collection: Collection,
   collectionHasClaim: boolean,
   collectionPending: Collection,
+  isBuiltin: boolean,
   doPlaylistAddAndAllowPlaying: (params: { uri: string, collectionName: string, collectionId: string }) => void,
 };
 
 function CollectionSelectItem(props: Props) {
-  const { icon, uri, collection, collectionHasClaim, collectionPending, doPlaylistAddAndAllowPlaying } = props;
-  const { name, id } = collection || {};
+  const { icon, uri, collection, collectionHasClaim, collectionPending, isBuiltin, doPlaylistAddAndAllowPlaying } = props;
+  const name = isBuiltin ? getLocalisedVersionForCollectionName(collection.name) : collection.name;
+  const id = collection.id;
 
   const [checked, setChecked] = React.useState(collectionHasClaim);
 

--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/view.jsx
@@ -15,6 +15,7 @@ import ChannelThumbnail from 'component/channelThumbnail';
 import UriIndicator from 'component/uriIndicator';
 import DateTime from 'component/dateTime';
 import { formatLbryUrlForWeb, generateListSearchUrlParams } from 'util/url';
+import { getLocalisedVersionForCollectionName } from 'util/collections';
 import CollectionPreviewOverlay from 'component/collectionPreviewOverlay';
 import Button from 'component/button';
 import ClaimPreviewLoading from 'component/common/claim-preview-loading';
@@ -73,6 +74,7 @@ function CollectionPreview(props: Props) {
   const navigateUrl = `/$/${PAGES.PLAYLIST}/${collectionId}`;
   const firstItemPath = collectionItemUrls && formatLbryUrlForWeb(collectionItemUrls[0] || '/');
   const hidePlayAll = collectionType === COL_TYPES.FEATURED_CHANNELS || collectionType === COL_TYPES.CHANNELS;
+  const usedCollectionName = isBuiltin ? getLocalisedVersionForCollectionName(collectionName) : collectionName;
 
   function handleClick(e) {
     if (navigateUrl) {
@@ -110,7 +112,7 @@ function CollectionPreview(props: Props) {
         <NavLink {...navLinkProps}>
           <h2>
             {isBuiltin && <Icon icon={COLLECTIONS_CONSTS.PLAYLIST_ICONS[collectionId]} />}
-            <TruncatedText text={collectionName} lines={1} style={{ marginRight: 'var(--spacing-s)' }} />
+            <TruncatedText text={usedCollectionName} lines={1} style={{ marginRight: 'var(--spacing-s)' }} />
           </h2>
         </NavLink>
         {hasClaim && (

--- a/ui/util/collections.js
+++ b/ui/util/collections.js
@@ -111,7 +111,7 @@ export function getTitleForCollection(collection: ?Collection) {
   return collection.title || collection.name;
 }
 
-export function getLocalisedVersionForCollectionName(collectionName: ?string) {
+export function getLocalisedVersionForCollectionName(collectionName: string) {
   switch (collectionName) {
     case 'Watch Later':
       return __('Watch Later');

--- a/ui/util/collections.js
+++ b/ui/util/collections.js
@@ -110,3 +110,14 @@ export function getTitleForCollection(collection: ?Collection) {
 
   return collection.title || collection.name;
 }
+
+export function getLocalisedVersionForCollectionName(collectionName: ?string) {
+  switch (collectionName) {
+    case "Watch Later":
+      return __('Watch Later');
+    case "Favorites":
+      return __('Favorites');
+    default:
+      return collectionName;
+  }
+}

--- a/ui/util/collections.js
+++ b/ui/util/collections.js
@@ -113,9 +113,9 @@ export function getTitleForCollection(collection: ?Collection) {
 
 export function getLocalisedVersionForCollectionName(collectionName: ?string) {
   switch (collectionName) {
-    case "Watch Later":
+    case 'Watch Later':
       return __('Watch Later');
-    case "Favorites":
+    case 'Favorites':
       return __('Favorites');
     default:
       return collectionName;


### PR DESCRIPTION
## Fixes
Built-in playlist always show English name. (Except within the 3-dot menu in thumbnail)

## Behavior now
Changed built-in lists to use localized string in these places:
-title in playlistspage
-now playing <listname>
-notification from hovering "add to watch later"
-add to playlists modal