### PR TITLE
Attempt 2 to use translation for built-in playlist titles

### DIFF
--- a/ui/component/fileWatchLaterLink/view.jsx
+++ b/ui/component/fileWatchLaterLink/view.jsx
@@ -25,7 +25,7 @@ function FileWatchLaterLink(props: Props) {
     const collectionId = COLLECTIONS_CONSTS.WATCH_LATER_ID;
     doPlaylistAddAndAllowPlaying({
       uri,
-      collectionName: getLocalizedNameForCollectionId(collectionId),
+      collectionName: getLocalizedNameForCollectionId(collectionId) || COLLECTIONS_CONSTS.WATCH_LATER_NAME,
       collectionId,
     });
   }

--- a/ui/component/fileWatchLaterLink/view.jsx
+++ b/ui/component/fileWatchLaterLink/view.jsx
@@ -4,6 +4,7 @@ import React, { useRef } from 'react';
 import Button from 'component/button';
 import useHover from 'effects/use-hover';
 import * as COLLECTIONS_CONSTS from 'constants/collections';
+import { getLocalizedNameForCollectionId } from 'util/collections';
 
 type Props = {
   uri: string,
@@ -21,10 +22,11 @@ function FileWatchLaterLink(props: Props) {
   function handleWatchLater(e) {
     if (e) e.preventDefault();
 
+    const collectionId = COLLECTIONS_CONSTS.WATCH_LATER_ID;
     doPlaylistAddAndAllowPlaying({
       uri,
-      collectionName: COLLECTIONS_CONSTS.WATCH_LATER_NAME,
-      collectionId: COLLECTIONS_CONSTS.WATCH_LATER_ID,
+      collectionName: getLocalizedNameForCollectionId(collectionId),
+      collectionId,
     });
   }
 

--- a/ui/component/playlistCard/index.js
+++ b/ui/component/playlistCard/index.js
@@ -30,6 +30,7 @@ const select = (state, props) => {
   const { permanent_url: playingItemUrl } = playingCurrentPlaylist ? selectClaimForUri(state, playingUri) || {} : {};
 
   return {
+    id: collectionId,
     playingItemUrl,
     playingCurrentPlaylist,
     collectionUrls: selectUrlsForCollectionId(state, collectionId),

--- a/ui/component/playlistCard/view.jsx
+++ b/ui/component/playlistCard/view.jsx
@@ -25,9 +25,10 @@ import usePersistedState from 'effects/use-persisted-state';
 import { HEADER_HEIGHT_MOBILE } from 'constants/player';
 import { getMaxLandscapeHeight } from 'util/window';
 import { useIsMobile, useIsMediumScreen } from 'effects/use-screensize';
+import { getLocalizedNameForCollectionId } from 'util/collections';
 
 type Props = {
-  id: ?string,
+  id: string,
   playingItemUrl: string,
   playingCurrentPlaylist: boolean,
   isMyCollection: boolean,
@@ -55,8 +56,9 @@ type Props = {
 };
 
 export default function PlaylistCard(props: Props) {
-  const { collectionName, useDrawer, hasCollectionById, playingItemIndex, collectionLength, collectionEmpty } = props;
+  const { collectionName, useDrawer, hasCollectionById, playingItemIndex, collectionLength, collectionEmpty, id } = props;
 
+  const usedCollectionName = getLocalizedNameForCollectionId(id) || collectionName;
   const [showEdit, setShowEdit] = React.useState(false);
 
   if (!hasCollectionById) return null;
@@ -71,7 +73,7 @@ export default function PlaylistCard(props: Props) {
           fixed
           icon={ICONS.PLAYLIST_PLAYBACK}
           label={
-            __('Now playing: --[Which Playlist is currently playing]--') + ' ' + collectionName + currentIndexLabel
+            __('Now playing: --[Which Playlist is currently playing]--') + ' ' + usedCollectionName + currentIndexLabel
           }
           type={DRAWERS.PLAYLIST}
         />
@@ -143,6 +145,8 @@ const PlaylistCardComponent = (props: PlaylistCardProps) => {
 
   const isMobile = useIsMobile();
   const isMediumScreen = useIsMediumScreen() && !isMobile;
+
+  const usedCollectionName = getLocalizedNameForCollectionId(id) || collectionName;
 
   const activeItemRef = React.useRef();
   const scrollRestorePending = React.useRef();
@@ -353,13 +357,13 @@ const PlaylistCardComponent = (props: PlaylistCardProps) => {
                 <>
                   <Icon icon={ICONS.PLAYLIST_PLAYBACK} size={40} />
                   <span className="text-ellipsis">
-                    {__('Now playing: --[Which Playlist is currently playing]--') + ' ' + collectionName}
+                    {__('Now playing: --[Which Playlist is currently playing]--') + ' ' + usedCollectionName}
                   </span>
                 </>
               ) : (
                 <>
                   <Icon icon={COLLECTIONS_CONSTS.PLAYLIST_ICONS[id] || ICONS.PLAYLIST} className="icon--margin-right" />
-                  <span className="text-ellipsis">{collectionName}</span>
+                  <span className="text-ellipsis">{usedCollectionName}</span>
                 </>
               )}
 

--- a/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/view.jsx
+++ b/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/view.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { FormField } from 'component/common/form';
 import { COL_TYPES } from 'constants/collections';
+import { getLocalizedNameForCollectionId } from 'util/collections';
 import Icon from 'component/common/icon';
 
 type Props = {
@@ -16,7 +17,8 @@ type Props = {
 
 function CollectionSelectItem(props: Props) {
   const { icon, uri, collection, collectionHasClaim, collectionPending, doPlaylistAddAndAllowPlaying } = props;
-  const { name, id } = collection || {};
+  const id = collection.id;
+  const name = getLocalizedNameForCollectionId(id) || collection.name;
 
   const [checked, setChecked] = React.useState(collectionHasClaim);
 

--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/view.jsx
@@ -15,6 +15,7 @@ import ChannelThumbnail from 'component/channelThumbnail';
 import UriIndicator from 'component/uriIndicator';
 import DateTime from 'component/dateTime';
 import { formatLbryUrlForWeb, generateListSearchUrlParams } from 'util/url';
+import { getLocalizedNameForCollectionId } from 'util/collections';
 import CollectionPreviewOverlay from 'component/collectionPreviewOverlay';
 import Button from 'component/button';
 import ClaimPreviewLoading from 'component/common/claim-preview-loading';
@@ -73,6 +74,7 @@ function CollectionPreview(props: Props) {
   const navigateUrl = `/$/${PAGES.PLAYLIST}/${collectionId}`;
   const firstItemPath = collectionItemUrls && formatLbryUrlForWeb(collectionItemUrls[0] || '/');
   const hidePlayAll = collectionType === COL_TYPES.FEATURED_CHANNELS || collectionType === COL_TYPES.CHANNELS;
+  const usedCollectionName = getLocalizedNameForCollectionId(collectionId) || collectionName;
 
   function handleClick(e) {
     if (navigateUrl) {
@@ -110,7 +112,7 @@ function CollectionPreview(props: Props) {
         <NavLink {...navLinkProps}>
           <h2>
             {isBuiltin && <Icon icon={COLLECTIONS_CONSTS.PLAYLIST_ICONS[collectionId]} />}
-            <TruncatedText text={collectionName} lines={1} style={{ marginRight: 'var(--spacing-s)' }} />
+            <TruncatedText text={usedCollectionName} lines={1} style={{ marginRight: 'var(--spacing-s)' }} />
           </h2>
         </NavLink>
         {hasClaim && (

--- a/ui/util/collections.js
+++ b/ui/util/collections.js
@@ -4,7 +4,7 @@ import {
   SECTION_TAGS,
   WATCH_LATER_ID,
   FAVORITES_ID,
-  QUEUE_ID
+  QUEUE_ID,
 } from 'constants/collections';
 import { getCurrentTimeInSec } from 'util/time';
 

--- a/ui/util/collections.js
+++ b/ui/util/collections.js
@@ -1,5 +1,11 @@
 // @flow
-import { COL_TYPES, SECTION_TAGS } from 'constants/collections';
+import {
+  COL_TYPES,
+  SECTION_TAGS,
+  WATCH_LATER_ID,
+  FAVORITES_ID,
+  QUEUE_ID
+} from 'constants/collections';
 import { getCurrentTimeInSec } from 'util/time';
 
 export const defaultCollectionState: Collection = {
@@ -109,4 +115,17 @@ export function getTitleForCollection(collection: ?Collection) {
   if (!collection) return collection;
 
   return collection.title || collection.name;
+}
+
+export function getLocalizedNameForCollectionId(collectionId: string) {
+  switch (collectionId) {
+    case WATCH_LATER_ID:
+      return __('Watch Later');
+    case FAVORITES_ID:
+      return __('Favorites');
+    case QUEUE_ID:
+      return __('Queue');
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
## Fixes
Built-in playlist always show English name. (Except within the 3-dot menu in thumbnail)

## Behavior now
Changed built-in lists to use localized string in these places:
-title in playlistspage
-now playing <listname>
-notification from hovering "add to watch later"
-add to playlists modal