### PR TITLE
Attempt to make DateTimePicker use app language + handle 24h clock on livestream page

### DIFF
--- a/ui/component/publish/shared/publishReleaseDate/index.js
+++ b/ui/component/publish/shared/publishReleaseDate/index.js
@@ -2,13 +2,14 @@ import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { selectPublishFormValue } from 'redux/selectors/publish';
 import { doUpdatePublishForm } from 'redux/actions/publish';
-import { selectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting, selectLanguage } from 'redux/selectors/settings';
 import PublishReleaseDate from './view';
 
 const select = (state) => ({
   releaseTime: selectPublishFormValue(state, 'releaseTime'),
   releaseTimeEdited: selectPublishFormValue(state, 'releaseTimeEdited'),
   clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
+  appLanguage: selectLanguage(state),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/publish/shared/publishReleaseDate/view.jsx
+++ b/ui/component/publish/shared/publishReleaseDate/view.jsx
@@ -24,6 +24,7 @@ type Props = {
   releaseTime: ?number,
   releaseTimeEdited: ?number,
   clock24h: boolean,
+  appLanguage: ?string,
   updatePublishForm: ({}) => void,
 };
 
@@ -32,6 +33,7 @@ const PublishReleaseDate = (props: Props) => {
     releaseTime,
     releaseTimeEdited,
     clock24h,
+    appLanguage,
     updatePublishForm,
     allowDefault = true,
     showNowBtn = true,
@@ -153,6 +155,7 @@ const PublishReleaseDate = (props: Props) => {
       <div className="form-field-date-picker__controls">
         {showDatePicker && (
           <DateTimePicker
+            locale={appLanguage}
             className="date-picker-input"
             calendarClassName="form-field-calendar"
             onBlur={handleBlur}

--- a/ui/component/publish/shared/publishStreamReleaseDate/index.js
+++ b/ui/component/publish/shared/publishStreamReleaseDate/index.js
@@ -1,11 +1,15 @@
 import { connect } from 'react-redux';
+import * as SETTINGS from 'constants/settings';
 import { selectPublishFormValue, selectIsScheduled } from 'redux/selectors/publish';
 import { doUpdatePublishForm } from 'redux/actions/publish';
+import { selectClientSetting, selectLanguage } from 'redux/selectors/settings';
 import PublishStreamReleaseDate from './view';
 
 const select = (state) => ({
   isScheduled: selectIsScheduled(state),
   releaseTime: selectPublishFormValue(state, 'releaseTime'),
+  clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
+  appLanguage: selectLanguage(state),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/publish/shared/publishStreamReleaseDate/view.jsx
+++ b/ui/component/publish/shared/publishStreamReleaseDate/view.jsx
@@ -15,10 +15,12 @@ function dateToLinuxTimestamp(date: Date) {
 type Props = {
   isScheduled: boolean,
   releaseTime: ?number,
+  clock24h: boolean,
+  appLanguage: ?string,
   updatePublishForm: ({}) => void,
 };
 const PublishStreamReleaseDate = (props: Props) => {
-  const { isScheduled, releaseTime, updatePublishForm } = props;
+  const { isScheduled, releaseTime, clock24h, appLanguage, updatePublishForm } = props;
 
   const [date, setDate] = React.useState(releaseTime ? linuxTimestampToDate(releaseTime) : 'DEFAULT');
   const [publishLater, setPublishLater] = React.useState(isScheduled);
@@ -83,11 +85,12 @@ const PublishStreamReleaseDate = (props: Props) => {
           {publishLater && (
             <div className="form-field-date-picker mb-0 controls md:ml-m">
               <DateTimePicker
+                locale={appLanguage}
                 className="date-picker-input w-full md:w-auto mt-s md:mt-0"
                 calendarClassName="form-field-calendar"
                 onChange={onDateTimePickerChanged}
                 value={date}
-                format="y-MM-dd h:mm a"
+                format={clock24h ? 'y-MM-dd HH:mm' : 'y-MM-dd h:mm a'}
                 disableClock
                 clearIcon={null}
                 minDate={moment().add('30', 'minutes').toDate()}


### PR DESCRIPTION
-DateTimePicker defaulted to browser's language. (Could be different from page language)
Now uses language set on page.

-DateTimePicker on Go Live page didn't handle 24h clock format.
Now it does.  

Note: `null` and random string as a locale defaults to English.