### PR TITLE
Make support texts more translatable + tip text change?

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2960,6 +2960,7 @@
   "Boost your repost": "Boost your repost",
   "Boost your playlist": "Boost your playlist",
   "Boost your claim": "Boost your claim",
+  "Leave a tip for the creator": "Leave a tip for the creator",
 
   "--end--": "--end--"
 }

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2961,6 +2961,7 @@
   "Boost your playlist": "Boost your playlist",
   "Boost your claim": "Boost your claim",
   "Leave a tip for the creator": "Leave a tip for the creator",
+  "Show this creator your appreciation by sending a donation.": "Show this creator your appreciation by sending a donation.",
 
   "--end--": "--end--"
 }

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2945,6 +2945,21 @@
   "Local Setup": "Local Setup",
   "YOUTUBE SYNCED CHANNELS!": "YOUTUBE SYNCED CHANNELS!",
   "If something went wrong with the sync, please don't try to fix it by deleting the channel. Instead reach out to us at help@odysee.com to get it fixed. Once deleted we may not be able to sync it again or fix it.": "If something went wrong with the sync, please don't try to fix it by deleting the channel. Instead reach out to us at help@odysee.com to get it fixed. Once deleted we may not be able to sync it again or fix it.",
+  "This refundable boost will improve the discoverability of this content while active.": "This refundable boost will improve the discoverability of this content while active.",
+  "This refundable boost will improve the discoverability of this channel while active.": "This refundable boost will improve the discoverability of this channel while active.",
+  "This refundable boost will improve the discoverability of this repost while active.": "This refundable boost will improve the discoverability of this repost while active.",
+  "This refundable boost will improve the discoverability of this playlist while active.": "This refundable boost will improve the discoverability of this playlist while active.",
+  "This refundable boost will improve the discoverability of this claim while active.": "This refundable boost will improve the discoverability of this claim while active.",
+  "Boost this content": "Boost this content",
+  "Boost this channel": "Boost this channel",
+  "Boost this repost": "Boost this repost",
+  "Boost this playlist": "Boost this playlist",
+  "Boost this claim": "Boost this claim",
+  "Boost your content": "Boost your content",
+  "Boost your channel": "Boost your channel",
+  "Boost your repost": "Boost your repost",
+  "Boost your playlist": "Boost your playlist",
+  "Boost your claim": "Boost your claim",
 
   "--end--": "--end--"
 }

--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -117,7 +117,7 @@ export default function WalletSendTip(props: Props) {
 
   // text for modal header
   const titleText = isSupport
-    ? __(claimIsMine ? boostYourContentText : boostThisContentText)
+    ? (claimIsMine ? boostYourContentText : boostThisContentText)
     : __('Leave a tip for the creator');
 
   let channelName;

--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -109,15 +109,16 @@ export default function WalletSendTip(props: Props) {
   const [disableSubmitButton, setDisableSubmitButton] = React.useState();
 
   /** CONSTS **/
-  const claimTypeText = getClaimTypeText();
+  const boostThisContentText = getBoostThisContentText();
+  const boostYourContentText = getBoostYourContentText();
   const isSupport = claimIsMine || activeTab === TAB_BOOST;
 
   const { icon: fiatIconToUse, symbol: fiatSymbolToUse } = STRIPE.CURRENCY[preferredCurrency];
 
   // text for modal header
   const titleText = isSupport
-    ? __(claimIsMine ? 'Boost Your %claimTypeText%' : 'Boost This %claimTypeText%', { claimTypeText })
-    : __('Tip This %claimTypeText%', { claimTypeText });
+    ? __(claimIsMine ? boostYourContentText : boostThisContentText)
+    : __('Leave a tip for the creator');
 
   let channelName;
   try {
@@ -128,31 +129,58 @@ export default function WalletSendTip(props: Props) {
   let explainerText = '';
   switch (activeTab) {
     case TAB_BOOST:
-      explainerText = __(
-        'This refundable boost will improve the discoverability of this %claimTypeText% while active.',
-        { claimTypeText }
-      );
+      explainerText = getBoostExplainerText();
       break;
     case TAB_FIAT:
     case TAB_LBC:
-      explainerText = __('Show this channel your appreciation by sending a donation.');
+      explainerText = __('Show this creator your appreciation by sending a donation.');
       break;
   }
 
   /** FUNCTIONS **/
 
-  function getClaimTypeText() {
+  function getBoostExplainerText() {
     switch (claimType) {
       case 'stream':
-        return __('Content');
+        return __('This refundable boost will improve the discoverability of this content while active.');
       case 'channel':
-        return __('Channel');
+        return __('This refundable boost will improve the discoverability of this channel while active.');
       case 'repost':
-        return __('Repost');
+        return __('This refundable boost will improve the discoverability of this repost while active.');
       case 'collection':
-        return __('List');
+        return __('This refundable boost will improve the discoverability of this playlist while active.');
       default:
-        return __('Claim');
+        return __('This refundable boost will improve the discoverability of this claim while active.');
+    }
+  }
+
+  function getBoostThisContentText() {
+    switch (claimType) {
+      case 'stream':
+        return __('Boost this content');
+      case 'channel':
+        return __('Boost this channel');
+      case 'repost':
+        return __('Boost this repost');
+      case 'collection':
+        return __('Boost this playlist');
+      default:
+        return __('Boost this claim');
+    }
+  }
+
+  function getBoostYourContentText() {
+    switch (claimType) {
+      case 'stream':
+        return __('Boost your content');
+      case 'channel':
+        return __('Boost your channel');
+      case 'repost':
+        return __('Boost your repost');
+      case 'collection':
+        return __('Boost your playlist');
+      default:
+        return __('Boost your claim');
     }
   }
 


### PR DESCRIPTION
The old strings weren't translatable in all languages(like Finnish). `claimTypeText` translates to different word depending of the context.   
Made separate phrase in each situation for each claim type.   

Also changed "Tip this %claimType%" to "Leave tip for the creator". (Sounds better?)

![leave-a-tip](https://user-images.githubusercontent.com/34790748/213894407-2c8d385d-8ee7-44c8-b015-e42b5ea7d453.png)
)