### PR TITLE
Fix attempt - show amount of reposts on file page

### DIFF
--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -1042,7 +1042,7 @@ export const selectGeoRestrictionForUri = createCachedSelector(
 )((state, uri) => String(uri));
 
 export const selectClaimRepostedAmountForUri = (state: State, uri: string) => {
-  const claim = selectClaimForUri(state);
+  const claim = selectClaimForUri(state, uri);
   return getClaimRepostedAmount(claim);
 };
 


### PR DESCRIPTION
`uri` was forgotten to pass in`selectClaimForUri`.

Now the repost count shows with the repost button