### PR TITLE
Fix attempt - remove collection from updatedCollections on edit

### DIFF
--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -512,6 +512,8 @@ export const doCollectionEdit = (collectionId: string, params: CollectionEditPar
     currentUrls.splice(order.to, 0, movedItem);
   }
 
+  await dispatch(doRemoveFromeUpdatedCollectionsForCollectionId(collectionId))
+
   const isQueue = collectionId === COLS.QUEUE_ID;
   const title = params.title || params.name;
 
@@ -537,6 +539,10 @@ export const doCollectionEdit = (collectionId: string, params: CollectionEditPar
 export const doClearEditsForCollectionId = (id: String) => (dispatch: Dispatch) => {
   dispatch({ type: ACTIONS.COLLECTION_DELETE, data: { id, collectionKey: 'edited' } });
   dispatch({ type: ACTIONS.COLLECTION_EDIT, data: { collectionKey: COLS.KEYS.UPDATED, collection: { id } } });
+};
+
+export const doRemoveFromeUpdatedCollectionsForCollectionId = (id: String) => (dispatch: Dispatch) => {
+  dispatch({ type: ACTIONS.COLLECTION_DELETE, data: { id, collectionKey: 'updated' } });
 };
 
 export const doClearQueueList = () => (dispatch: Dispatch, getState: GetState) =>

--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -541,7 +541,7 @@ export const doClearEditsForCollectionId = (id: String) => (dispatch: Dispatch) 
   dispatch({ type: ACTIONS.COLLECTION_EDIT, data: { collectionKey: COLS.KEYS.UPDATED, collection: { id } } });
 };
 
-export const doRemoveFromUpdatedCollectionsForCollectionId = (id: String) => (dispatch: Dispatch) => {
+export const doRemoveFromUpdatedCollectionsForCollectionId = (id: string) => (dispatch: Dispatch) => {
   dispatch({ type: ACTIONS.COLLECTION_DELETE, data: { id, collectionKey: 'updated' } });
 };
 

--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -512,7 +512,7 @@ export const doCollectionEdit = (collectionId: string, params: CollectionEditPar
     currentUrls.splice(order.to, 0, movedItem);
   }
 
-  await dispatch(doRemoveFromeUpdatedCollectionsForCollectionId(collectionId))
+  await dispatch(doRemoveFromUpdatedCollectionsForCollectionId(collectionId))
 
   const isQueue = collectionId === COLS.QUEUE_ID;
   const title = params.title || params.name;
@@ -541,7 +541,7 @@ export const doClearEditsForCollectionId = (id: String) => (dispatch: Dispatch) 
   dispatch({ type: ACTIONS.COLLECTION_EDIT, data: { collectionKey: COLS.KEYS.UPDATED, collection: { id } } });
 };
 
-export const doRemoveFromeUpdatedCollectionsForCollectionId = (id: String) => (dispatch: Dispatch) => {
+export const doRemoveFromUpdatedCollectionsForCollectionId = (id: String) => (dispatch: Dispatch) => {
   dispatch({ type: ACTIONS.COLLECTION_DELETE, data: { id, collectionKey: 'updated' } });
 };
 

--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -512,7 +512,7 @@ export const doCollectionEdit = (collectionId: string, params: CollectionEditPar
     currentUrls.splice(order.to, 0, movedItem);
   }
 
-  await dispatch(doRemoveFromUpdatedCollectionsForCollectionId(collectionId))
+  await dispatch(doRemoveFromUpdatedCollectionsForCollectionId(collectionId));
 
   const isQueue = collectionId === COLS.QUEUE_ID;
   const title = params.title || params.name;

--- a/ui/redux/reducers/collections.js
+++ b/ui/redux/reducers/collections.js
@@ -99,7 +99,7 @@ const collectionsReducer = handleActions(
       const { id, collectionKey } = action.data;
 
       const collectionsByIdForKey = Object.assign({}, state[collectionKey]);
-      delete collectionsByIdForKey[id];
+      if (collectionsByIdForKey[id]) delete collectionsByIdForKey[id];
 
       return {
         ...state,


### PR DESCRIPTION
**Old behavior:**
If there is an entry in updatedCollection, updatedAt time of the edited list in the editedCollections list will revert to that on http://odysee.com/$/playlists page.

Steps to see the issue:
1. Have collection that's in updatedCollections
2. Edit it
3. Go to http://odysee.com/$/playlists 
4. UpdatedAt time shows the old updatedAt time from updatedCollections.
(5.) Next prefrence_set will also change the updatedAt of the list in the  editedCollections to the older time

**New behavior:**
When collection is edited, it gets removed from updatedCollections, so above can't happen. 