### PR TITLE
Add `resolve:true` to collection_list

### DIFF
--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -36,7 +36,7 @@ import { doToast } from 'redux/actions/notifications';
 
 const FETCH_BATCH_SIZE = 50;
 
-export const doFetchCollectionListMine = (options: CollectionListOptions = { page: 1, page_size: 50 }) => async (
+export const doFetchCollectionListMine = (options: CollectionListOptions = { resolve: true, page: 1, page_size: 50 }) => async (
   dispatch: Dispatch
 ) => {
   dispatch({ type: ACTIONS.COLLECTION_LIST_MINE_STARTED });


### PR DESCRIPTION
## Fixes

`claim.meta` won't be empty in collection_list call, and all public collections will have a "Created At" time. 
