### PR TITLE
Fix edit buttons for first collection in list

### DIFF
--- a/ui/component/collectionEditButtons/view.jsx
+++ b/ui/component/collectionEditButtons/view.jsx
@@ -37,7 +37,7 @@ export default function CollectionButtons(props: Props) {
     : !altCollection
     ? 0
     : altCollection.length - 1;
-  const collectionIndex = Number(foundIndex) || Number(altIndex);
+  const collectionIndex = Number(altIndex) || Number(foundIndex);
 
   function handleOnClick(change) {
     if (!altCollection) {


### PR DESCRIPTION
## Fixes

Issue Number: #2520 

Changing order makes `collectionIndex` to be `0`, instead of `NaN` for first item, when `altIndex` isn't defined