### PR TITLE
Fix attempt - channel update without thumbnailUrl

### DIFF
--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -626,6 +626,13 @@ export function doUpdateChannel(params: any, cb: any) {
       featured: params.featured || [],
     };
 
+    // Remove params with null values
+    for (const [k, v] of Object.entries(updateParams)) {
+      if (v == null) {
+        delete updateParams[k]
+      }
+    }
+
     if (params.tags) {
       updateParams.tags = params.tags.map((tag) => tag.name);
     }

--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -629,7 +629,7 @@ export function doUpdateChannel(params: any, cb: any) {
     // Remove params with null values
     for (const [k, v] of Object.entries(updateParams)) {
       if (v == null) {
-        delete updateParams[k]
+        delete updateParams[k];
       }
     }
 


### PR DESCRIPTION
## Fixes

Issue Number: #2518 

SDK channel_update gives error for `null`  values , so remove params with those before sending.