### PR TITLE
Home page fix attempt (too much playlist items shown? + playlists section overlapping on edit )

### DIFF
--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/homeTabSection/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/homeTabSection/view.jsx
@@ -68,6 +68,7 @@ function HomeTabSection(props: Props) {
   const shouldPerformSearch =
     !singleClaimUri && !fetchingClaimSearch && !timedOut && !claimSearchResults && !collectionUrls && section;
   const publishedList = (Object.keys(publishedCollections || {}): any);
+  const maxClaimsInSection = 12;
 
   const windowSize = useWindowSize();
   const maxTilesPerRow = windowSize >= 1600 ? 6 : windowSize > 1150 ? 4 : windowSize > 900 ? 3 : 2;
@@ -370,6 +371,7 @@ function HomeTabSection(props: Props) {
                     infiniteScroll={false}
                     useSkeletonScreen={false}
                     uris={collectionUrls || claimSearchResults}
+                    maxClaimRender={maxClaimsInSection}
                     claimIds={collectionClaimIds}
                     fetchViewCount
                     injectedItem={

--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/homeTabSection/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/homeTabSection/view.jsx
@@ -68,7 +68,7 @@ function HomeTabSection(props: Props) {
   const shouldPerformSearch =
     !singleClaimUri && !fetchingClaimSearch && !timedOut && !claimSearchResults && !collectionUrls && section;
   const publishedList = (Object.keys(publishedCollections || {}): any);
-  const maxClaimsInSection = collectionUrls ? 6 : 12;
+  const maxClaimsInSection = 12;
 
   const windowSize = useWindowSize();
   const maxTilesPerRow = windowSize >= 1600 ? 6 : windowSize > 1150 ? 4 : windowSize > 900 ? 3 : 2;

--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/homeTabSection/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/homeTabSection/view.jsx
@@ -68,7 +68,7 @@ function HomeTabSection(props: Props) {
   const shouldPerformSearch =
     !singleClaimUri && !fetchingClaimSearch && !timedOut && !claimSearchResults && !collectionUrls && section;
   const publishedList = (Object.keys(publishedCollections || {}): any);
-  const maxClaimsInSection = 12;
+  const maxClaimsInSection = collectionUrls ? 6 : 12;
 
   const windowSize = useWindowSize();
   const maxTilesPerRow = windowSize >= 1600 ? 6 : windowSize > 1150 ? 4 : windowSize > 900 ? 3 : 2;

--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/style.scss
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/style.scss
@@ -233,13 +233,24 @@
   }
   .home-section-wrapper--edit-playlist {
     @media (min-width: $breakpoint-small) {
-      max-height: 576px;
+      max-height: 960px;
     }
     @media (min-width: $breakpoint-medium) {
-      max-height: 574px;
+      max-height: 758px;
     }
     @media (min-width: $breakpoint-large) {
-      max-height: 350px;
+      max-height: 520px;
+    }
+  }
+  .home-section-wrapper--edit-playlists {
+    @media (min-width: $breakpoint-small) {
+      max-height: 960px;
+    }
+    @media (min-width: $breakpoint-medium) {
+      max-height: 758px;
+    }
+    @media (min-width: $breakpoint-large) {
+      max-height: 520px;
     }
   }
   .home-section-wrapper--edit-onerow {

--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/view.jsx
@@ -152,7 +152,7 @@ function HomeTab(props: Props) {
                   'home-section-wrapper--edit-content': edit && section?.type === 'content',
                   'home-section-wrapper--edit-playlist': edit && section?.type === 'playlist',
                   'home-section-wrapper--edit-onerow':
-                    edit && section?.type !== 'content' && section?.type !== 'featured' && section?.type !== 'playlist',
+                    edit && section?.type !== 'content' && section?.type !== 'featured' && section?.type !== 'playlist' && section?.type !== 'playlists',
                 })}
               >
                 <div className="order">

--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/view.jsx
@@ -151,6 +151,7 @@ function HomeTab(props: Props) {
                   'home-section-wrapper--edit-featured': edit && section?.type === 'featured',
                   'home-section-wrapper--edit-content': edit && section?.type === 'content',
                   'home-section-wrapper--edit-playlist': edit && section?.type === 'playlist',
+                  'home-section-wrapper--edit-playlists': edit && section?.type === 'playlists',
                   'home-section-wrapper--edit-onerow':
                     edit && section?.type !== 'content' && section?.type !== 'featured' && section?.type !== 'playlist' && section?.type !== 'playlists',
                 })}


### PR DESCRIPTION
Old looks like this:  
![old-homepage](https://user-images.githubusercontent.com/34790748/216345756-7d07634b-cc9f-43ab-b71c-f7c754649b7c.png)  

Now should look like this(edit still bit off, but less bad?):  
![new-homepage](https://user-images.githubusercontent.com/34790748/216347542-ddf87aa6-b7e1-4740-be65-65ca9d845f61.png)

https://odysee.com/@a:f1