### PR TITLE
Fix attempt - show lists which have deleted items in lower indexes in  playlists + delete unused function?

### DIFF
--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/index.js
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/index.js
@@ -6,7 +6,6 @@ import {
   selectClaimForClaimId,
 } from 'redux/selectors/claims';
 import {
-  selectThumbnailClaimUrisForCollectionId,
   selectCollectionTitleForId,
   selectCountForCollectionId,
   selectAreCollectionItemsFetchingForId,
@@ -42,7 +41,6 @@ const select = (state, props) => {
     uri: collectionUri,
     collectionCount: selectCountForCollectionId(state, collectionId),
     collectionName: selectCollectionTitleForId(state, collectionId),
-    collectionItemUrls: selectThumbnailClaimUrisForCollectionId(state, collectionId), // ForId || ForUri
     collectionType: selectCollectionTypeForId(state, collectionId),
     isFetchingItems: selectAreCollectionItemsFetchingForId(state, collectionId),
     isResolvingCollection: selectIsResolvingForId(state, collectionId),

--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionPreview/view.jsx
@@ -28,7 +28,6 @@ type Props = {
   // -- redux --
   collectionCount: number,
   collectionName: string,
-  collectionItemUrls: ?Array<string>,
   collectionType: ?string,
   isFetchingItems: boolean,
   isResolvingCollection: boolean,
@@ -52,7 +51,6 @@ function CollectionPreview(props: Props) {
     collectionCount,
     isFetchingItems,
     isResolvingCollection,
-    collectionItemUrls,
     collectionType,
     hasClaim,
     firstCollectionItemUrl,
@@ -67,12 +65,12 @@ function CollectionPreview(props: Props) {
 
   const { push } = useHistory();
 
-  if (isFetchingItems || isResolvingCollection || collectionItemUrls === undefined) {
+  if (isFetchingItems || isResolvingCollection) {
     return <ClaimPreviewLoading />;
   }
 
   const navigateUrl = `/$/${PAGES.PLAYLIST}/${collectionId}`;
-  const firstItemPath = collectionItemUrls && formatLbryUrlForWeb(collectionItemUrls[0] || '/');
+  const firstItemPath = formatLbryUrlForWeb(firstCollectionItemUrl) || '/';
   const hidePlayAll = collectionType === COL_TYPES.FEATURED_CHANNELS || collectionType === COL_TYPES.CHANNELS;
   const usedCollectionName = getLocalizedNameForCollectionId(collectionId) || collectionName;
 

--- a/ui/redux/selectors/collections.js
+++ b/ui/redux/selectors/collections.js
@@ -461,39 +461,6 @@ export const selectCollectionForIdClaimForUriItem = createSelector(
   }
 );
 
-export const selectThumbnailClaimUrisForCollectionId = createSelector(
-  selectHasPrivateCollectionForId,
-  selectItemsForCollectionId,
-  selectClaimsById,
-  (isPrivate, items, claimsById) => {
-    if (!items || isPrivate) return items;
-
-    const uris = new Set([]);
-
-    let thumbnailUrisNotFetched;
-
-    items.some((item, index) => {
-      let uri;
-      try {
-        const claim = claimsById[item];
-        uri = claim.permanent_url;
-      } catch (e) {}
-
-      if (uri) {
-        uris.add(uri);
-      } else {
-        thumbnailUrisNotFetched = true;
-      }
-
-      if (index === 2) return true;
-    });
-
-    if (thumbnailUrisNotFetched) return undefined;
-
-    return Array.from(uris);
-  }
-);
-
 export const selectCollectionTypeForId = (state: State, id: string) => {
   const collection = selectCollectionForId(state, id);
   return collection?.type;


### PR DESCRIPTION
NEW | OLD (Lists that aren't loading in old had some deleted items )
![deleted-items](https://user-images.githubusercontent.com/34790748/216462076-6fe19d81-36ff-43f2-b1f2-5a33dff82587.png)  


- Couldn't figure out how to make preview overlay to appear properly on lists like that, but at least the lists themselves appear now.  (Currently no overlay preview at all for lists with deleted items in early indexes)

- `selectThumbnailClaimUrisForCollectionId` was used only in one place(as far as I can tell) and for different purpose than name suggests. Seemed like duplicate of `selectUrlsForCollectionId`(which was/is used to get the thumbnail urls for collectionPreviewOverlay https://github.com/OdyseeTeam/odysee-frontend/blob/master/ui/component/collectionPreviewOverlay/index.js#L10) So seems that there's no need for it anymore?

- Doesn't seem to break anything, but don't know if I'm missing something (Also not sure why that third thumbnail is different in screenshot, but currently it's showing same than old for me)