### PR TITLE
Fix/improve attempt for playlists page filter options persistence

### DIFF
--- a/ui/component/common/paginate.jsx
+++ b/ui/component/common/paginate.jsx
@@ -9,7 +9,7 @@ const PAGINATE_PARAM = 'page';
 
 type Props = {
   totalPages: number,
-  shouldResetPageNumber?: Boolean,
+  shouldResetPageNumber?: boolean,
   location: { search: string },
   history: { push: (string) => void },
   onPageChange?: (number) => void,

--- a/ui/component/common/paginate.jsx
+++ b/ui/component/common/paginate.jsx
@@ -9,6 +9,7 @@ const PAGINATE_PARAM = 'page';
 
 type Props = {
   totalPages: number,
+  shouldResetPageNumber?: Boolean,
   location: { search: string },
   history: { push: (string) => void },
   onPageChange?: (number) => void,
@@ -16,7 +17,7 @@ type Props = {
 };
 
 function Paginate(props: Props) {
-  const { totalPages = 1, location, history, onPageChange, disableHistory } = props;
+  const { totalPages = 1, shouldResetPageNumber, location, history, onPageChange, disableHistory } = props;
   const { search } = location;
   const [textValue, setTextValue] = React.useState('');
   const urlParams = new URLSearchParams(search);
@@ -24,6 +25,7 @@ function Paginate(props: Props) {
   const initialPage = disableHistory ? 1 : urlParamPage || 1;
   const [currentPage, setCurrentPage] = React.useState(initialPage);
   const isMobile = useIsMobile();
+  const firstPage = 1;
 
   function handleChangePage(newPageNumber: number) {
     if (onPageChange) {
@@ -47,6 +49,10 @@ function Paginate(props: Props) {
       handleChangePage(newPage);
     }
     setTextValue('');
+  }
+
+  if (shouldResetPageNumber && currentPage != firstPage) {
+    handleChangePage(firstPage);
   }
 
   React.useEffect(() => {

--- a/ui/component/common/paginate.jsx
+++ b/ui/component/common/paginate.jsx
@@ -51,7 +51,7 @@ function Paginate(props: Props) {
     setTextValue('');
   }
 
-  if (shouldResetPageNumber && currentPage != firstPage) {
+  if (shouldResetPageNumber && currentPage !== firstPage) {
     handleChangePage(firstPage);
   }
 

--- a/ui/constants/collections.js
+++ b/ui/constants/collections.js
@@ -10,6 +10,10 @@ export const THUMBNAIL_PREVIEW_AMOUNT = 3;
 export const COLLECTION_ID = 'lid';
 export const COLLECTION_INDEX = 'linx';
 
+export const FILTER_TYPE_KEY = 'filterType';
+
+export const SEARCH_TERM_KEY = 'search';
+
 export const COL_TYPES = Object.freeze({
   PLAYLIST: 'playlist',
   CHANNELS: 'channelList',

--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/index.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/index.jsx
@@ -32,7 +32,7 @@ export default function CollectionsListMine(props: Props) {
 
   const history = useHistory();
   const {
-    location: { search, pathname }
+    location: { search, pathname },
   } = history;
 
   const [expanded, setExpanded] = React.useState(false);

--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/index.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/index.jsx
@@ -30,9 +30,10 @@ export default function CollectionsListMine(props: Props) {
     setPersistedOption,
   } = props;
 
+  const history = useHistory();
   const {
-    location: { search, pathname },
-  } = useHistory();
+    location: { search, pathname }
+  } = history;
 
   const [expanded, setExpanded] = React.useState(false);
 
@@ -47,7 +48,15 @@ export default function CollectionsListMine(props: Props) {
     setSortOption(sortObj);
 
     const url = `?${urlParams.toString()}`;
-    history.replaceState(history.state, '', url);
+    history.push(url);
+  }
+
+  function handleFilterTypeChange(value) {
+    urlParams.set(COLS.FILTER_TYPE_KEY, value);
+    setFilterType(value);
+
+    const url = `?${urlParams.toString()}`;
+    history.push(url);
   }
 
   function handleClear() {
@@ -55,7 +64,7 @@ export default function CollectionsListMine(props: Props) {
 
     setSortOption(persistedOption);
     const url = urlParams.toString() ? `?${urlParams.toString()}` : pathname;
-    history.replaceState(history.state, '', url);
+    history.push(url);
   }
 
   return (
@@ -71,7 +80,7 @@ export default function CollectionsListMine(props: Props) {
                 key={String(value)}
                 button="alt"
                 // $FlowFixMe
-                onClick={() => setFilterType(value)}
+                onClick={() => handleFilterTypeChange(String(value))}
                 className={classnames('button-toggle', { 'button-toggle--active': filterType === value })}
               />
             ))}

--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/internal/rightSideActions/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/internal/rightSideActions/view.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import { FormField, Form } from 'component/common/form';
-import { useHistory } from 'react-router'
+import { useHistory } from 'react-router';
 import { CollectionsListContext } from 'page/playlists/internal/collectionsListMine/view';
 import * as COLS from 'constants/collections';
 import * as MODALS from 'constants/modal_types';
@@ -22,7 +22,7 @@ const RightSideActions = (props: Props) => {
 
   const history = useHistory();
   const {
-    location: { search }
+    location: { search },
   } = history;
   const urlParams = new URLSearchParams(search);
 

--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/internal/rightSideActions/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/internal/rightSideActions/view.jsx
@@ -1,7 +1,9 @@
 // @flow
 import React from 'react';
 import { FormField, Form } from 'component/common/form';
+import { useHistory } from 'react-router'
 import { CollectionsListContext } from 'page/playlists/internal/collectionsListMine/view';
+import * as COLS from 'constants/collections';
 import * as MODALS from 'constants/modal_types';
 import * as KEYCODES from 'constants/keycodes';
 import * as ICONS from 'constants/icons';
@@ -18,8 +20,27 @@ const RightSideActions = (props: Props) => {
 
   const { searchText, setSearchText } = React.useContext(CollectionsListContext);
 
+  const history = useHistory();
+  const {
+    location: { search }
+  } = history;
+  const urlParams = new URLSearchParams(search);
+
   function handleCreatePlaylist() {
     doOpenModal(MODALS.COLLECTION_CREATE);
+  }
+
+  function handleSearchTextChange(value) {
+    setSearchText(value);
+
+    if (value === '') {
+      urlParams.get(COLS.SEARCH_TERM_KEY) && urlParams.delete(COLS.SEARCH_TERM_KEY);
+    } else {
+      urlParams.set(COLS.SEARCH_TERM_KEY, value);
+    }
+
+    const url = `?${urlParams.toString()}`;
+    history.push(url);
   }
 
   function escapeListener(e: SyntheticKeyboardEvent<*>) {
@@ -49,7 +70,7 @@ const RightSideActions = (props: Props) => {
             onBlur={onTextareaBlur}
             className="wunderbar__input--inline"
             value={searchText}
-            onChange={(e) => setSearchText(e.target.value)}
+            onChange={(e) => handleSearchTextChange(e.target.value)}
             type="text"
             placeholder={__('Search')}
           />

--- a/ui/page/playlists/internal/collectionsListMine/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/view.jsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import * as COLS from 'constants/collections';
 
 import { useIsMobile } from 'effects/use-screensize';
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router';
 import { getTitleForCollection } from 'util/collections';
 
 import CollectionPreview from './internal/collectionPreview';

--- a/ui/page/playlists/internal/collectionsListMine/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/view.jsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import * as COLS from 'constants/collections';
 
 import { useIsMobile } from 'effects/use-screensize';
-import { useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router'
 import { getTitleForCollection } from 'util/collections';
 
 import CollectionPreview from './internal/collectionPreview';
@@ -48,18 +48,18 @@ export default function CollectionsListMine(props: Props) {
 
   const isMobile = useIsMobile();
 
-  const {
-    location: { search },
-  } = useHistory();
+  const { search } = useLocation();
 
   const urlParams = new URLSearchParams(search);
   const sortByParam = Object.keys(COLS.SORT_VALUES).find((key) => urlParams.get(key));
-  const defaultSortOption = sortByParam ? { key: sortByParam, value: urlParams.get(sortByParam) } : COLS.DEFAULT_SORT;
+  const [persistedOption, setPersistedOption] = usePersistedState('playlist-sort', COLS.DEFAULT_SORT);
+  const defaultSortOption = sortByParam ? { key: sortByParam, value: urlParams.get(sortByParam) } : persistedOption;
+  const defaultFilterType = urlParams.get(COLS.FILTER_TYPE_KEY) || 'All';
+  const defaultSearchTerm = urlParams.get(COLS.SEARCH_TERM_KEY) || '';
 
-  const [filterType, setFilterType] = React.useState(COLS.LIST_TYPE.ALL);
-  const [searchText, setSearchText] = React.useState('');
-  const [sortOption, setSortOption] = usePersistedState('playlists-sort', defaultSortOption);
-  const [persistedOption, setPersistedOption] = React.useState(sortOption);
+  const [filterType, setFilterType] = React.useState(defaultFilterType);
+  const [searchText, setSearchText] = React.useState(defaultSearchTerm);
+  const [sortOption, setSortOption] = React.useState(defaultSortOption);
 
   const unpublishedCollectionsList = (Object.keys(unpublishedCollections || {}): any);
   const publishedList = (Object.keys(publishedCollections || {}): any);

--- a/ui/page/playlists/internal/collectionsListMine/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/view.jsx
@@ -60,6 +60,7 @@ export default function CollectionsListMine(props: Props) {
   const [filterType, setFilterType] = React.useState(defaultFilterType);
   const [searchText, setSearchText] = React.useState(defaultSearchTerm);
   const [sortOption, setSortOption] = React.useState(defaultSortOption);
+  const [filterParamsChanged, setFilterParamsChanged] = React.useState(false);
 
   const unpublishedCollectionsList = (Object.keys(unpublishedCollections || {}): any);
   const publishedList = (Object.keys(publishedCollections || {}): any);
@@ -209,6 +210,21 @@ export default function CollectionsListMine(props: Props) {
     }
   }, [doFetchThumbnailClaimsForCollectionIds, paginatedCollectionsStr]);
 
+  const firstUpdate = React.useRef(true);
+  React.useLayoutEffect(() => {
+    if (firstUpdate.current) {
+      firstUpdate.current = false;
+      return;
+    }
+    setFilterParamsChanged(true);
+  }, [searchText, filterType, sortOption]);
+
+  React.useEffect(() => {
+    if (filterParamsChanged) {
+      setFilterParamsChanged(false);
+    }
+  }, [filterParamsChanged]);
+
   return (
     <>
       <SectionLabel label={__('Your Playlists')} />
@@ -250,7 +266,7 @@ export default function CollectionsListMine(props: Props) {
             />
           )}
 
-          <Paginate totalPages={totalPages} />
+          <Paginate totalPages={totalPages} shouldResetPageNumber={filterParamsChanged} />
         </ul>
       ) : (
         <div className="empty main--empty">{__('No matching playlists')}</div>


### PR DESCRIPTION
## Fixes 
Issue Number: #2410 

Also supposed to fix/improve these: 
-changing page number cleared sort_type param from url 
-sort_type param in url didn't actually got used  
-sort_type param changes got always persistently stored, even without clicking the check-mark-button
-search text can now also be passed from url, making last search persist when navigating  to page using back button 
-now goes to first page when tab/sortby/searchText changes