### PR TITLE
Merge claim.meta for pending claim from old claim on update

### DIFF
--- a/ui/redux/reducers/claims.js
+++ b/ui/redux/reducers/claims.js
@@ -651,13 +651,13 @@ reducers[ACTIONS.UPDATE_PENDING_CLAIMS] = (state: State, action: any): State => 
   pendingClaims.forEach((claim: Claim) => {
     let newClaim;
     const { permanent_url: uri, claim_id: claimId, type, value_type: valueType } = claim;
-    pendingById[claimId] = claim; // make sure we don't need to merge?
     const oldClaim = state.byId[claimId];
     if (oldClaim && oldClaim.canonical_url) {
       newClaim = mergeClaim(oldClaim, claim);
     } else {
       newClaim = claim;
     }
+    pendingById[claimId] = newClaim;
     if (valueType === 'channel') {
       // $FlowFixMe
       const channelClaim: ChannelClaim = claim;


### PR DESCRIPTION
## Fixes

Issue Number: #2492 
Also some stuff  in channel's about page doesn't get cleared anymore while pending confirmation.

#### Details
Claim.meta gotten from `channel_update` is empty, so put claim in the `pendingById[]` after it's merged with oldClaim.  