### PR TITLE
Sidebar hides when user clicks outside it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ package-lock.json
 .env.desktop
 .env.lbrytv
 analyzeResults*.html
+.yarnrc.yml

--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -291,6 +291,8 @@ function SideNavigation(props: Props) {
 
   const shouldRenderLargeMenu = (menuCanCloseCompletely && !isAbsolute) || sidebarOpen;
 
+  const sideNavigationRef = React.useRef(null);
+
   const showMicroMenu = !sidebarOpen && !menuCanCloseCompletely;
   const showPushMenu = sidebarOpen && !menuCanCloseCompletely;
   const showOverlay = sidebarOpen;
@@ -472,9 +474,19 @@ function SideNavigation(props: Props) {
       }
     }
 
-    window.addEventListener('keydown', handleKeydown);
+    function handleOutsideClick(e) {
+      if (sideNavigationRef.current === null || !sideNavigationRef.current.contains(e.target)) {
+        setSidebarOpen(false);
+      }
+    }
 
-    return () => window.removeEventListener('keydown', handleKeydown);
+    window.addEventListener('keydown', handleKeydown);
+    window.addEventListener('mouseup', handleOutsideClick);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+      window.removeEventListener('mouseup', handleOutsideClick);
+    };
   }, [sidebarOpen, setSidebarOpen, isAbsolute]);
 
   React.useEffect(() => {
@@ -586,6 +598,7 @@ function SideNavigation(props: Props) {
         'navigation__wrapper--micro': showMicroMenu,
         'navigation__wrapper--absolute': isAbsolute,
       })}
+      ref={sideNavigationRef}
     >
       <nav
         aria-label={'Sidebar'}


### PR DESCRIPTION
## What is the current behavior?
When the sidebar is open, and the user clicks on an element in the top navbar, then the sidebar does not hide

## What is the new behavior?
When the sidebar is open, and the user clicks on an element outside the sidebar, then the sidebar hides

## Video Demonstration

https://user-images.githubusercontent.com/84881706/218353162-cf33b12f-c140-4875-b2e6-c05e9d58bf38.mp4

## PR Checklist

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
