### PR TITLE
Fix attempt? - Don't clear publish form when previous file finishes uploading

### DIFF
--- a/ui/modal/modalPublish/index.js
+++ b/ui/modal/modalPublish/index.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
 import ModalPublishSuccess from './view';
 import { makeSelectClaimForUri } from 'redux/selectors/claims';
-import { doClearPublish } from 'redux/actions/publish';
 import { push } from 'connected-react-router';
 
 const select = (state, props) => ({

--- a/ui/modal/modalPublish/index.js
+++ b/ui/modal/modalPublish/index.js
@@ -11,7 +11,6 @@ const select = (state, props) => ({
 
 const perform = (dispatch) => ({
   closeModal: () => dispatch(doHideModal()),
-  clearPublish: () => dispatch(doClearPublish()),
   navigate: (path) => dispatch(push(path)),
 });
 

--- a/ui/modal/modalPublish/view.jsx
+++ b/ui/modal/modalPublish/view.jsx
@@ -9,7 +9,6 @@ import Nag from 'component/nag';
 
 type Props = {
   closeModal: () => void,
-  clearPublish: () => void,
   navigate: (string) => void,
   uri: string,
   isEdit: boolean,
@@ -19,11 +18,6 @@ type Props = {
 };
 
 class ModalPublishSuccess extends React.PureComponent<Props> {
-  componentDidMount() {
-    const { clearPublish } = this.props;
-    clearPublish();
-  }
-
   render() {
     const { closeModal, navigate, uri, isEdit, filePath, lbryFirstError, claim } = this.props;
     //   $FlowFixMe


### PR DESCRIPTION
Supposed to fix publish form details getting cleared when previous upload finishes.

Noticed now that this was fixed at one point, but was reverted. I don't quite understand the reason, is it still up to date?
https://github.com/OdyseeTeam/odysee-frontend/commit/d2243f41972d78bbb961e0d4f7c88eb698cf76ca
Currently publish forms seem to always clear on entry in case that's related, so couldn't figure out why this would be needed anymore.