### PR TITLE
Search improvements

### DIFF
--- a/flow-typed/subscription.js
+++ b/flow-typed/subscription.js
@@ -2,7 +2,6 @@
 
 declare type Subscription = {
   channelName: string, // @CryptoCandor,
-  channelTitle: string, // Crypto Candor,
   uri: string, // lbry://@CryptoCandor#9152f3b054f692076a6882d1b58a30e8781cc8e6
   notificationsDisabled?: boolean,
 };

--- a/flow-typed/subscription.js
+++ b/flow-typed/subscription.js
@@ -2,6 +2,7 @@
 
 declare type Subscription = {
   channelName: string, // @CryptoCandor,
+  channelTitle: string, // Crypto Candor,
   uri: string, // lbry://@CryptoCandor#9152f3b054f692076a6882d1b58a30e8781cc8e6
   notificationsDisabled?: boolean,
 };

--- a/ui/component/sideNavigation/index.js
+++ b/ui/component/sideNavigation/index.js
@@ -31,7 +31,7 @@ const select = (state) => ({
 export default connect(select, {
   doClearClaimSearch,
   doSignOut,
-  doClearPurchasedUriSuccess,
   doFetchLastActiveSubs,
+  doClearPurchasedUriSuccess,
   doOpenModal,
 })(SideNavigation);

--- a/ui/component/sideNavigation/index.js
+++ b/ui/component/sideNavigation/index.js
@@ -1,15 +1,19 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doFetchLastActiveSubs } from 'redux/actions/subscriptions';
-import { selectLastActiveSubscriptions, selectSubscriptions } from 'redux/selectors/subscriptions';
-import { doClearClaimSearch } from 'redux/actions/claims';
+import {
+  selectLastActiveSubscriptions,
+  selectSubscriptionUris,
+  selectSubscriptions,
+} from 'redux/selectors/subscriptions';
+import { doClearClaimSearch, doResolveUris } from 'redux/actions/claims';
 import { doClearPurchasedUriSuccess } from 'redux/actions/file';
 import { selectFollowedTags } from 'redux/selectors/tags';
 import { selectUserVerifiedEmail, selectUser } from 'redux/selectors/user';
 import { selectClientSetting, selectHomepageData } from 'redux/selectors/settings';
 import { doOpenModal, doSignOut } from 'redux/actions/app';
 import { selectUnseenNotificationCount } from 'redux/selectors/notifications';
-import { selectPurchaseUriSuccess } from 'redux/selectors/claims';
+import { selectClaimsByUri, selectPurchaseUriSuccess } from 'redux/selectors/claims';
 import { selectUserHasValidOdyseeMembership } from 'redux/selectors/memberships';
 
 import SideNavigation from './view';
@@ -26,6 +30,8 @@ const select = (state) => ({
   homepageOrder: selectClientSetting(state, SETTINGS.HOMEPAGE_ORDER),
   homepageOrderApplyToSidebar: selectClientSetting(state, SETTINGS.HOMEPAGE_ORDER_APPLY_TO_SIDEBAR),
   hasMembership: selectUserHasValidOdyseeMembership(state),
+  subscriptionUris: selectSubscriptionUris(state) || [],
+  claimsByUri: selectClaimsByUri(state),
 });
 
 export default connect(select, {
@@ -34,4 +40,5 @@ export default connect(select, {
   doFetchLastActiveSubs,
   doClearPurchasedUriSuccess,
   doOpenModal,
+  doResolveUris,
 })(SideNavigation);

--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -131,51 +131,59 @@ const UNAUTH_LINKS: Array<SideNavLink> = [
 type HomepageOrder = { active: ?Array<string>, hidden: ?Array<string> };
 
 type Props = {
+  uploadCount: number,
+  sidebarOpen: boolean,
+  isMediumScreen: boolean,
+  isOnFilePage: boolean,
+  setSidebarOpen: (boolean) => void,
+  // --- select ---
   subscriptions: Array<Subscription>,
   lastActiveSubs: ?Array<Subscription>,
   followedTags: Array<Tag>,
   email: ?string,
-  uploadCount: number,
-  doSignOut: () => void,
-  sidebarOpen: boolean,
-  setSidebarOpen: (boolean) => void,
-  isMediumScreen: boolean,
-  isOnFilePage: boolean,
-  unseenCount: number,
   purchaseSuccess: boolean,
-  doClearPurchasedUriSuccess: () => void,
+  unseenCount: number,
   user: ?User,
   homepageData: any,
   homepageOrder: HomepageOrder,
   homepageOrderApplyToSidebar: boolean,
-  doClearClaimSearch: () => void,
   hasMembership: ?boolean,
+  subscriptionUris: Array<string>,
+  claimsByUri: { [string]: Claim },
+  // --- perform ---
+  doClearClaimSearch: () => void,
+  doSignOut: () => void,
   doFetchLastActiveSubs: (force?: boolean, count?: number) => void,
+  doClearPurchasedUriSuccess: () => void,
   doOpenModal: (id: string, ?{}) => void,
+  doResolveUris: (uris: Array<string>, cache: boolean) => Promise<any>,
 };
 
 function SideNavigation(props: Props) {
   const {
-    subscriptions,
-    lastActiveSubs,
-    doSignOut,
-    email,
-    purchaseSuccess,
-    doClearPurchasedUriSuccess,
     sidebarOpen,
     setSidebarOpen,
     isMediumScreen,
     isOnFilePage,
+    subscriptions,
+    lastActiveSubs,
+    followedTags,
+    email,
+    purchaseSuccess,
     unseenCount,
+    user,
     homepageData,
     homepageOrder,
     homepageOrderApplyToSidebar,
-    user,
-    followedTags,
-    doClearClaimSearch,
     hasMembership,
+    subscriptionUris,
+    claimsByUri,
+    doClearClaimSearch,
+    doSignOut,
     doFetchLastActiveSubs,
+    doClearPurchasedUriSuccess,
     doOpenModal,
+    doResolveUris,
   } = props;
 
   const isLargeScreen = useIsLargeScreen();
@@ -357,10 +365,21 @@ function SideNavigation(props: Props) {
   function getSubscriptionSection() {
     const showSubsSection = shouldRenderLargeMenu && isPersonalized && subscriptions && subscriptions.length > 0;
     if (showSubsSection) {
-      let displayedSubscriptions;
+      let displayedSubscriptions = [];
       if (subscriptionFilter) {
         const filter = subscriptionFilter.toLowerCase();
-        displayedSubscriptions = subscriptions.filter((sub) => sub.channelName.toLowerCase().includes(filter));
+
+        subscriptions &&
+          subscriptions.map((subscription) => {
+            if (
+              claimsByUri[subscription.uri].name.toLowerCase().includes(filter) ||
+              // $FlowIgnore
+              claimsByUri[subscription.uri].value?.title?.toLowerCase().includes(filter)
+            ) {
+              displayedSubscriptions.push(subscription);
+            }
+          });
+        // displayedSubscriptions = subscriptions.filter((sub) => sub.channelName.toLowerCase().includes(filter));
       } else {
         displayedSubscriptions =
           lastActiveSubs && lastActiveSubs.length > 0 ? lastActiveSubs : subscriptions.slice(0, SIDEBAR_SUBS_DISPLAYED);
@@ -534,6 +553,12 @@ function SideNavigation(props: Props) {
       doFetchLastActiveSubs();
     }
   }, [doFetchLastActiveSubs, sidebarOpen]);
+
+  // --- Resolve subscriptions
+  React.useEffect(() => {
+    doResolveUris(subscriptionUris, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount
+  }, []);
 
   // **************************************************************************
   // **************************************************************************

--- a/ui/component/wunderbarSuggestions/index.js
+++ b/ui/component/wunderbarSuggestions/index.js
@@ -4,15 +4,22 @@ import { doToast } from 'redux/actions/notifications';
 import { doHideModal } from 'redux/actions/app';
 import { withRouter } from 'react-router';
 import { doResolveUris } from 'redux/actions/claims';
+import { selectSubscriptionUris } from 'redux/selectors/subscriptions';
+import { selectClaimsByUri } from 'redux/selectors/claims';
+
 import analytics from 'analytics';
 import Wunderbar from './view';
 import * as SETTINGS from 'constants/settings';
 
-const select = (state, props) => ({
-  languageSetting: selectLanguage(state),
-  searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
-  showMature: selectShowMatureContent(state),
-});
+const select = (state, props) => {
+  return {
+    languageSetting: selectLanguage(state),
+    searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
+    showMature: selectShowMatureContent(state),
+    claimsByUri: selectClaimsByUri(state),
+    subscriptionUris: selectSubscriptionUris(state) || [],
+  };
+};
 
 const perform = (dispatch, ownProps) => ({
   doResolveUris: (uris) => dispatch(doResolveUris(uris)),

--- a/ui/component/wunderbarSuggestions/view.jsx
+++ b/ui/component/wunderbarSuggestions/view.jsx
@@ -52,7 +52,7 @@ type Props = {
   navigateToSearchPage: (string) => void,
   doShowSnackBar: (string) => void,
   doCloseMobileSearch: () => void,
-  doResolveUris: (uris: Array<string>, cache: boolean) => Promise<any>,
+  doResolveUris: (uris: Array<string>) => Promise<any>,
 };
 
 export default function WunderBarSuggestions(props: Props) {
@@ -321,16 +321,10 @@ export default function WunderBarSuggestions(props: Props) {
     if (stringifiedResults) {
       const arrayResults = JSON.parse(stringifiedResults);
       if (arrayResults && arrayResults.length > 0) {
-        doResolveUris(arrayResults, true);
+        doResolveUris(arrayResults);
       }
     }
   }, [doResolveUris, stringifiedResults]);
-
-  // --- Resolve subscriptions
-  React.useEffect(() => {
-    doResolveUris(subscriptionUris, true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount
-  }, []);
 
   const [subscriptionResults, setSubscriptionResults] = React.useState([]);
   React.useEffect(() => {

--- a/ui/redux/actions/subscriptions.js
+++ b/ui/redux/actions/subscriptions.js
@@ -96,6 +96,18 @@ export function doChannelUnsubscribe(subscription: SubscriptionArgs, followToast
   };
 }
 
+/*
+export function doFetchSubscriptionTitles(){
+  return (dispatch: Dispatch) => {
+    if (subscriptions.length) {
+      actions.push(doResolveUris(subscriptions));
+    }
+
+    dispatch(batchActions(...actions));
+  }
+}
+*/
+
 export function doFetchLastActiveSubs(forceFetch: boolean = false, count: number = SIDEBAR_SUBS_DISPLAYED) {
   function parseIdFromUri(uri) {
     try {

--- a/ui/redux/selectors/subscriptions.js
+++ b/ui/redux/selectors/subscriptions.js
@@ -14,6 +14,7 @@ import { getChannelFromClaim, isChannelClaim } from 'util/claim';
 
 // Returns the entire subscriptions state
 const selectState = (state) => state.subscriptions || {};
+if (selectState) console.log('state.subscriptions: ', selectState);
 
 // Returns the list of channel uris a user is subscribed to
 export const selectSubscriptions = createSelector(

--- a/ui/scss/component/_wunderbar.scss
+++ b/ui/scss/component/_wunderbar.scss
@@ -154,6 +154,12 @@
       }
     }
   }
+
+  ul {
+    li {
+      margin-top: 0;
+    }
+  }
 }
 
 .wunderbar__suggestions--mobile {


### PR DESCRIPTION
This change would resolve subscription claims by default. Not ideal, but somewhat necessary if we want the search results to be useful.

This change would allow us to search/filter via the channel titles. For example the search filter for the subscriptions in the `sideNavigation` can currently only search the channel names but not the titles which is kinda pointless. Resolved claims would make that feature way more functional. On top of that I've also added this new search functionality to the header `wunderbar`. Searching for a channel that you're subscribed to would return an instant result.