### PR TITLE
Fix attempt - Sometimes blank side bar on page load

### DIFF
--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -519,7 +519,9 @@ function SideNavigation(props: Props) {
     if (hideMenuFromView || !menuInitialized) {
       const handler = setTimeout(() => {
         setMenuInitialized(true);
-        setCanDisposeMenu(true);
+        if (hideMenuFromView) {
+          setCanDisposeMenu(true);
+        }
       }, 250);
       return () => {
         clearTimeout(handler);


### PR DESCRIPTION
Sometimes page loads for me looking like one in the screenshot. Sidebar categories are loaded, but only show when sidebar is expanded.
Don't fully understand why it happens, but this seems to fix it.
![blank-side-bar](https://user-images.githubusercontent.com/34790748/220451250-efbdf929-a281-44c7-9c35-627a41b54b19.png)

EDIT: Supposed to fix #966