### PR TITLE
Fix attempt - Restore scroll position in categories

### DIFF
--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -309,7 +309,9 @@ function AppRouter(props: Props) {
           window.scrollTo(0, element.offsetTop);
         }
       } else {
-        window.scrollTo(0, currentScroll);
+        setTimeout( () => {
+          window.scrollTo(0, currentScroll);
+        }, 0);
       }
     }
   }, [currentScroll, pathname, search, hash, resetScroll, hasLinkedCommentInUrl, historyAction]);

--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -309,7 +309,7 @@ function AppRouter(props: Props) {
           window.scrollTo(0, element.offsetTop);
         }
       } else {
-        setTimeout( () => {
+        setTimeout(() => {
           window.scrollTo(0, currentScroll);
         }, 0);
       }


### PR DESCRIPTION
## Fixes 

Issue Number: #2550 
Setting timeout of 0ms seems to be enough to fix it. 
Don't know if best solution, page quite often loads as scrolled to top, and then instantly jumps to the wanted scroll position. (I think it used to load page to the wanted scroll position without the jump, but not sure)

