### PR TITLE
Comments upgrade

### DIFF
--- a/ui/component/comment/index.js
+++ b/ui/component/comment/index.js
@@ -5,6 +5,7 @@ import {
   selectThumbnailForUri,
   selectHasChannels,
   selectMyClaimIdsRaw,
+  selectTitleForUri,
   selectDateForUri,
 } from 'redux/selectors/claims';
 import { doCommentUpdate, doCommentList } from 'redux/actions/comments';
@@ -55,6 +56,7 @@ const select = (state, props) => {
     creatorMembership: selectMembershipForCreatorOnlyIdAndChannelId(state, creatorId, channel_id),
     repliesFetching: selectIsFetchingCommentsForParentId(state, comment_id),
     fetchedReplies: selectRepliesForParentId(state, comment_id),
+    authorTitle: selectTitleForUri(state, channel_url),
     channelAge,
   };
 };

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -354,11 +354,7 @@ function CommentView(props: Props) {
                     commentIsMine={commentIsMine}
                     isPinned={isPinned}
                     isTopLevel={isTopLevel}
-                    // disableEdit
-                    // disableRemove
                     isUserLabel
-                    // isLiveComment
-                    // handleDismissPin={handleDismissPin}
                     handleEditComment={() => handleEditComment(true)}
                     setQuickReply={setQuickReply}
                     className={classnames('comment__author', {

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -41,7 +41,6 @@ import CommentsReplies from 'component/commentsReplies';
 import { useHistory } from 'react-router';
 import CommentCreate from 'component/commentCreate';
 import CommentMenuList from 'component/commentMenuList';
-import UriIndicator from 'component/uriIndicator';
 import CreditAmount from 'component/common/credit-amount';
 import OptimizedImage from 'component/optimizedImage';
 import { getChannelFromClaim } from 'util/claim';
@@ -90,6 +89,7 @@ type Props = {
   repliesFetching: boolean,
   threadLevel?: number,
   threadDepthLevel?: number,
+  authorTitle: string,
   channelAge?: any,
   disabled?: boolean,
   doClearPlayingSource: () => void,
@@ -128,6 +128,7 @@ function CommentView(props: Props) {
     threadLevel = 0,
     threadDepthLevel = 0,
     doClearPlayingSource,
+    authorTitle,
     channelAge,
     disabled,
   } = props;
@@ -148,6 +149,7 @@ function CommentView(props: Props) {
     replies: numDirectReplies,
     timestamp,
   } = comment;
+  const claimName = authorTitle || author;
 
   const timePosted = timestamp * 1000;
   const commentIsMine = channelId && myChannelIds && myChannelIds.includes(channelId);
@@ -334,15 +336,36 @@ function CommentView(props: Props) {
               {!author ? (
                 <span className="comment__author">{__('Anonymous')}</span>
               ) : (
-                <UriIndicator
-                  className={classnames('comment__author', {
-                    'comment__author--creator': commentByOwnerOfContent,
-                  })}
-                  link
-                  uri={authorUri}
-                  comment
-                  showAtSign
-                />
+                <Menu>
+                  <MenuButton
+                    className={classnames('button--uri-indicator comment__author', {
+                      'comment__author--creator': commentByOwnerOfContent,
+                    })}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {claimName}
+                  </MenuButton>
+
+                  <CommentMenuList
+                    uri={uri}
+                    commentId={commentId}
+                    authorUri={authorUri}
+                    authorName={claimName}
+                    commentIsMine={commentIsMine}
+                    isPinned={isPinned}
+                    isTopLevel={isTopLevel}
+                    // disableEdit
+                    // disableRemove
+                    isUserLabel
+                    // isLiveComment
+                    // handleDismissPin={handleDismissPin}
+                    handleEditComment={() => handleEditComment(true)}
+                    setQuickReply={setQuickReply}
+                    className={classnames('comment__author', {
+                      'comment__author--creator': commentByOwnerOfContent,
+                    })}
+                  />
+                </Menu>
               )}
               {isSprout && <CommentBadge label={__('Sprout')} icon={ICONS.BADGE_SPROUT} size={14} />}
               {isGlobalMod && <CommentBadge label={__('Admin')} icon={ICONS.BADGE_ADMIN} />}

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -190,6 +190,13 @@ function CommentView(props: Props) {
   const commentByOwnerOfContent = contentChannelClaim && contentChannelClaim.permanent_url === authorUri;
   const stickerFromMessage = parseSticker(message);
 
+  React.useEffect(() => {
+    if (threadLevel === 0 && comment.replies) {
+      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST);
+      setShowReplies(true);
+    }
+  }, []);
+
   const isSprout = channelAge && Math.round((new Date() - channelAge) / (1000 * 60 * 60 * 24)) < 7;
 
   let channelOwnerOfContent;
@@ -518,7 +525,7 @@ function CommentView(props: Props) {
               threadCommentId={threadCommentId}
               numDirectReplies={numDirectReplies}
               onShowMore={() => setPage(page + 1)}
-              hasMore={page < totalReplyPages}
+              hasMore={page < totalReplyPages && threadLevel > 0}
               threadDepthLevel={threadDepthLevel}
             />
           ))}

--- a/ui/component/commentMenuList/view.jsx
+++ b/ui/component/commentMenuList/view.jsx
@@ -28,6 +28,7 @@ type Props = {
   disableRemove?: boolean,
   supportAmount?: any,
   isLiveComment: boolean,
+  isUserLabel: boolean,
   // --- select ---
   claim: ?Claim,
   claimIsMine: boolean,
@@ -74,6 +75,7 @@ function CommentMenuList(props: Props) {
     disableRemove,
     supportAmount,
     isLiveComment,
+    isUserLabel,
     doToast,
     handleEditComment,
     openModal,
@@ -203,11 +205,11 @@ function CommentMenuList(props: Props) {
   return (
     <MenuList
       className={classnames('menu__list', {
-        'menu__chat-comment': isLiveComment,
+        'menu__chat-comment': isLiveComment || isUserLabel,
       })}
       onClick={(e) => e.stopPropagation()}
     >
-      {isLiveComment && (
+      {(isLiveComment || isUserLabel) && (
         <div className="comment__menu-target">
           <ChannelThumbnail xsmall noLazyLoad uri={authorUri} />
           <NavLink className="comment__menu-channel" to={formatLbryUrlForWeb(authorUri)}>

--- a/ui/component/sideNavigation/view.jsx
+++ b/ui/component/sideNavigation/view.jsx
@@ -475,15 +475,17 @@ function SideNavigation(props: Props) {
     }
 
     function handleOutsideClick(e) {
-      const isNavigationButton =
-        e.target.classList.contains('icon--Menu') ||
-        (e.target.hasChildNodes() && e.target.firstChild.classList.contains('icon--Menu')) ||
-        e.target.classList.contains('button-rotate');
-      if (
-        (sideNavigationRef.current === null || !sideNavigationRef.current.contains(e.target)) &&
-        !isNavigationButton
-      ) {
-        setSidebarOpen(false);
+      if (sidebarOpen) {
+        const isNavigationButton =
+          e.target.classList.contains('icon--Menu') ||
+          (e.target.hasChildNodes() && e.target.firstChild.classList.contains('icon--Menu')) ||
+          e.target.classList.contains('button-rotate');
+        if (
+          (sideNavigationRef.current === null || !sideNavigationRef.current.contains(e.target)) &&
+          !isNavigationButton
+        ) {
+          setSidebarOpen(false);
+        }
       }
     }
 

--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -297,12 +297,6 @@ $thumbnailWidthSmall: 2rem;
   width: calc(100% - var(--spacing-m) - var(--spacing-s));
   padding-top: 1px;
 
-  /*
-  @media (max-width: $breakpoint-small) {
-    width: calc(100% - 100px - var(--spacing-m) - var(--spacing-s));
-  }
-  */
-
   .channel-name {
     color: var(--color-link);
 
@@ -313,6 +307,10 @@ $thumbnailWidthSmall: 2rem;
 
   .icon {
     color: var(--color-text);
+  }
+
+  .comment__author {
+    color: var(--color-primary);
   }
 
   .comment__author--creator {
@@ -432,6 +430,10 @@ $thumbnailWidthSmall: 2rem;
       padding-top: 0 !important;
       border-radius: var(--border-radius);
     }
+  }
+
+  .channel-name {
+    color: var(--color-primary);
   }
 
   @media (max-width: $breakpoint-small) {


### PR DESCRIPTION
- **Collapse first level of replies by default**
Hiding them seems pointless when most claims have less than 100 comments anyways.

- **Resolve channel titles**
Show titles instead of names (@handle) for the comment authors.

- **Add context menu to authors**
Resolved author titles use the same context menu as they do in the chat.
