### PR TITLE
 Add option to hide anonymous on /$/discover

### DIFF
--- a/flow-typed/Lbry.js
+++ b/flow-typed/Lbry.js
@@ -136,6 +136,8 @@ declare type ClaimSearchOptions = {
   has_source?: boolean, // find claims containing a source field
   has_no_source?: boolean, // find claims not containing a source field
   include_purchase_receipt?: boolean, // include purchase receipt in response
+  has_channel_signature?: boolean, // only return claims which have channel signature
+  valid_channel_signature?: boolean, // filter out claims with invalid channel signature (doesn't filter claims without channel signature)
 };
 
 declare type ClaimSearchResponse = {

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -299,6 +299,7 @@ function ClaimListDiscover(props: Props) {
   const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION_ALL], 'durUser', null);
   const [minDurationMinutes] = usePersistedState(`minDurUserMinutes-${location.pathname}`, null);
   const [maxDurationMinutes] = usePersistedState(`maxDurUserMinutes-${location.pathname}`, null);
+  const [hideAnonymous] = usePersistedState(`hideAnonymous-${location.pathname}`, false);
   const channelIdsInUrl = urlParams.get(CS.CHANNEL_IDS_KEY);
   const channelIdsParam = channelIdsInUrl ? channelIdsInUrl.split(',') : channelIds;
   const excludedIdsParam = excludedChannelIds;
@@ -420,6 +421,11 @@ function ClaimListDiscover(props: Props) {
         console.error('Unhandled duration: ' + durationParam);
         break;
     }
+  }
+
+  if (hideAnonymous) {
+    options.has_channel_signature = true;
+    options.valid_channel_signature = true;
   }
 
   if (streamTypeParam && streamTypeParam !== CS.CONTENT_ALL && claimType !== CS.CLAIM_CHANNEL) {

--- a/ui/component/claimListHeader/style.scss
+++ b/ui/component/claimListHeader/style.scss
@@ -10,4 +10,9 @@ $OPTIONS_MIN_WIDTH: 250px;
   .claim-search__menus {
     padding: 0;
   }
+
+  .checkbox {
+    margin-left: 5px;
+    margin-top: 9px;
+  }
 }

--- a/ui/component/claimListHeader/style.scss
+++ b/ui/component/claimListHeader/style.scss
@@ -12,7 +12,83 @@ $OPTIONS_MIN_WIDTH: 250px;
   }
 
   .checkbox {
-    margin-left: 5px;
-    margin-top: 9px;
+    background-color: rgba(var(--color-header-background-base), 0.9);
+    margin-left: var(--spacing-s);
+    border-radius: var(--border-radius);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 var(--spacing-s);
+    label {
+      margin-bottom: -6px;
+      &::before,
+      &::after {
+        margin-top: -2px;
+      }
+    }
+  }
+
+  .section__actions--no-margin {
+    @media (max-width: $breakpoint-medium) {
+      position: absolute;
+      top: calc(40px * -1);
+      right: 0;
+    }
+
+    @media (max-width: $breakpoint-medium) {
+      top: calc(50px * -1);
+    }
+  }
+
+  .claim-search__top {
+    @media (max-width: $breakpoint-medium) {
+      justify-content: space-between;
+
+      .claim-search__menu-group {
+        &:nth-child(2) {
+          margin-right: auto;
+        }
+      }
+    }
+    @media (max-width: $breakpoint-small) {
+      flex-direction: row;
+      max-width: 100%;
+      .claim-search__menu-group {
+        // flex:1;
+        align-items: stretch;
+        width: 100%;
+        margin-right: 0 !important;
+
+        &:first-of-type {
+          button {
+            flex: 1;
+            .button__content {
+              justify-content: center;
+            }
+          }
+        }
+        &:nth-child(2) {
+          button {
+            width: 100%;
+            .button__content {
+              justify-content: center;
+            }
+          }
+          .button-toggle {
+            background: red;
+            .button__content {
+              margin-left: 4px;
+            }
+          }
+        }
+        &:nth-child(3) {
+          .checkbox {
+            height: var(--height-button);
+            margin-left: 0;
+            width: 100%;
+          }
+        }
+      }
+    }
   }
 }

--- a/ui/component/claimListHeader/view.jsx
+++ b/ui/component/claimListHeader/view.jsx
@@ -5,6 +5,7 @@ import TagSearch from './internal/tagSearch/tagSearch';
 import * as CS from 'constants/claim_search';
 import * as ICONS from 'constants/icons';
 import * as SETTINGS from 'constants/settings';
+import * as PAGES from 'constants/pages';
 import type { Node } from 'react';
 import classnames from 'classnames';
 import React from 'react';
@@ -78,7 +79,7 @@ function ClaimListHeader(props: Props) {
   const isMobile = useIsMobile();
   const filterCtx = React.useContext(ClaimSearchFilterContext);
   const { push, location } = useHistory();
-  const { search } = location;
+  const { search, pathname } = location;
   const [expanded, setExpanded] = usePersistedState(`expanded-${location.pathname}`, false);
   const urlParams = new URLSearchParams(search);
   const freshnessParam = freshness || urlParams.get(CS.FRESH_KEY) || defaultFreshness;
@@ -91,6 +92,8 @@ function ClaimListHeader(props: Props) {
   const channelIdsParam = channelIdsInUrl ? channelIdsInUrl.split(',') : channelIds;
   const feeAmountParam = urlParams.get('fee_amount') || feeAmount || CS.FEE_AMOUNT_ANY;
   const showDuration = !(claimType && claimType === CS.CLAIM_CHANNEL && claimType === CS.CLAIM_COLLECTION);
+  const isDiscoverPage = pathname.includes(PAGES.DISCOVER);
+  const [hideAnonymous, setHideAnonymous] = usePersistedState(`hideAnonymous-${location.pathname}`, false);
 
   const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION_ALL], 'durUser', null);
   const [minDurationMinutes, setMinDurationMinutes] = usePersistedState(`minDurUserMinutes-${location.pathname}`, null);
@@ -291,6 +294,17 @@ function ClaimListHeader(props: Props) {
               )}
 
               {filterCtx?.liftUpTagSearch && <TagSearch standalone urlParams={urlParams} handleChange={handleChange} />}
+
+              {isDiscoverPage && expanded && (
+                <FormField
+                  label={__('Hide anonymous')}
+                  className="hide-anonymous-checkbox"
+                  name="hide_anonymous"
+                  type="checkbox"
+                  checked={hideAnonymous}
+                  onChange={() => setHideAnonymous(!hideAnonymous)}
+                />
+              )}
             </div>
           </div>
           {meta && !isMobile && <div className="section__actions--no-margin">{meta}</div>}

--- a/ui/component/claimListHeader/view.jsx
+++ b/ui/component/claimListHeader/view.jsx
@@ -93,6 +93,8 @@ function ClaimListHeader(props: Props) {
   const feeAmountParam = urlParams.get('fee_amount') || feeAmount || CS.FEE_AMOUNT_ANY;
   const showDuration = !(claimType && claimType === CS.CLAIM_CHANNEL && claimType === CS.CLAIM_COLLECTION);
   const isDiscoverPage = pathname.includes(PAGES.DISCOVER);
+  const isRabbitHolePage = pathname.includes(PAGES.RABBIT_HOLE);
+  const showhideAnonymous = isDiscoverPage || isRabbitHolePage;
   const [hideAnonymous, setHideAnonymous] = usePersistedState(`hideAnonymous-${location.pathname}`, false);
 
   const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION_ALL], 'durUser', null);
@@ -296,7 +298,7 @@ function ClaimListHeader(props: Props) {
               {filterCtx?.liftUpTagSearch && <TagSearch standalone urlParams={urlParams} handleChange={handleChange} />}
             </div>
             <div className="claim-search__menu-group">
-              {isDiscoverPage && (
+              {showhideAnonymous && (
                 <FormField
                   label={__('Hide anonymous')}
                   className="hide-anonymous-checkbox"

--- a/ui/component/claimListHeader/view.jsx
+++ b/ui/component/claimListHeader/view.jsx
@@ -294,8 +294,9 @@ function ClaimListHeader(props: Props) {
               )}
 
               {filterCtx?.liftUpTagSearch && <TagSearch standalone urlParams={urlParams} handleChange={handleChange} />}
-
-              {isDiscoverPage && expanded && (
+            </div>
+            <div className="claim-search__menu-group">
+              {isDiscoverPage && (
                 <FormField
                   label={__('Hide anonymous')}
                   className="hide-anonymous-checkbox"

--- a/ui/component/claimListHeader/view.jsx
+++ b/ui/component/claimListHeader/view.jsx
@@ -94,7 +94,7 @@ function ClaimListHeader(props: Props) {
   const showDuration = !(claimType && claimType === CS.CLAIM_CHANNEL && claimType === CS.CLAIM_COLLECTION);
   const isDiscoverPage = pathname.includes(PAGES.DISCOVER);
   const isRabbitHolePage = pathname.includes(PAGES.RABBIT_HOLE);
-  const showhideAnonymous = isDiscoverPage || isRabbitHolePage;
+  const showHideAnonymous = isDiscoverPage || isRabbitHolePage;
   const [hideAnonymous, setHideAnonymous] = usePersistedState(`hideAnonymous-${location.pathname}`, false);
 
   const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION_ALL], 'durUser', null);
@@ -298,7 +298,7 @@ function ClaimListHeader(props: Props) {
               {filterCtx?.liftUpTagSearch && <TagSearch standalone urlParams={urlParams} handleChange={handleChange} />}
             </div>
             <div className="claim-search__menu-group">
-              {showhideAnonymous && (
+              {showHideAnonymous && (
                 <FormField
                   label={__('Hide anonymous')}
                   className="hide-anonymous-checkbox"

--- a/ui/scss/component/_main.scss
+++ b/ui/scss/component/_main.scss
@@ -706,6 +706,12 @@ body {
 .main--full-width {
   @extend .main;
   max-width: none;
+
+  &.main__discover {
+    @media (max-width: $breakpoint-small) {
+      padding: 0 var(--spacing-xs);
+    }
+  }
 }
 
 .main--popout-chat {
@@ -1346,10 +1352,6 @@ body {
         }
       }
     }
-  }
-
-  @media (max-width: $breakpoint-small) {
-    padding: var(--spacing-xs);
   }
 }
 


### PR DESCRIPTION
Allows filtering anonymous uploads in https://odysee.com/$/discover (tag search)

Not page wide setting since this also filters channel claims. 

This should otherwise be functional, but don't know what to do for UI(this was the only idea I had). Can you help @toshokanneko?
![hide-anonymous](https://user-images.githubusercontent.com/34790748/221899381-31c55f61-6bb5-4d78-97b8-2ddf32b57934.png)
