### PR TITLE
Drag-and-drop: file unselected when entering Upload Page

### DIFF
--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -394,15 +394,6 @@ function UploadForm(props: Props) {
     }
   }
 
-  // When accessing to publishing, make sure to reset file input attributes
-  // since we can't restore from previous user selection (like we do
-  // with other properties such as name, title, etc.) for security reasons.
-  useEffect(() => {
-    if (mode === PUBLISH_MODES.FILE) {
-      updatePublishForm({ filePath: '', fileDur: 0, fileSize: 0 });
-    }
-  }, [mode, updatePublishForm]);
-
   // FIle Source Selector State.
   const [fileSource, setFileSource] = useState();
   const changeFileSource = (state) => setFileSource(state);


### PR DESCRIPTION
## Issue
Closes #2546

## Notes
Back in 2021, https://github.com/lbryio/lbry-desktop/pull/6855 intentionally resets `filePath` during the mode transition in order to (indirectly?) handle the F5 reload case, since files need to be reselected for security reasons.

With the publish page revamp in 2022, that change doesn't make much sense anymore since the meaning of `mode` is kind of different now (that part needs some cleanup). Also, the new system is more aggresive in clearing the form in various cases, so the original F5 cases seems to be covered as well.

## Change
Removed the change in 2021 since the bug that it was trying to fix is already handled in the revamped version.

If the original F5 issue comes back through another scenario, a better fix would be to clear unwanted fields during boot through the `REHYDRATE` phase rather than through page transitions.
