### PR TITLE
Support language specific `/$/content/get`

### DIFF
--- a/flow-typed/homepage.js
+++ b/flow-typed/homepage.js
@@ -11,6 +11,17 @@ declare type HomepageData = {
   default: (any) => any,
 };
 
+declare type HomepagesDb = {
+  [string]: {
+    categories: {},
+    portals: {},
+    featured: {},
+    meme: string,
+    discover: Array<string>,
+    announcement: string,
+  }
+};
+
 declare type RowDataItem = {
   id: string,
   title: any,

--- a/ui/component/app/index.js
+++ b/ui/component/app/index.js
@@ -17,11 +17,18 @@ import {
   selectThemePath,
   selectDefaultChannelClaim,
   selectHomepageAnnouncement,
+  selectHomepageCode,
 } from 'redux/selectors/settings';
 import { selectAnyNagsShown } from 'redux/selectors/notifications';
 import { selectModal, selectActiveChannelClaim, selectIsReloadRequired } from 'redux/selectors/app';
 import { selectUploadCount } from 'redux/selectors/publish';
-import { doOpenAnnouncements, doSetLanguage, doSetDefaultChannel, doFetchLanguage } from 'redux/actions/settings';
+import {
+  doOpenAnnouncements,
+  doSetLanguage,
+  doSetDefaultChannel,
+  doFetchLanguage,
+  doFetchHomepages,
+} from 'redux/actions/settings';
 import { doSyncLoop } from 'redux/actions/sync';
 import { doSignIn, doSetIncognito, doSetGdprConsentList } from 'redux/actions/app';
 import { doFetchModBlockedList, doFetchCommentModAmIList } from 'redux/actions/comments';
@@ -34,6 +41,7 @@ const select = (state) => ({
   theme: selectThemePath(state),
   language: selectLanguage(state),
   languages: selectLoadedLanguages(state),
+  homepageCode: selectHomepageCode(state),
   isReloadRequired: selectIsReloadRequired(state),
   prefsReady: selectPrefsReady(state),
   syncError: selectGetSyncErrorMessage(state),
@@ -54,6 +62,7 @@ const select = (state) => ({
 const perform = {
   setLanguage: doSetLanguage,
   fetchLanguage: doFetchLanguage,
+  doFetchHomepages,
   signIn: doSignIn,
   syncLoop: doSyncLoop,
   doUserSetReferrerForUri,

--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -68,6 +68,8 @@ type Props = {
   signIn: () => void,
   setLanguage: (string) => void,
   fetchLanguage: (string) => void,
+  homepageCode: string,
+  doFetchHomepages: (string) => void,
   isReloadRequired: boolean,
   uploadCount: number,
   balance: ?number,
@@ -115,6 +117,8 @@ function App(props: Props) {
     languages,
     setLanguage,
     fetchLanguage,
+    homepageCode,
+    doFetchHomepages,
     rewards,
     doUserSetReferrerForUri,
     isAuthenticated,
@@ -359,6 +363,10 @@ function App(props: Props) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [language, languages]);
+
+  useEffect(() => {
+    doFetchHomepages(homepageCode);
+  }, [homepageCode, doFetchHomepages]);
 
   useEffect(() => {
     if (shouldMigrateLanguage) {

--- a/ui/component/homepageSelector/index.js
+++ b/ui/component/homepageSelector/index.js
@@ -1,14 +1,15 @@
 import { connect } from 'react-redux';
 import SelectHomepage from './view';
 import { doSetHomepage } from 'redux/actions/settings';
-import { selectHomepageCode } from 'redux/selectors/settings';
+import { selectHomepageCode, selectHomepageKeys } from 'redux/selectors/settings';
 
-const select = state => ({
+const select = (state) => ({
   homepage: selectHomepageCode(state),
+  homepageKeys: selectHomepageKeys(state),
 });
 
-const perform = dispatch => ({
-  setHomepage: value => dispatch(doSetHomepage(value)),
+const perform = (dispatch) => ({
+  setHomepage: (value) => dispatch(doSetHomepage(value)),
 });
 
 export default connect(select, perform)(SelectHomepage);

--- a/ui/component/homepageSelector/view.jsx
+++ b/ui/component/homepageSelector/view.jsx
@@ -6,13 +6,12 @@ import { getDefaultHomepageKey } from 'util/default-languages';
 
 type Props = {
   homepage: string,
+  homepageKeys: Array<string>,
   setHomepage: (string) => void,
 };
 
 function SelectHomepage(props: Props) {
-  const { homepage, setHomepage } = props;
-  const homepages = window.homepages || {};
-  const homepageKeys = Object.keys(homepages);
+  const { homepage, homepageKeys, setHomepage } = props;
 
   function handleSetHomepage(e) {
     const { value } = e.target;

--- a/ui/component/settingAppearance/index.js
+++ b/ui/component/settingAppearance/index.js
@@ -1,13 +1,14 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doSetClientSetting } from 'redux/actions/settings';
-import { selectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting, selectHomepageKeys } from 'redux/selectors/settings';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import SettingAppearance from './view';
 
 const select = (state) => ({
   clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
   searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
+  homepageKeys: selectHomepageKeys(state),
   isAuthenticated: selectUserVerifiedEmail(state),
   hideBalance: selectClientSetting(state, SETTINGS.HIDE_BALANCE),
   hideTitleNotificationCount: selectClientSetting(state, SETTINGS.HIDE_TITLE_NOTIFICATION_COUNT),

--- a/ui/component/settingAppearance/view.jsx
+++ b/ui/component/settingAppearance/view.jsx
@@ -14,6 +14,7 @@ import ThemeSelector from 'component/themeSelector';
 type Props = {
   clock24h: boolean,
   searchInLanguage: boolean,
+  homepageKeys: Array<string>,
   isAuthenticated: boolean,
   hideBalance: boolean,
   hideTitleNotificationCount: boolean,
@@ -25,6 +26,7 @@ export default function SettingAppearance(props: Props) {
   const {
     clock24h,
     searchInLanguage,
+    homepageKeys,
     isAuthenticated,
     hideBalance,
     hideTitleNotificationCount,
@@ -35,7 +37,6 @@ export default function SettingAppearance(props: Props) {
     location: { hash },
   } = useHistory();
   const highlightSearchInLanguage = hash === `#${SEARCH_IN_LANGUAGE}`;
-  const homepages = window.homepages || {};
 
   return (
     <>
@@ -47,7 +48,7 @@ export default function SettingAppearance(props: Props) {
         isBodyList
         body={
           <>
-            {homepages && Object.keys(homepages).length > 1 && (
+            {homepageKeys.length > 1 && (
               <SettingsRow title={__('Homepage')} subtitle={__('Tailor your experience.')}>
                 <HomepageSelector />
               </SettingsRow>

--- a/ui/component/settingUnauthenticated/index.js
+++ b/ui/component/settingUnauthenticated/index.js
@@ -1,12 +1,13 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doSetClientSetting } from 'redux/actions/settings';
-import { selectClientSetting } from 'redux/selectors/settings';
+import { selectClientSetting, selectHomepageKeys } from 'redux/selectors/settings';
 
 import SettingUnauthenticated from './view';
 
 const select = (state) => ({
   searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
+  homepageKeys: selectHomepageKeys(state),
 });
 
 const perform = (dispatch) => ({

--- a/ui/component/settingUnauthenticated/view.jsx
+++ b/ui/component/settingUnauthenticated/view.jsx
@@ -12,12 +12,12 @@ import SettingsRow from 'component/settingsRow';
 
 type Props = {
   searchInLanguage: boolean,
+  homepageKeys: Array<string>,
   setSearchInLanguage: (boolean) => void,
 };
 
 export default function SettingUnauthenticated(props: Props) {
-  const { searchInLanguage, setSearchInLanguage } = props;
-  const homepages = window.homepages || {};
+  const { searchInLanguage, homepageKeys, setSearchInLanguage } = props;
 
   return (
     <Card
@@ -37,7 +37,7 @@ export default function SettingUnauthenticated(props: Props) {
             />
           </SettingsRow>
 
-          {homepages && Object.keys(homepages).length > 1 && (
+          {homepageKeys.length > 1 && (
             <SettingsRow title={__('Homepage')} subtitle={__('Tailor your experience.')}>
               <HomepageSelector />
             </SettingsRow>

--- a/ui/index.jsx
+++ b/ui/index.jsx
@@ -23,7 +23,12 @@ import {
 import Lbry, { apiCall } from 'lbry';
 import { isURIValid } from 'util/lbryURI';
 import { setSearchApi } from 'redux/actions/search';
-import { doSetLanguage, doFetchLanguage, doUpdateIsNightAsync, doFetchHomepages } from 'redux/actions/settings';
+import {
+  doSetLanguage,
+  doFetchLanguage,
+  doUpdateIsNightAsync,
+  doLoadBuiltInHomepageData,
+} from 'redux/actions/settings';
 import { doFetchUserLocale } from 'redux/actions/user';
 import { Lbryio, doBlackListedOutpointsSubscribe, doFilteredOutpointsSubscribe } from 'lbryinc';
 import rewards from 'rewards';
@@ -235,12 +240,13 @@ function AppWrapper() {
   useEffect(() => {
     if (readyToLaunch && persistDone) {
       app.store.dispatch(doDaemonReady());
+      app.store.dispatch(doLoadBuiltInHomepageData());
 
       const timer = setTimeout(() => {
         if (DEFAULT_LANGUAGE) {
           app.store.dispatch(doFetchLanguage(DEFAULT_LANGUAGE));
         }
-        app.store.dispatch(doFetchHomepages());
+
         app.store.dispatch(doUpdateIsNightAsync());
         app.store.dispatch(doBlackListedOutpointsSubscribe());
         app.store.dispatch(doFilteredOutpointsSubscribe());

--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -350,9 +350,14 @@ export function doOpenAnnouncements() {
 
 export function doFetchHomepages() {
   return (dispatch) => {
-    // -- Use this env flag to use local homepage data and meme (faster).
-    // -- Otherwise, it will grab from `/$/api/content/v*/get`.
     // @if USE_LOCAL_HOMEPAGE_DATA='true'
+    // ------------------------------------------------------------------------
+    // USE_LOCAL_HOMEPAGE_DATA used to be able to replace the fetch entirely,
+    // but is now mainly for fallback data and perceived faster startup. We
+    // still need to fetch anyway (hence, no early return here) because the
+    // Announcements framework depends on fresh data, and the built-in version
+    // could be a stale one from browser caching.
+    // ------------------------------------------------------------------------
     loadBuiltInHomepageData(dispatch);
     // @endif
 

--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -15,6 +15,7 @@ import { doAlertWaitingForSync, doGetAndPopulatePreferences, doOpenModal } from 
 import { selectPrefsReady } from 'redux/selectors/sync';
 import { Lbryio } from 'lbryinc';
 import { getDefaultLanguage } from 'util/default-languages';
+import { postProcessHomepageDb } from 'util/homepages';
 import { LocalStorage } from 'util/storage';
 
 const { URL_DEV } = require('config');
@@ -365,7 +366,7 @@ export function doFetchHomepages() {
       .then((response) => response.json())
       .then((json) => {
         if (json?.status === 'success' && json?.data) {
-          window.homepages = json.data;
+          window.homepages = postProcessHomepageDb(json.data);
           populateCategoryTitles(window.homepages?.en?.categories);
           dispatch({ type: ACTIONS.FETCH_HOMEPAGES_DONE });
         } else {

--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -15,7 +15,7 @@ import { doAlertWaitingForSync, doGetAndPopulatePreferences, doOpenModal } from 
 import { selectPrefsReady } from 'redux/selectors/sync';
 import { Lbryio } from 'lbryinc';
 import { getDefaultLanguage } from 'util/default-languages';
-import { postProcessHomepageDb } from 'util/homepages';
+import { postProcessHomepageDb, updateHomepageDb } from 'util/homepages';
 import { LocalStorage } from 'util/storage';
 
 const { URL_DEV } = require('config');
@@ -323,19 +323,32 @@ function populateCategoryTitles(categories) {
   }
 }
 
-function loadBuiltInHomepageData(dispatch) {
-  const homepages = require('homepages');
-  if (homepages) {
-    const v2 = {};
-    const homepageKeys = Object.keys(homepages);
-    homepageKeys.forEach((hp) => {
-      v2[hp] = homepages[hp];
-    });
+export function doLoadBuiltInHomepageData() {
+  return (dispatch) => {
+    // @if USE_LOCAL_HOMEPAGE_DATA='true'
+    // ------------------------------------------------------------------------
+    // USE_LOCAL_HOMEPAGE_DATA used to be able to replace the fetch entirely,
+    // but is now mainly for fallback data and perceived faster startup. We
+    // still need to fetch anyway because the Announcements framework depends on
+    // fresh data, and the built-in version could be a stale one from browser
+    // caching.
+    // ------------------------------------------------------------------------
 
-    window.homepages = v2;
-    populateCategoryTitles(window.homepages?.en?.categories);
-    dispatch({ type: ACTIONS.FETCH_HOMEPAGES_DONE });
-  }
+    const homepages = require('homepages');
+    if (homepages) {
+      const v2 = {};
+      const homepageKeys = Object.keys(homepages);
+      homepageKeys.forEach((hp) => {
+        v2[hp] = homepages[hp];
+      });
+
+      window.homepages = v2;
+      populateCategoryTitles(window.homepages?.en?.categories);
+      dispatch({ type: ACTIONS.FETCH_HOMEPAGES_DONE });
+    }
+
+    // @endif
+  };
 }
 
 export function doOpenAnnouncements() {
@@ -349,24 +362,16 @@ export function doOpenAnnouncements() {
   };
 }
 
-export function doFetchHomepages() {
+export function doFetchHomepages(hp /* ?string */) {
   return (dispatch) => {
-    // @if USE_LOCAL_HOMEPAGE_DATA='true'
-    // ------------------------------------------------------------------------
-    // USE_LOCAL_HOMEPAGE_DATA used to be able to replace the fetch entirely,
-    // but is now mainly for fallback data and perceived faster startup. We
-    // still need to fetch anyway (hence, no early return here) because the
-    // Announcements framework depends on fresh data, and the built-in version
-    // could be a stale one from browser caching.
-    // ------------------------------------------------------------------------
-    loadBuiltInHomepageData(dispatch);
-    // @endif
+    const param = hp ? `?hp=${hp}` : '';
 
-    fetch('https://odysee.com/$/api/content/v2/get')
+    fetch(`https://odysee.com/$/api/content/v2/get${param}`)
       .then((response) => response.json())
       .then((json) => {
         if (json?.status === 'success' && json?.data) {
-          window.homepages = postProcessHomepageDb(json.data);
+          window.homepages = updateHomepageDb(window.homepages, json.data, hp);
+          window.homepages = postProcessHomepageDb(window.homepages);
           populateCategoryTitles(window.homepages?.en?.categories);
           dispatch({ type: ACTIONS.FETCH_HOMEPAGES_DONE });
         } else {

--- a/ui/redux/selectors/settings.js
+++ b/ui/redux/selectors/settings.js
@@ -88,14 +88,6 @@ export const selectHomepageKeys = (state) => {
 export const selectHomepageData = (state) => {
   const homepageCode = selectHomepageCode(state);
   const homepages = selectHomepageDb(state);
-
-  if (homepages && homepages[homepageCode] && !homepages[homepageCode].portals) {
-    homepages[homepageCode].portals = homepages['en'].portals;
-  }
-  if (homepages && homepages[homepageCode] && !homepages[homepageCode].featured) {
-    homepages[homepageCode].featured = homepages['en'].featured;
-  }
-
   return homepages ? homepages[homepageCode] || homepages['en'] || {} : undefined;
 };
 

--- a/ui/redux/selectors/settings.js
+++ b/ui/redux/selectors/settings.js
@@ -57,7 +57,7 @@ export const selectThemePath = createSelector(
 
 export const selectHomepageCode = (state) => {
   const hp = selectClientSetting(state, SETTINGS.HOMEPAGE);
-  const homepages = window.homepages || {};
+  const homepages = selectHomepageDb(state) || {};
   return homepages[hp] ? hp : getDefaultHomepageKey();
 };
 
@@ -66,9 +66,28 @@ export const selectLanguage = (state) => {
   return lang || getDefaultLanguage();
 };
 
+/**
+ * Returns the full/raw homepage object that was fetched.
+ */
+export const selectHomepageDb = (state) => {
+  return window.homepages; // TODO: find a better place than window.
+};
+
+/**
+ * Returns an array of homepage codes that we currently support.
+ * e.g. "['en', 'es', 'ru']"
+ */
+export const selectHomepageKeys = (state) => {
+  const db = selectHomepageDb(state) || {};
+  return Object.keys(db);
+};
+
+/**
+ * Returns the data for the currently-selected homepage.
+ */
 export const selectHomepageData = (state) => {
   const homepageCode = selectHomepageCode(state);
-  const homepages = window.homepages;
+  const homepages = selectHomepageDb(state);
 
   if (homepages && homepages[homepageCode] && !homepages[homepageCode].portals) {
     homepages[homepageCode].portals = homepages['en'].portals;
@@ -82,7 +101,7 @@ export const selectHomepageData = (state) => {
 
 export const selectHomepageMeme = (state) => {
   const homepageCode = selectHomepageCode(state);
-  const homepages = window.homepages;
+  const homepages = selectHomepageDb(state);
   if (homepages) {
     const meme = homepages[homepageCode].meme;
     if (meme && meme.text && meme.url) {
@@ -94,7 +113,7 @@ export const selectHomepageMeme = (state) => {
 
 export const selectHomepageDiscover = (state) => {
   const homepageCode = selectHomepageCode(state);
-  const homepages = window.homepages;
+  const homepages = selectHomepageDb(state);
   if (homepages) {
     const discover = homepages[homepageCode].discover;
     if (discover) {
@@ -106,7 +125,7 @@ export const selectHomepageDiscover = (state) => {
 
 export const selectHomepageAnnouncement = (state) => {
   const homepageCode = selectHomepageCode(state);
-  const homepages = window.homepages;
+  const homepages = selectHomepageDb(state);
   if (homepages) {
     const news = homepages[homepageCode].announcement;
     if (news) {

--- a/ui/util/homepages.js
+++ b/ui/util/homepages.js
@@ -1,0 +1,33 @@
+// @flow
+
+/**
+ * Hook to post-process or customize the fetched homepage data.
+ *
+ * The only change for now is to point empty `portals` and `featured` to the
+ * English version so that we don't have to repeatedly do that in selectors.
+ * This assumes the rest of the app does not need to know if a particular
+ * homepage have a blank `portals` or `featured`.
+ *
+ * @param oldDb
+ * @returns The new db.
+ */
+export function postProcessHomepageDb(oldDb: ?HomepagesDb) {
+  if (!oldDb || !oldDb['en']) {
+    return oldDb;
+  }
+
+  const db = { ...oldDb };
+  const homepagesToCheck = Object.keys(oldDb).filter((hp) => hp !== 'en');
+
+  homepagesToCheck.forEach((hp) => {
+    if (!db[hp].portals) {
+      db[hp].portals = db['en'].portals;
+    }
+
+    if (!db[hp].featured) {
+      db[hp].featured = db['en'].featured;
+    }
+  });
+
+  return db;
+}

--- a/ui/util/homepages.js
+++ b/ui/util/homepages.js
@@ -1,6 +1,28 @@
 // @flow
 
 /**
+ * Merges data, either partially or completely, from newDb to oldDb.
+ *
+ * @param oldDb
+ * @param newDb
+ * @param hp If provided, only update the data for this specified homepage.
+ * @returns The new/merged db.
+ */
+export function updateHomepageDb(oldDb: ?HomepagesDb, newDb: ?HomepagesDb, hp: ?string) {
+  if (!oldDb && newDb) {
+    return newDb;
+  } else if (!oldDb || !newDb) {
+    return oldDb;
+  }
+
+  if (hp) {
+    return { ...oldDb, [hp]: newDb[hp] };
+  } else {
+    return { ...newDb };
+  }
+}
+
+/**
  * Hook to post-process or customize the fetched homepage data.
  *
  * The only change for now is to point empty `portals` and `featured` to the

--- a/web/src/getHomepageJSON.js
+++ b/web/src/getHomepageJSON.js
@@ -31,6 +31,10 @@ if (!memo.homepageData) {
   }
 }
 
+// ****************************************************************************
+// v1
+// ****************************************************************************
+
 const getHomepageJsonV1 = () => {
   if (!memo.homepageData) {
     return {};
@@ -44,6 +48,10 @@ const getHomepageJsonV1 = () => {
   return v1;
 };
 
+// ****************************************************************************
+// v2
+// ****************************************************************************
+
 const reformatV2Categories = (categories, format) => {
   if (format === FORMAT.ROKU) {
     return categories && Object.entries(categories).map(([key, value]) => value);
@@ -52,23 +60,39 @@ const reformatV2Categories = (categories, format) => {
   }
 };
 
-const getHomepageJsonV2 = (format) => {
+/**
+ * getHomepageJsonV2
+ *
+ * @param format [?string] Request for custom format. See FORMAT above.
+ * @param lang [?string] Only populates data for the requested homepage.
+ *             NOTE: the key for all supported languages will still be created
+ *             (for apps to define dropdown lists), just that the value is left
+ *             empty.
+ * @returns {{}}
+ */
+const getHomepageJsonV2 = (format, lang) => {
   if (!memo.homepageData) {
     return {};
   }
 
   const v2 = {};
   const homepageKeys = Object.keys(memo.homepageData);
+
   homepageKeys.forEach((hp) => {
-    v2[hp] = {
-      categories: reformatV2Categories(memo.homepageData[hp].categories, format),
-      portals: memo.homepageData[hp].portals,
-      featured: memo.homepageData[hp].featured,
-      meme: memo.homepageData[hp].meme,
-      discover: memo.homepageData[hp].discover,
-      announcement: memo.announcements[hp],
-    };
+    if (!lang || lang === hp) {
+      v2[hp] = {
+        categories: reformatV2Categories(memo.homepageData[hp].categories, format),
+        portals: memo.homepageData[hp].portals,
+        featured: memo.homepageData[hp].featured,
+        meme: memo.homepageData[hp].meme,
+        discover: memo.homepageData[hp].discover,
+        announcement: memo.announcements[hp],
+      };
+    } else {
+      v2[hp] = null;
+    }
   });
+
   return v2;
 };
 

--- a/web/src/homepageApi.js
+++ b/web/src/homepageApi.js
@@ -9,9 +9,10 @@ async function getHomepage(ctx, version) {
   }
 
   const format = ctx?.request?.query?.format;
+  const hp = ctx?.request?.query?.hp;
 
   try {
-    const content = version === 1 ? getHomepageJsonV1() : getHomepageJsonV2(format);
+    const content = version === 1 ? getHomepageJsonV1() : getHomepageJsonV2(format, hp);
     ctx.set('Content-Type', 'application/json');
     ctx.set('Access-Control-Allow-Origin', '*');
     ctx.body = {


### PR DESCRIPTION
## API-Change Notes

1. `existing` To retrieve full homepage dataset :
    - https://odysee.com/$/api/content/v2/get
    - <img width="370" alt="image" src="https://user-images.githubusercontent.com/64950861/222883568-001a648e-a292-45d6-80e3-fef4212d2caf.png">
2. `new` To retrieve a specific homepage :
    - https://odysee.com/$/api/content/v2/get?hp=xx 
      - _where `xx` = `en`, `fr`, `es`, etc..._
    - The return object will still include the keys for all available homepages, but the values for unwanted homepages will be set to `null`. 
    - The full key set will allow clients to generate drop-down lists without needing a different API.
    - <img width="384" alt="image" src="https://user-images.githubusercontent.com/64950861/222883439-4f09788f-ec2e-488f-8bee-ec8d5d2c449d.png">


## Review Notes
<details>
  <summary>Expand...</summary>
  <br>
  Closes #2388

  - Test using `kp.odysee.tv`.  There is a CORS problem, but most likely not affecting the API.
  - Not familiar with portals' behavior to detect unintended breakage -- do take a look.  But I don't think it will be broken.
  - What other scenarios to double-confirm besides these:
    - Incognito
    - Setting saved to non-English
    - Browser default is non-English
 
</details>

