### PR TITLE
Use app language for the date in livestream overlay

### DIFF
--- a/ui/component/livestreamScheduledInfo/index.js
+++ b/ui/component/livestreamScheduledInfo/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 
 import { selectMomentReleaseTimeForUri } from 'redux/selectors/claims';
+import { selectLanguage } from 'redux/selectors/settings';
 
 import LivestreamScheduledInfo from './view';
 
@@ -11,6 +12,7 @@ const select = (state, props) => {
 
   return {
     releaseTimeMs: releaseTime ? releaseTime.unix() * 1000 : 0,
+    appLanguage: selectLanguage(state),
   };
 };
 

--- a/ui/component/livestreamScheduledInfo/view.jsx
+++ b/ui/component/livestreamScheduledInfo/view.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import * as ICONS from 'constants/icons';
 import Icon from 'component/common/icon';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 import 'scss/component/livestream-scheduled-info.scss';
 import I18nMessage from 'component/i18nMessage';
 import { getTimeAgoStr } from 'util/time';
@@ -13,15 +13,16 @@ const CALC_TIME_INTERVAL_MS = 1000;
 type Props = {
   // -- redux --
   releaseTimeMs: number,
+  appLanguage: string,
 };
 
 export default function LivestreamScheduledInfo(props: Props) {
-  const { releaseTimeMs } = props;
+  const { releaseTimeMs, appLanguage } = props;
 
   const [startDateFromNow, setStartDateFromNow] = React.useState();
   const [inPast, setInPast] = React.useState();
 
-  const startDate = React.useMemo(() => moment(releaseTimeMs).format('MMMM Do, h:mm a'), [releaseTimeMs]);
+  const startDate = React.useMemo(() => moment(releaseTimeMs).locale(appLanguage).format('LLL'), [releaseTimeMs]);
 
   React.useEffect(() => {
     const calcTime = () => {


### PR DESCRIPTION

Use app language for date in here. (Had missed this one)
![overaly](https://user-images.githubusercontent.com/34790748/224103804-ab4e124b-74ea-4b19-85b4-6bc672c1ef2e.png)

