### PR TITLE
Support chapters which have tab as separator (Timestamp\tTitle)

### DIFF
--- a/ui/component/viewers/videoViewer/internal/chapters.jsx
+++ b/ui/component/viewers/videoViewer/internal/chapters.jsx
@@ -61,7 +61,7 @@ function parse(claim: StreamClaim) {
 
   lines.forEach((line) => {
     if (line.length > 0) {
-      const splitIndex = line.indexOf(' ');
+      const splitIndex = line.search(/[ |\t]/);
       if (splitIndex >= 0 && splitIndex < line.length - 2) {
         const ts = line.substring(0, splitIndex);
         const label = line.substring(splitIndex + 1);


### PR DESCRIPTION
Fixes:
Chapters where separator between the timestamp and the title was a tab didn't got detected.

Example:
This has no chapters in current version of Odysee.
https://odysee.com/@y:48/sup:b