### PR TITLE
Fix attempt - Handle unmuting channels with ":" in url

### DIFF
--- a/ui/redux/reducers/blocked.js
+++ b/ui/redux/reducers/blocked.js
@@ -1,6 +1,7 @@
 // @flow
 import * as ACTIONS from 'constants/action_types';
 import { handleActions } from 'util/redux-utils';
+import { getOldFormatForLbryUri } from 'util/lbryURI';
 
 const defaultState: BlocklistState = {
   blockedChannels: [],
@@ -34,9 +35,10 @@ export default handleActions(
     [ACTIONS.USER_STATE_POPULATE]: (state: BlocklistState, action: { data: { blocked: ?Array<string> } }) => {
       const { blocked } = action.data;
       const sanitizedBlocked = blocked && blocked.filter((e) => typeof e === 'string');
+      const parsedBlocked = sanitizedBlocked && Array.from(new Set(sanitizedBlocked.map((uri) => getOldFormatForLbryUri(uri))));
       return {
         ...state,
-        blockedChannels: sanitizedBlocked || state.blockedChannels,
+        blockedChannels: parsedBlocked || state.blockedChannels,
       };
     },
   },

--- a/ui/util/lbryURI.js
+++ b/ui/util/lbryURI.js
@@ -347,3 +347,7 @@ export function sanitizeName(name: string) {
   const INVALID_URI_CHARS = new RegExp(regexInvalidURI, 'gu');
   return name.replace(INVALID_URI_CHARS, '-');
 }
+
+export function getOldFormatForLbryUri(uri: string) {
+  return uri.replace(/:/g, '#').replace('#',':');
+}

--- a/ui/util/lbryURI.js
+++ b/ui/util/lbryURI.js
@@ -349,5 +349,5 @@ export function sanitizeName(name: string) {
 }
 
 export function getOldFormatForLbryUri(uri: string) {
-  return uri.replace(/:/g, '#').replace('#',':');
+  return uri.replace(/:/g, '#').replace('#', ':');
 }


### PR DESCRIPTION
Supposed to fix issue number: #2587

----- 
~Note:
Search acts bit strange if the same lbryUrl is in muted channels multiple times. Duplicated ones don't disappear when they should. (Had 4 times the DEADBUG Says in muted list)~
![same_key](https://user-images.githubusercontent.com/34790748/224558881-8c515f21-c0f6-4e6d-9fb0-268756dcbda5.png)

~Tested using `index` as a `key` in here, and above stopped from happening. But couldn't figure out a good way to make unique keys, so didn't do anything for it for now.  Guess this also pretty rare to happen.~

~In here -> https://github.com/OdyseeTeam/odysee-frontend/blob/master/ui/component/claimList/view.jsx#L442~


