### PR TITLE
Fix broken CodeMirror after webpack upgrade

### DIFF
--- a/ui/component/viewers/codeViewer.jsx
+++ b/ui/component/viewers/codeViewer.jsx
@@ -48,7 +48,8 @@ class CodeViewer extends React.PureComponent<Props> {
       /* webpackChunkName: "codemirror" */
       'codemirror/lib/codemirror'
     ).then((CodeMirror) => {
-      me.codeMirror = CodeMirror.fromTextArea(me.textarea, {
+      const CM = CodeMirror.default || CodeMirror;
+      me.codeMirror = CM.fromTextArea(me.textarea, {
         // Auto detect syntax with file contentType
         mode: contentType,
         // Adaptive theme


### PR DESCRIPTION
Ticket: Closes #2584

_Note that you still won't see it load due to an component bug -- that has been filed separatedly._

## Cause
Webpack 5 changed how it handles ES6 modules by default, and here's a reminder:

> _Note that when using import() on ES6 modules you must reference the .default property as it's the actual module object that will be returned when the promise is resolved._

## Change
We probably don't need to be backward compatible with older webpack, but look for both syntax nonetheless.
