### PR TITLE
Fix attempt - Always functional profile menu button

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2881,6 +2881,7 @@
   "Boost your claim": "Boost your claim",
   "Leave a tip for the creator": "Leave a tip for the creator",
   "Show this creator your appreciation by sending a donation.": "Show this creator your appreciation by sending a donation.",
+  "Loading channels...": "Loading channels...",
 
   "--end--": "--end--"
 }

--- a/ui/component/channelSelector/internal/loading-selector.jsx
+++ b/ui/component/channelSelector/internal/loading-selector.jsx
@@ -1,0 +1,19 @@
+// @flow
+import React from 'react';
+import classnames from 'classnames';
+
+type Props = {
+  isSelected?: boolean,
+};
+
+const LoadingSelector = (props: Props) => {
+  const { isSelected } = props;
+
+  return (
+    <div className={classnames('channel__list-item', { 'channel__list-item--selected': isSelected })}>
+      <h2 className="channel__list-text">{__('Loading channels...')}</h2>
+    </div>
+  );
+};
+
+export default LoadingSelector;

--- a/ui/component/channelSelector/view.jsx
+++ b/ui/component/channelSelector/view.jsx
@@ -8,6 +8,7 @@ import { Menu, MenuList, MenuButton, MenuItem } from '@reach/menu-button';
 import Icon from 'component/common/icon';
 import { useHistory } from 'react-router';
 import IncognitoSelector from './internal/incognito-selector';
+import LoadingSelector from './internal/loading-selector';
 import ChannelListItem from './internal/channelListItem';
 import { NavLink } from 'react-router-dom';
 import { formatLbryUrlForWeb } from 'util/url';
@@ -64,6 +65,8 @@ function ChannelSelector(props: Props) {
 
   const activeChannelUrl = activeChannelClaim && activeChannelClaim.permanent_url;
   const activeChannelId = activeChannelClaim && activeChannelClaim.claim_id;
+  const noActiveChannel = activeChannelUrl === null;
+  const pendingChannelFetch = !noActiveChannel && channelIds === undefined;
 
   function handleChannelSelect(channelId) {
     doSetIncognito(false);
@@ -125,6 +128,8 @@ function ChannelSelector(props: Props) {
             <MenuButton>
               {showAllOption && allOptionProps?.isSelected ? (
                 <AllSelector isSelected />
+              ) : pendingChannelFetch ? (
+                <LoadingSelector isSelected />
               ) : (incognito && !hideAnon) || !activeChannelUrl ? (
                 <IncognitoSelector isSelected />
               ) : (

--- a/ui/component/channelSelector/view.jsx
+++ b/ui/component/channelSelector/view.jsx
@@ -125,7 +125,7 @@ function ChannelSelector(props: Props) {
               </MenuButton>
             </>
           ) : (
-            <MenuButton>
+            <MenuButton disabled={pendingChannelFetch}>
               {showAllOption && allOptionProps?.isSelected ? (
                 <AllSelector isSelected />
               ) : pendingChannelFetch ? (

--- a/ui/component/headerProfileMenuButton/index.js
+++ b/ui/component/headerProfileMenuButton/index.js
@@ -14,7 +14,6 @@ const select = (state) => ({
   automaticDarkModeEnabled: selectClientSetting(state, SETTINGS.AUTOMATIC_DARK_MODE_ENABLED),
 
   user: selectUser(state),
-  myChannelClaimIds: selectMyChannelClaimIds(state),
   activeChannelClaim: selectActiveChannelClaim(state),
   authenticated: selectUserVerifiedEmail(state),
   email: selectUserEmail(state),

--- a/ui/component/headerProfileMenuButton/index.js
+++ b/ui/component/headerProfileMenuButton/index.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import { doSignOut } from 'redux/actions/app';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
-import { selectMyChannelClaimIds } from 'redux/selectors/claims';
 import { selectUser, selectUserEmail, selectUserVerifiedEmail } from 'redux/selectors/user';
 import { selectClientSetting } from 'redux/selectors/settings';
 import { doSetClientSetting } from 'redux/actions/settings';

--- a/ui/component/headerProfileMenuButton/view.jsx
+++ b/ui/component/headerProfileMenuButton/view.jsx
@@ -13,7 +13,6 @@ import classnames from 'classnames';
 import HeaderMenuLink from 'component/common/header-menu-link';
 import Icon from 'component/common/icon';
 import React from 'react';
-import Skeleton from '@mui/material/Skeleton';
 import ChannelSelector from 'component/channelSelector';
 import Button from 'component/button';
 import ClickAwayListener from '@mui/material/ClickAwayListener';

--- a/ui/component/headerProfileMenuButton/view.jsx
+++ b/ui/component/headerProfileMenuButton/view.jsx
@@ -44,7 +44,6 @@ export default function HeaderProfileMenuButton(props: HeaderMenuButtonProps) {
 
     // User
     user,
-    myChannelClaimIds,
     activeChannelClaim,
     authenticated,
     email,
@@ -61,8 +60,6 @@ export default function HeaderProfileMenuButton(props: HeaderMenuButtonProps) {
 
   const activeChannelUrl = activeChannelClaim && activeChannelClaim.permanent_url;
   // activeChannel will be: undefined = fetching, null = nothing, or { channel claim }
-  const noActiveChannel = activeChannelUrl === null;
-  const pendingChannelFetch = !noActiveChannel && myChannelClaimIds === undefined;
   const uploadProps = { requiresAuth: !authenticated };
 
   const isMobile = useIsMobile();
@@ -123,27 +120,24 @@ export default function HeaderProfileMenuButton(props: HeaderMenuButtonProps) {
         )}
         {notificationsEnabled && !isMobile && <NotificationHeaderButton />}
 
-        {pendingChannelFetch ? (
-          <Skeleton variant="circular" animation="wave" className="header__navigationItem--iconSkeleton" />
-        ) : (
-          <Button
-            id="basic-button"
-            aria-controls={open ? 'basic-menu' : undefined}
-            aria-haspopup="true"
-            aria-expanded={open ? 'true' : undefined}
-            onClick={handleClick}
-            className={classnames('header__navigationItem', {
-              'header__navigationItem--icon': !activeChannelUrl,
-              'header__navigationItem--profilePic': activeChannelUrl,
-            })}
-          >
-            {activeChannelUrl ? (
-              <ChannelThumbnail uri={activeChannelUrl} hideTooltip small noLazyLoad showMemberBadge />
-            ) : (
-              <Icon size={18} icon={ICONS.ACCOUNT} aria-hidden />
-            )}
-          </Button>
-        )}
+        <Button
+          id="basic-button"
+          aria-controls={open ? 'basic-menu' : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? 'true' : undefined}
+          onClick={handleClick}
+          className={classnames('header__navigationItem', {
+            'header__navigationItem--icon': !activeChannelUrl,
+            'header__navigationItem--profilePic': activeChannelUrl,
+          })}
+        >
+          {activeChannelUrl ? (
+            <ChannelThumbnail uri={activeChannelUrl} hideTooltip small noLazyLoad showMemberBadge />
+          ) : (
+            <Icon size={18} icon={ICONS.ACCOUNT} aria-hidden />
+          )}
+        </Button>
+
         {authenticated ? (
           <ClickAwayListener onClickAway={handleClickAway}>
             <MuiMenu {...menuProps}>

--- a/ui/component/headerProfileMenuButton/view.jsx
+++ b/ui/component/headerProfileMenuButton/view.jsx
@@ -27,7 +27,6 @@ type HeaderMenuButtonProps = {
   handleThemeToggle: (boolean, string) => void,
 
   user: ?User,
-  myChannelClaimIds: ?Array<string>,
   activeChannelClaim: ?ChannelClaim,
   authenticated: boolean,
   email: ?string,


### PR DESCRIPTION
Removes loading state from profile menu button. This prevented opening of profile menu when `channel_list` didn't return or was slow. 
Moved the logic to channel selector, so it shows some indication for channel list still loading.

NEW | OLD
![new-old](https://user-images.githubusercontent.com/34790748/228380388-234cf42e-2139-4bad-92b7-273cfc45824c.png)