### PR TITLE
Also use native VHS for iPad (patches 74450634)

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -212,7 +212,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
   const volumePanelScrollHandlerRef = useRef();
 
   const { videoUrl: livestreamVideoUrl } = activeLivestreamForChannel || {};
-  const overrideNativeVhs = !platform.isIPhone();
+  const overrideNativeVhs = !platform.isIOS();
   const showQualitySelector = (!isLivestreamClaim && overrideNativeVhs) || livestreamVideoUrl;
 
   // initiate keyboard shortcuts


### PR DESCRIPTION
As noted in 74450634, videojs dev says it can't populate what the system does not provide.

I think we just forgot that iPadOS exists.