### PR TITLE
Fix ads being loaded despite SHOW_ADS=false

### DIFF
--- a/web/component/adsSticky/index.js
+++ b/web/component/adsSticky/index.js
@@ -4,7 +4,7 @@ import { selectShouldShowAds, selectAdBlockerFound } from 'redux/selectors/app';
 import { selectClaimForUri } from 'redux/selectors/claims';
 import { selectAnyNagsShown } from 'redux/selectors/notifications';
 import { selectHomepageData } from 'redux/selectors/settings';
-import { selectUserVerifiedEmail, selectUserLocale } from 'redux/selectors/user';
+import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { isChannelClaim, isStreamPlaceholderClaim } from 'util/claim';
 
 const select = (state, props) => {
@@ -15,7 +15,6 @@ const select = (state, props) => {
     isChannelClaim: isChannelClaim(claim),
     authenticated: selectUserVerifiedEmail(state),
     homepageData: selectHomepageData(state) || {},
-    locale: selectUserLocale(state),
     nagsShown: selectAnyNagsShown(state),
     shouldShowAds: selectShouldShowAds(state),
     adBlockerFound: selectAdBlockerFound(state),

--- a/web/component/adsSticky/view.jsx
+++ b/web/component/adsSticky/view.jsx
@@ -22,22 +22,13 @@ type Props = {
   authenticated: ?boolean,
   shouldShowAds: boolean,
   homepageData: any,
-  locale: ?LocaleInfo,
   nagsShown: boolean,
   adBlockerFound: ?boolean,
 };
 
 export default function AdsSticky(props: Props) {
-  const {
-    isContentClaim,
-    isChannelClaim,
-    authenticated,
-    shouldShowAds,
-    homepageData,
-    locale,
-    nagsShown,
-    adBlockerFound,
-  } = props;
+  const { isContentClaim, isChannelClaim, authenticated, shouldShowAds, homepageData, nagsShown, adBlockerFound } =
+    props;
 
   // $FlowIgnore
   const inAllowedPath = shouldShowAdsForPath(location.pathname, isContentClaim, isChannelClaim, authenticated);
@@ -60,7 +51,6 @@ export default function AdsSticky(props: Props) {
   }
 
   function shouldShowAdsForPath(pathname, isContentClaim, isChannelClaim, authenticated) {
-    // $FlowIgnore
     const pathIsCategory = Object.values(homepageData.categories || {}).some((x) =>
       // $FlowIgnore
       pathname.startsWith(`/$/${x?.name}`)
@@ -83,7 +73,7 @@ export default function AdsSticky(props: Props) {
 
   React.useEffect(() => {
     let script, scriptId, scriptSticky;
-    if (!isActive && inAllowedPath && locale && !locale.gdpr_required && !nagsShown) {
+    if (shouldShowAds && !isActive && inAllowedPath && !nagsShown) {
       try {
         const stickyIdCheck = Array.from(document.getElementsByTagName('script')).findIndex((e) => {
           return Boolean(e.innerHTML.indexOf('rcStickyWidgetId'));
@@ -128,7 +118,7 @@ export default function AdsSticky(props: Props) {
         };
       } catch (e) {}
     }
-  }, [shouldShowAds, inAllowedPath, AD_CONFIG, isActive, location]);
+  }, [shouldShowAds, nagsShown, inAllowedPath, isActive]);
 
   return (
     <div


### PR DESCRIPTION
## Issue
Couldn't install blockers in BrowserStack, so had to disable by flag, but ads are still being loaded.

## Changes
- `shouldShowAds` covers `locale`, so `locale` is not required. But `shouldShowAds` also looks at the user's GDPR answer -- is that why the logic was split?
- Fixed dependency.
