### PR TITLE
Don't mount video until `get` is complete

### DIFF
--- a/ui/hocs/withStreamClaimRender/view.jsx
+++ b/ui/hocs/withStreamClaimRender/view.jsx
@@ -326,6 +326,8 @@ const withStreamClaimRender = (StreamClaimComponent: FunctionalComponentParam) =
       } else if (renderMode === 'md') {
         return <LoadingScreen />;
       }
+
+      return <LoadingScreen />;
     }
 
     // -- Main Component Render -- return when already has the claim's contents


### PR DESCRIPTION
## Ticket
Closes #2624
We were seeing video urls with `..../undefined` being called, before the actual url is called later.

## Cause
PR_2578 changed the "loading" if-block such that there is no final else-block, so the bottom code got executed and mounted the video player.

## Change
Based on the original code, it was just showing the spinner whenever there is no `fileInfo`, so I followed that logic.
