### PR TITLE
Revert "Don't mount video until `get` is complete"

### DIFF
--- a/ui/hocs/withStreamClaimRender/view.jsx
+++ b/ui/hocs/withStreamClaimRender/view.jsx
@@ -326,8 +326,6 @@ const withStreamClaimRender = (StreamClaimComponent: FunctionalComponentParam) =
       } else if (renderMode === 'md') {
         return <LoadingScreen />;
       }
-
-      return <LoadingScreen />;
     }
 
     // -- Main Component Render -- return when already has the claim's contents


### PR DESCRIPTION
Reverts OdyseeTeam/odysee-frontend#2625

If a valid livestream is loaded from F5 (direct URL), it won't load.

The logic there needs to be more elaborate I guess