### PR TITLE
Fix undefined video url + code viewer not loading

### DIFF
--- a/ui/hocs/withStreamClaimRender/view.jsx
+++ b/ui/hocs/withStreamClaimRender/view.jsx
@@ -325,6 +325,8 @@ const withStreamClaimRender = (StreamClaimComponent: FunctionalComponentParam) =
         );
       } else if (renderMode === 'md') {
         return <LoadingScreen />;
+      } else if (!streamingUrl) {
+        return <LoadingScreen />;
       }
     }
 


### PR DESCRIPTION
Test: `salt`

## Ticket
Closes [#2602 Text/Code viewer not executed](https://github.com/OdyseeTeam/odysee-frontend/issues/2602)
Closes [#2624 First video always fetches twice; first one is undefined](https://github.com/OdyseeTeam/odysee-frontend/issues/2624)

## Change
First attempt (#2625) broke livestreams. Seems like livestreams was depending on the logic falling through to the "main component render" part.

Trying a more restrictive change.

Tested on:
- code, markdown, video, livestream, audio.
- for each type, tested on both "enter through page transition" and "direct url load".
