### PR TITLE
Fix recommendation-overlay semantics

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -239,8 +239,6 @@ function VideoViewer(props: Props) {
       // if a playlist, navigate to next item
     } else if (playNextUri) {
       doPlayNextUri({ uri: playNextUri });
-    } else {
-      setShowRecommendationOverlay(true);
     }
   }, [doPlayNextUri, doSetShowAutoplayCountdownForUri, playNextUri, shouldPlayRecommended, uri]);
 
@@ -283,7 +281,11 @@ function VideoViewer(props: Props) {
     if (embedContext) {
       embedContext.setVideoEnded(true);
     } else {
-      handlePlayNextUri();
+      if (canPlayNext) {
+        handlePlayNextUri();
+      } else {
+        setShowRecommendationOverlay(true);
+      }
     }
 
     clearPosition(uri);


### PR DESCRIPTION
## Scenario
Play with "autoplay next" disable

## Issues
1. Behavioral:
    - If you press Shift+N while playing, the overlay incorrectly appears. 
2. Semantics
    - `handlePlayNextUri` should only do what the name suggests -- injecting the overlay code there breaks the meaning and usage.
    - `handlePlayNextUri` is passed to the "Next" and "Next-Shortcut" handlers -- it's weird that the overlay state permeated there, hence the behavioral bug above.
