### PR TITLE
Fix: "undefined" URL | code viewer | iOS autoplay temp workaround

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -564,6 +564,9 @@ export default React.memo<Props>(function VideoJs(props: Props) {
           .catch((error) => {
             const noPermissionError = typeof error === 'object' && error.name && error.name === 'NotAllowedError';
 
+            const attributes = ['font-weight:bold', 'color:pink'];
+            console.log(`%c---play() disallowed---\n${error}`, attributes.join(';')); // eslint-disable-line no-console
+
             if (noPermissionError) {
               if (IS_IOS) {
                 // autoplay not allowed, mute video, play and show 'tap to unmute' button

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -235,8 +235,15 @@ function VideoViewer(props: Props) {
 
   const handlePlayNextUri = React.useCallback(() => {
     if (shouldPlayRecommended) {
-      doSetShowAutoplayCountdownForUri({ uri, show: true });
-      // if a playlist, navigate to next item
+      if (IS_IOS) {
+        // Safari doesn't like it when there is an async action between click
+        // and `player.play()`. Chrome allows it. Skip the countdown for now.
+
+        // $FlowIgnore: shouldPlayRecommended guarantees non-null playNextUri
+        doPlayNextUri({ uri: playNextUri });
+      } else {
+        doSetShowAutoplayCountdownForUri({ uri, show: true });
+      }
     } else if (playNextUri) {
       doPlayNextUri({ uri: playNextUri });
     }

--- a/ui/hocs/withStreamClaimRender/view.jsx
+++ b/ui/hocs/withStreamClaimRender/view.jsx
@@ -325,6 +325,8 @@ const withStreamClaimRender = (StreamClaimComponent: FunctionalComponentParam) =
         );
       } else if (renderMode === 'md') {
         return <LoadingScreen />;
+      } else if (!streamingUrl) {
+        return <LoadingScreen />;
       }
     }
 


### PR DESCRIPTION
## Test
`salt`

## Changes
- Alleviate iOS autoplay-next permission issue by not using the Countdown screen. This then avoids the need to mute-and-play it.
    - Just a temp workaround for a now until a better fix 
- [Fix undefined video url + code viewer not loading #2627](https://github.com/OdyseeTeam/odysee-frontend/pull/2627)

```
iOS scenarios that pauses autoplay
  1. Playing the first video after F5 on homepage  [remains unfixed]
  2. Clicking Next to play next rect               [workaround seems reliable]
  3. Autoplay Next on end of video                 [workaround works 90%, fails sometimes]
----------------------------------------------------------
  4. F5 on claim page (applies to all sites, a hard rule)
```
