### PR TITLE
Video: cog icon cleanup

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-settings-menu/videojs-plus/Components/SettingMenu/Setting.scss
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-settings-menu/videojs-plus/Components/SettingMenu/Setting.scss
@@ -1,31 +1,26 @@
+@import 'videojs-font/scss/videojs-icons.scss';
 @import '../../variable.scss';
 @import '~ui/scss/init/breakpoints';
 
 .vjs-setting-button {
   .vjs-icon-placeholder {
+    @extend .vjs-icon-cog;
+
+    display: block;
+    height: 100%;
+    transform: rotate(0deg);
+    transition: 0.2s transform;
+
     &:before {
-      content: '';
-
-      // @see "div.vjs-setting-button" :(
-      background-size: 42%;
-      @media (max-width: $breakpoint-small) {
-        background-size: 50%;
-      }
-
-      background-position: center center;
-      background-repeat: no-repeat;
-      background-image: url('data:image/svg+xml;utf8,<svg fill="none" height="24" viewBox="0 0 24 24" stroke="%23FFFFFF" stroke-width="2" width="4" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>');
-
-      transform: rotate(0deg);
-      transition: 0.2s transform;
+      font-size: 1em;
+      //transform: translateY(-0.005em);
+      display: block;
     }
   }
 
   &[aria-expanded='true'] {
     .vjs-icon-placeholder {
-      &:before {
-        transform: rotate(30deg);
-      }
+      transform: rotate(30deg);
     }
   }
 }

--- a/ui/scss/component/_file-render.scss
+++ b/ui/scss/component/_file-render.scss
@@ -868,12 +868,6 @@ $control-bar-icon-size: 30px;
       margin-top: -0px;
     }
 
-    div.vjs-setting-button {
-      @media (max-width: $breakpoint-small) {
-        width: 2.8em;
-      }
-    }
-
     .vjs-snapshot-button {
       margin-right: 8px;
       svg {


### PR DESCRIPTION
- Uses cog from packaged videojs-font font instead of copy-pasting another set of SVG.
- Removes the `div.vjs-setting-button` hack to handle mobile. Seems no longer needed after moving to font version.
- Fixes bounding area that was going off screen.

----

@toshokanneko, this is the cleanup I mentioned. 
<strike>I think the shifting issue no longer exists after this (?), but</strike> probably still needs the height adjustment that you mentioned.  