### PR TITLE
Fix safari-mac crash when moving from chaptered to non-chaptered video.

### DIFF
--- a/ui/component/viewers/videoViewer/internal/chapters.jsx
+++ b/ui/component/viewers/videoViewer/internal/chapters.jsx
@@ -129,7 +129,7 @@ function overrideHoverTooltip(player: any, tsData: TimestampData, duration: numb
 
 function load(player: any, timestampData: TimestampData, duration: number) {
   player.one('loadedmetadata', () => {
-    const textTrack = player.addTextTrack('chapters', __('Chapters'), 'en');
+    const textTrack = player.addRemoteTextTrack({ kind: 'chapters' }).track;
 
     setTimeout(() => {
       const values = Object.values(timestampData);
@@ -172,7 +172,7 @@ function deleteHoverInformation(player) {
 export function parseAndLoad(player: any, claim: StreamClaim) {
   console.assert(claim, 'null claim');
 
-  if (platform.isMobile()) {
+  if (platform.isMobile() || platform.isSafari()) {
     return;
   }
 


### PR DESCRIPTION
I believe the issue is with `addTextTrack` not having cleanup counterparts + we are now recycling the video instance + the Safari implementation probably didn't handle it robustly.

Moved to `addRemoteTextTrack`, which the docs says it includes auto cleanup when the src changes. It is also the recommended API anyway as it comes with `removedRemoveTextTrack`, in case we ever need to manually clean things up.

Closes #2638