### PR TITLE
Fix abandoned claims showing up in Recommended

### DIFF
--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -367,11 +367,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
   // **************************************************************************
   // **************************************************************************
 
-  if (
-    claim &&
-    !playlistPreviewItem &&
-    ((shouldHide && !showNullPlaceholder) || (isLivestream && !ENABLE_NO_SOURCE_CLAIMS))
-  ) {
+  if (!playlistPreviewItem && ((shouldHide && !showNullPlaceholder) || (isLivestream && !ENABLE_NO_SOURCE_CLAIMS))) {
     return null;
   }
 


### PR DESCRIPTION
## Ticket
Closes #2607

## Change
Undo a line introduced in [e1b13013](https://github.com/OdyseeTeam/odysee-frontend/commit/e1b13013bcb802a67b7daaf87aa2021ff9a8f1a2#diff-5f51ecc20c34db2478b2507e7e03c183dbca1eb3cec96fc46fe0ede1ef5210daR358-R361) (click and wait for auto scroll) that's causing the problem.

Logically, `shouldHide` can be because of `!claim` (among others), so adding a `claim` there doesn't make sense.

But it's unclear what the change was trying to fix (was squashed), so this could re-open some issues. But whatever that issue is, it'll require a different fix (separate if block)
