### PR TITLE
Clean up release_time publish handling

### DIFF
--- a/flow-typed/publish.js
+++ b/flow-typed/publish.js
@@ -2,30 +2,32 @@
 
 declare type Paywall = 'free' | 'fiat' | 'sdk';
 
-// SDK
 declare type PublishParams = {
-  name: ?string,
-  bid: ?number,
-  filePath?: string,
-  description: ?string,
-  language: string,
-  publishingLicense?: string,
-  publishingLicenseUrl?: string,
-  thumbnail: ?string,
-  channel: string,
-  channelId?: string,
-  title: string,
-  paywall: Paywall,
-  uri?: string,
-  license: ?string,
-  licenseUrl: ?string,
-  fee?: {
-    amount: string,
-    currency: string,
-  },
-  claim: StreamClaim,
-  nsfw: boolean,
-  tags: Array<Tag>,
+  // --- Odysee API ---
+  remote_url?: string,
+  claim_id?: string, // I think this is for edits
+  // --- LBRY SDK ---
+  name: string,
+  bid?: number,
+  file_path?: string,
+  file_name?: string,
+  optimize_file?: boolean,
+  fee_currency?: string,
+  fee_amount?: number,
+  title?: string,
+  description?: string,
+  author?: string,
+  tags?: Array<string>,
+  language?: Array<string>,
+  locations?: Array<string>,
+  license?: string,
+  license_url?: string,
+  thumbnail_url?: string,
+  release_time?: number,
+  channel_id?: string,
+  channel_name?: string,
+  preview?: boolean,
+  blocking?: boolean,
 };
 
 // Redux slice. Includes both form data and some UI states
@@ -56,9 +58,12 @@ declare type PublishState = {
   thumbnailError: ?boolean,
   description: string,
   language: string,
+  // releaseTime:
+  //   The user-entered value, whether valid or not. The UI can gray out for
+  //   some scenarios, but value should be retained for un-graying.
+  //   @see PUBLISH.releaseTime() for full logic for "undefined".
   releaseTime: ?number,
-  releaseTimeEdited: ?number,
-  releaseAnytime: boolean,
+  releaseTimeError: ?string,
   channel: string,
   channelId: ?string,
   name: string,

--- a/ui/component/publish/shared/publishReleaseDate/index.js
+++ b/ui/component/publish/shared/publishReleaseDate/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
-import { selectPublishFormValue } from 'redux/selectors/publish';
+import { selectMyClaimForUri, selectPublishFormValue } from 'redux/selectors/publish';
 import { doUpdatePublishForm } from 'redux/actions/publish';
 import { selectClientSetting, selectLanguage } from 'redux/selectors/settings';
 import PublishReleaseDate from './view';
 
 const select = (state) => ({
-  isEdit: Boolean(selectPublishFormValue(state, 'editingURI')),
+  claimToEdit: selectMyClaimForUri(state),
   releaseTime: selectPublishFormValue(state, 'releaseTime'),
   releaseTimeError: selectPublishFormValue(state, 'releaseTimeError'),
   clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),

--- a/ui/component/publish/shared/publishReleaseDate/index.js
+++ b/ui/component/publish/shared/publishReleaseDate/index.js
@@ -6,8 +6,9 @@ import { selectClientSetting, selectLanguage } from 'redux/selectors/settings';
 import PublishReleaseDate from './view';
 
 const select = (state) => ({
+  isEdit: Boolean(selectPublishFormValue(state, 'editingURI')),
   releaseTime: selectPublishFormValue(state, 'releaseTime'),
-  releaseTimeEdited: selectPublishFormValue(state, 'releaseTimeEdited'),
+  releaseTimeError: selectPublishFormValue(state, 'releaseTimeError'),
   clock24h: selectClientSetting(state, SETTINGS.CLOCK_24H),
   appLanguage: selectLanguage(state),
 });

--- a/ui/component/publish/shared/publishReleaseDate/view.jsx
+++ b/ui/component/publish/shared/publishReleaseDate/view.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { useEffect } from 'react';
+import React from 'react';
 import Button from 'component/button';
 import DateTimePicker from 'react-datetime-picker';
 
@@ -17,137 +17,68 @@ const RESET_TO_ORIGINAL = 'reset-to-original';
 const FUTURE_DATE_ERROR = 'Cannot set to a future date.';
 
 type Props = {
-  allowDefault: ?boolean,
-  showNowBtn: ?boolean,
-  useMaxDate: ?boolean,
   // --- redux:
+  isEdit: boolean,
   releaseTime: ?number,
-  releaseTimeEdited: ?number,
+  releaseTimeError: ?string,
   clock24h: boolean,
   appLanguage: ?string,
   updatePublishForm: ({}) => void,
 };
 
 const PublishReleaseDate = (props: Props) => {
-  const {
-    releaseTime,
-    releaseTimeEdited,
-    clock24h,
-    appLanguage,
-    updatePublishForm,
-    allowDefault = true,
-    showNowBtn = true,
-    useMaxDate = true,
-  } = props;
-  const maxDate = useMaxDate ? new Date() : undefined;
-  const [date, setDate] = React.useState(releaseTime ? linuxTimestampToDate(releaseTime) : undefined);
-  const [error, setError] = React.useState([]);
+  const { isEdit, releaseTime, releaseTimeError, clock24h, appLanguage, updatePublishForm } = props;
 
-  const isNew = releaseTime === undefined;
-  const isEdit = !isNew || allowDefault === false;
-
-  // const showEditBtn = isNew && releaseTimeEdited === undefined && allowDefault !== false;
-  const showEditBtn = false;
-  const showDefaultBtn = isNew && releaseTimeEdited !== undefined && allowDefault !== false;
-  // const showDatePicker = isEdit || releaseTimeEdited !== undefined;
+  const maxDate = new Date();
+  const showDefaultBtn = releaseTime !== undefined;
   const showDatePicker = true;
-
-  const updateError = (action, error) => {
-    switch (action) {
-      case 'remove':
-        setError((prev) => prev.filter((x) => x !== error));
-        break;
-
-      case 'clear':
-        setError([]);
-        break;
-
-      case 'add':
-        setError((prev) => {
-          const nextError = prev.slice();
-          if (!nextError.includes(error)) {
-            nextError.push(error);
-            return nextError;
-          }
-          return prev;
-        });
-        break;
-    }
-  };
 
   const onDateTimePickerChanged = (value) => {
     const isValueInFuture = maxDate && value && value.getTime() > maxDate.getTime();
-    if (isValueInFuture) {
-      updateError('add', FUTURE_DATE_ERROR);
-      return;
-    }
 
-    updateError('remove', FUTURE_DATE_ERROR);
+    console.assert(value, 'onDateTimePickerChanged: null value?'); // eslint-disable-line no-console
 
-    if (value) {
-      newDate(value);
-    } else {
-      // "!value" should never happen since we now hide the "clear" button,
-      // but retained the logic here anyway.
-      if (releaseTime) {
-        newDate(RESET_TO_ORIGINAL);
-      } else {
-        newDate(NOW);
-      }
-    }
+    updatePublishForm({
+      releaseTime: isValueInFuture ? releaseTime : dateToLinuxTimestamp(value),
+      releaseTimeError: isValueInFuture ? FUTURE_DATE_ERROR : undefined,
+    });
   };
 
   function newDate(value: string | Date) {
-    updateError('clear', FUTURE_DATE_ERROR);
+    const changes: UpdatePublishState = {
+      releaseTimeError: undefined, // clear
+    };
 
     switch (value) {
       case NOW:
-        const newDate = new Date();
-        setDate(newDate);
-        updatePublishForm({ releaseTimeEdited: dateToLinuxTimestamp(newDate) });
+        changes.releaseTime = dateToLinuxTimestamp(new Date());
         break;
 
       case DEFAULT:
-        setDate(undefined);
-        updatePublishForm({ releaseTimeEdited: undefined });
-        break;
-
       case RESET_TO_ORIGINAL:
-        if (releaseTime) {
-          setDate(linuxTimestampToDate(releaseTime));
-          updatePublishForm({ releaseTimeEdited: undefined });
-        }
+        // PUBLISH.releaseTime() will do the right thing based on various scenarios.
+        changes.releaseTime = undefined;
         break;
 
       default:
-        if (value instanceof Date) {
-          setDate(value);
-          updatePublishForm({ releaseTimeEdited: dateToLinuxTimestamp(value) });
-        }
+        console.assert(false, 'unhandled case'); // eslint-disable-line no-console
+        changes.releaseTime = undefined;
         break;
     }
+
+    updatePublishForm(changes);
   }
 
   function handleBlur(event) {
     if (event.target.name === 'minute' || event.target.name === 'day') {
       const validity = event?.target?.validity;
       if (validity.rangeOverflow || validity.rangeUnderflow) {
-        updateError('add', event.target.name);
-      } else if (error.includes(event.target.name)) {
-        updateError('remove', event.target.name);
+        updatePublishForm({ releaseTimeError: event.target.name });
+      } else if (releaseTimeError === event.target.name) {
+        updatePublishForm({ releaseTimeError: undefined });
       }
     }
   }
-
-  useEffect(() => {
-    return () => {
-      updatePublishForm({ releaseTimeEdited: undefined });
-    };
-  }, []);
-
-  useEffect(() => {
-    updatePublishForm({ releaseTimeError: error.join(';') });
-  }, [error]);
 
   return (
     <div className="form-field-date-picker">
@@ -160,29 +91,13 @@ const PublishReleaseDate = (props: Props) => {
             calendarClassName="form-field-calendar"
             onBlur={handleBlur}
             onChange={onDateTimePickerChanged}
-            value={date}
+            value={releaseTime ? linuxTimestampToDate(releaseTime) : undefined}
             format={clock24h ? 'y-MM-dd HH:mm' : 'y-MM-dd h:mm a'}
             disableClock
             clearIcon={null}
           />
         )}
-        {showEditBtn && (
-          <Button
-            button="link"
-            label={__('Edit')}
-            aria-label={__('Set custom release date')}
-            onClick={() => newDate(NOW)}
-          />
-        )}
-        {showDatePicker && isEdit && releaseTime && (
-          <Button
-            button="link"
-            label={__('Reset')}
-            aria-label={__('Reset to original (previous) publish date')}
-            onClick={() => newDate(RESET_TO_ORIGINAL)}
-          />
-        )}
-        {showDatePicker && showNowBtn && (
+        {showDatePicker && (
           <Button
             button="link"
             label={__('Now')}
@@ -193,15 +108,14 @@ const PublishReleaseDate = (props: Props) => {
         {showDefaultBtn && (
           <Button
             button="link"
-            label={__('Default')}
-            aria-label={__('Remove custom release date')}
+            label={isEdit ? __('Reset') : __('Default')}
+            aria-label={isEdit ? __('Reset to original (previous) publish date') : __('Remove custom release date')}
             onClick={() => newDate(DEFAULT)}
           />
         )}
-        {error.length > 0 && (
+        {releaseTimeError && (
           <span className="form-field-date-picker__error">
-            {error.includes(FUTURE_DATE_ERROR) && <span>{__(FUTURE_DATE_ERROR)}</span>}
-            {(!error.includes(FUTURE_DATE_ERROR) || error.length > 1) && <span>{__('Invalid date/time.')}</span>}
+            <span>{releaseTimeError === FUTURE_DATE_ERROR ? __(FUTURE_DATE_ERROR) : __('Invalid date/time.')}</span>
           </span>
         )}
       </div>

--- a/ui/component/publish/shared/publishReleaseDate/view.jsx
+++ b/ui/component/publish/shared/publishReleaseDate/view.jsx
@@ -18,7 +18,7 @@ const FUTURE_DATE_ERROR = 'Cannot set to a future date.';
 
 type Props = {
   // --- redux:
-  isEdit: boolean,
+  claimToEdit: ?StreamClaim,
   releaseTime: ?number,
   releaseTimeError: ?string,
   clock24h: boolean,
@@ -27,11 +27,18 @@ type Props = {
 };
 
 const PublishReleaseDate = (props: Props) => {
-  const { isEdit, releaseTime, releaseTimeError, clock24h, appLanguage, updatePublishForm } = props;
+  const { claimToEdit, releaseTime, releaseTimeError, clock24h, appLanguage, updatePublishForm } = props;
 
   const maxDate = new Date();
   const showDefaultBtn = releaseTime !== undefined;
   const showDatePicker = true;
+  const isEdit = Boolean(claimToEdit);
+
+  let claimDateStr;
+  if (isEdit) {
+    const date = new Date((claimToEdit?.value?.release_time || claimToEdit?.timestamp || 0) * 1000);
+    claimDateStr = date.toLocaleString(appLanguage || 'en');
+  }
 
   const onDateTimePickerChanged = (value) => {
     const isValueInFuture = maxDate && value && value.getTime() > maxDate.getTime();
@@ -119,6 +126,9 @@ const PublishReleaseDate = (props: Props) => {
           </span>
         )}
       </div>
+      {claimDateStr && (
+        <div className="form-field-date-picker__past-value">{__('Previous:  %date%', { date: claimDateStr })}</div>
+      )}
     </div>
   );
 };

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -117,6 +117,7 @@ function UploadForm(props: Props) {
     publishError,
     publishSuccess,
     publishing,
+    releaseTimeError,
     remoteUrl,
     resetThumbnailStatus,
     resolveUri,
@@ -197,6 +198,7 @@ function UploadForm(props: Props) {
     thumbnail &&
     !bidError &&
     !emptyPostError &&
+    !releaseTimeError &&
     !(thumbnailError && !thumbnailUploaded) &&
     !(uploadThumbnailStatus === THUMBNAIL_STATUSES.IN_PROGRESS);
 

--- a/ui/modal/modalPublishPreview/view.jsx
+++ b/ui/modal/modalPublishPreview/view.jsx
@@ -40,7 +40,7 @@ type Props = {
   fiatRentalFee: Price,
   fiatRentalExpiration: Duration,
   language: string,
-  releaseTimeEdited: ?number,
+  releaseTime: ?number,
   licenseType: string,
   otherLicenseDescription: ?string,
   licenseUrl: ?string,
@@ -86,7 +86,7 @@ const ModalPublishPreview = (props: Props) => {
     fiatRentalExpiration,
 
     language,
-    releaseTimeEdited,
+    releaseTime,
     licenseType,
     otherLicenseDescription,
     licenseUrl,
@@ -119,7 +119,7 @@ const ModalPublishPreview = (props: Props) => {
 
   const formattedTitle = truncateWithEllipsis(title, 128);
   const formattedUri = truncateWithEllipsis(uri, 128);
-  const releasesInFuture = releaseTimeEdited && moment(releaseTimeEdited * 1000).isAfter();
+  const releasesInFuture = releaseTime && moment(releaseTime * 1000).isAfter();
   const txFee = previewResponse ? previewResponse['total_fee'] : null;
   const isOptimizeAvail = filePath && filePath !== '' && isVid && ffmpegStatus.available;
   const modalTitle = getModalTitle();
@@ -403,7 +403,7 @@ const ModalPublishPreview = (props: Props) => {
                     {createRow(__('Deposit'), getDeposit())}
                     {createRow(getPriceLabel(), getPriceValue())}
                     {createRow(__('Language'), language ? getLanguageName(language) : '')}
-                    {releaseTimeEdited && createRow(getReleaseTimeLabel(), getReleaseTimeValue(releaseTimeEdited))}
+                    {releaseTime && createRow(getReleaseTimeLabel(), getReleaseTimeValue(releaseTime))}
                     {createRow(__('License'), getLicense())}
                     {createRow(__('Restricted to'), getTierRestrictionValue(), !tiers || !restrictingTiers)}
                     {createRow(__('Tags'), getTagsValue(tags))}

--- a/ui/redux/reducers/publish.js
+++ b/ui/redux/reducers/publish.js
@@ -18,6 +18,7 @@ import { PAYWALL } from 'constants/publish';
 // any pending uploads. Can be removed from January 2022 onwards.
 const getOldKeyFromParam = (params) => `${params.name}#${params.channel || 'anonymous'}`;
 
+// @see 'flow-typed/publish.js' for documentation
 const defaultState: PublishState = {
   editingURI: undefined,
   fileText: '',
@@ -46,9 +47,7 @@ const defaultState: PublishState = {
   description: '',
   language: '',
   releaseTime: undefined,
-  releaseTimeEdited: undefined,
-  releaseTimeError: false,
-  releaseAnytime: false,
+  releaseTimeError: undefined,
   nsfw: false,
   channel: CHANNEL_ANONYMOUS,
   channelId: '',

--- a/ui/scss/component/_form-field.scss
+++ b/ui/scss/component/_form-field.scss
@@ -833,6 +833,12 @@ fieldset-section {
   }
 }
 
+.form-field-date-picker__past-value {
+  font-size: var(--font-xsmall);
+  color: var(--color-text-subtitle);
+  margin-top: var(--spacing-xxxs);
+}
+
 .form-field-calendar {
   border-radius: var(--border-radius);
   border: 1px solid var(--color-border);


### PR DESCRIPTION
## Test
- Available in `salt` :salt: 
- SDK publish payload must remain identical.
- GUI changed a bit after the logic simplification, but nothing drastic.
- More love on scheduled livestreams would be nice.

Note that there is a bug where the app doesn't return you to the right page after editing.  Will address that separately.

## Issue
Several updates in this area has introduce few variables that somewhat overlap each other, making it hard to tweak for upcoming visibility (public|unlisted) changes.

## Change
- Removed overlapping variables, and document how the current one should behave.
    - `releaseTime` is now the only variable needed and represents the user-entered value.  If `undefined`, it means the user didn't set any, so use `Date.now()` for Create and past value for Edits (which we can get from the Claim directly).
- Consolidated the logic into a single place to (hopefully) easily see and tweak all permutations.
- Fixed flux-pattern in the GUI component. The local states aren't necessary when we are using redux, and components should be free of business logic.
    - e.g. `publishStreamReleaseDate` shouldn't be resetting states when mounting. `CLEAR_PUBLISH` or `doPrepareEdit()` should be doing that, we just need to translate props to jsx.
- Tweaked the behavior of the GUI a bit for clarity.
