### PR TITLE
Improve file::get error

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2885,6 +2885,7 @@
   "Leave a tip for the creator": "Leave a tip for the creator",
   "Show this creator your appreciation by sending a donation.": "Show this creator your appreciation by sending a donation.",
   "Loading channels...": "Loading channels...",
+  "Failed to load the file. If problem persists, visit https://help.odysee.tv/ for support.": "Failed to load the file. If problem persists, visit https://help.odysee.tv/ for support.",
 
   "--end--": "--end--"
 }

--- a/ui/redux/actions/file.js
+++ b/ui/redux/actions/file.js
@@ -174,8 +174,10 @@ export const doFileGetForUri =
 
         dispatch(
           doToast({
-            message: `Failed to view ${uri}, please try again. If this problem persists, visit https://help.odysee.tv/ for support.`,
+            message: __('Failed to load the file. If problem persists, visit https://help.odysee.tv/ for support.'),
+            ...(error.message ? { subMessage: error.message } : {}),
             isError: true,
+            duration: 'long',
           })
         );
       });


### PR DESCRIPTION
## Issues
- The message is not localized.
- The long `uri` would be truncated anyway.
- "Please try again" does not help for access-related issues.

## Change
Relay the error message

<img width="250" src="https://user-images.githubusercontent.com/64950861/231746670-cf8e4873-6e6e-4a0a-8a30-31bb5f2ac8be.png"> --> <img width="250" alt="image" src="https://user-images.githubusercontent.com/64950861/231746758-215ff5a7-f9d7-460f-9c5c-b30db3df644d.png">


