### PR TITLE
Fix subscription claim_id parsing

### DIFF
--- a/ui/page/channelsFollowing/index.js
+++ b/ui/page/channelsFollowing/index.js
@@ -2,10 +2,8 @@ import { connect } from 'react-redux';
 
 import * as SETTINGS from 'constants/settings';
 
-import { splitBySeparator } from 'util/lbryURI';
-
 import { selectIsFetchingActiveLivestreams, selectFilteredActiveLivestreamUris } from 'redux/selectors/livestream';
-import { selectSubscriptions } from 'redux/selectors/subscriptions';
+import { selectSubscriptionIds } from 'redux/selectors/subscriptions';
 import { selectClientSetting } from 'redux/selectors/settings';
 
 import { doFetchAllActiveLivestreamsForQuery } from 'redux/actions/livestream';
@@ -13,11 +11,9 @@ import { doFetchAllActiveLivestreamsForQuery } from 'redux/actions/livestream';
 import ChannelsFollowingPage from './view';
 
 const select = (state) => {
-  const subscribedChannels = selectSubscriptions(state);
-  const channelIds = subscribedChannels.map((sub) => splitBySeparator(sub.uri)[1]);
+  const channelIds = selectSubscriptionIds(state);
 
   return {
-    subscribedChannels,
     channelIds,
     tileLayout: selectClientSetting(state, SETTINGS.TILE_LAYOUT),
     fetchingActiveLivestreams: selectIsFetchingActiveLivestreams(state),

--- a/ui/page/channelsFollowing/view.jsx
+++ b/ui/page/channelsFollowing/view.jsx
@@ -15,7 +15,6 @@ import ScheduledStreams from 'component/scheduledStreams';
 import usePersistedState from 'effects/use-persisted-state';
 
 type Props = {
-  subscribedChannels: Array<Subscription>,
   channelIds: Array<string>,
   tileLayout: boolean,
   activeLivestreamUris: ?Array<string>,
@@ -26,7 +25,6 @@ type Props = {
 
 function ChannelsFollowingPage(props: Props) {
   const {
-    subscribedChannels,
     channelIds,
     tileLayout,
     activeLivestreamUris,
@@ -35,7 +33,7 @@ function ChannelsFollowingPage(props: Props) {
     hideScheduledLivestreams,
   } = props;
 
-  const hasSubscribedChannels = subscribedChannels.length > 0;
+  const hasSubscribedChannels = channelIds.length > 0;
   const [hideMembersOnly] = usePersistedState('channelPage-hideMembersOnly', false);
 
   React.useEffect(() => {

--- a/ui/page/channelsFollowingDiscover/index.js
+++ b/ui/page/channelsFollowingDiscover/index.js
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux';
-import { selectSubscriptions } from 'redux/selectors/subscriptions';
+import { selectSubscriptionIds } from 'redux/selectors/subscriptions';
 import { selectHomepageData, selectHomepageDiscover } from 'redux/selectors/settings';
 import ChannelsFollowingDiscover from './view';
 
 const select = (state) => ({
-  subscribedChannels: selectSubscriptions(state),
+  subscribedChannelIds: selectSubscriptionIds(state),
   homepageData: selectHomepageData(state) || {},
   discoverData: selectHomepageDiscover(state),
 });

--- a/ui/page/channelsFollowingDiscover/view.jsx
+++ b/ui/page/channelsFollowingDiscover/view.jsx
@@ -4,19 +4,18 @@ import Page from 'component/page';
 import ClaimListDiscover from 'component/claimListDiscover';
 import * as CS from 'constants/claim_search';
 import { CUSTOM_HOMEPAGE, SIMPLE_SITE } from 'config';
-import { parseClaimIdFromPermanentUrl } from 'util/url';
 
 const MORE_CHANNELS_ANCHOR = 'MoreChannels';
 
 type Props = {
-  subscribedChannels: Array<Subscription>,
+  subscribedChannelIds: Array<ClaimId>,
   blockedChannels: Array<string>,
   homepageData: any,
   discoverData: ?Array<string>,
 };
 
 function ChannelsFollowingDiscover(props: Props) {
-  const { subscribedChannels, homepageData, discoverData } = props;
+  const { subscribedChannelIds, homepageData, discoverData } = props;
   const { PRIMARY_CONTENT, LATEST } = homepageData;
 
   let channelIds;
@@ -37,7 +36,7 @@ function ChannelsFollowingDiscover(props: Props) {
         defaultFreshness={CS.FRESH_ALL}
         claimType={CS.CLAIM_CHANNEL}
         claimIds={CUSTOM_HOMEPAGE && channelIds ? channelIds : undefined}
-        excludedChannelIds={subscribedChannels.map((x) => parseClaimIdFromPermanentUrl(x.uri))}
+        excludedChannelIds={subscribedChannelIds}
         scrollAnchor={MORE_CHANNELS_ANCHOR}
         maxPages={SIMPLE_SITE ? 3 : undefined}
         hideFilters={SIMPLE_SITE}

--- a/ui/page/home/index.js
+++ b/ui/page/home/index.js
@@ -6,7 +6,7 @@ import { selectIsFetchingActiveLivestreams, selectFilteredActiveLivestreamUris }
 import { selectFollowedTags } from 'redux/selectors/tags';
 import { selectHomepageFetched, selectUserVerifiedEmail } from 'redux/selectors/user';
 import { selectUserHasValidOdyseeMembership, selectUserHasOdyseePremiumPlus } from 'redux/selectors/memberships';
-import { selectSubscriptions } from 'redux/selectors/subscriptions';
+import { selectSubscriptionIds } from 'redux/selectors/subscriptions';
 import {
   selectShowMatureContent,
   selectHomepageData,
@@ -18,7 +18,7 @@ import HomePage from './view';
 
 const select = (state) => ({
   followedTags: selectFollowedTags(state),
-  subscribedChannels: selectSubscriptions(state),
+  subscribedChannelIds: selectSubscriptionIds(state),
   authenticated: selectUserVerifiedEmail(state),
   showNsfw: selectShowMatureContent(state),
   homepageData: selectHomepageData(state) || {},

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -18,7 +18,6 @@ import Yrbl from 'component/yrbl';
 import { useIsLargeScreen } from 'effects/use-screensize';
 import { GetLinksData } from 'util/buildHomepage';
 import ScheduledStreams from 'component/scheduledStreams';
-import { splitBySeparator } from 'util/lbryURI';
 import AdTileA from 'web/component/ads/adTileA';
 import Meme from 'web/component/meme';
 import Portals from 'component/portals';
@@ -31,7 +30,7 @@ type HomepageOrder = { active: ?Array<string>, hidden: ?Array<string> };
 type Props = {
   authenticated: boolean,
   followedTags: Array<Tag>,
-  subscribedChannels: Array<Subscription>,
+  subscribedChannelIds: Array<ClaimId>,
   showNsfw: boolean,
   homepageData: any,
   homepageMeme: ?{ text: string, url: string },
@@ -50,7 +49,7 @@ type Props = {
 function HomePage(props: Props) {
   const {
     followedTags,
-    subscribedChannels,
+    subscribedChannelIds,
     authenticated,
     showNsfw,
     homepageData,
@@ -66,11 +65,10 @@ function HomePage(props: Props) {
     getActiveLivestreamUrisForIds,
   } = props;
 
-  const showPersonalizedChannels = (authenticated || !IS_WEB) && subscribedChannels && subscribedChannels.length > 0;
+  const showPersonalizedChannels = (authenticated || !IS_WEB) && subscribedChannelIds.length > 0;
   const showPersonalizedTags = (authenticated || !IS_WEB) && followedTags && followedTags.length > 0;
   const showIndividualTags = showPersonalizedTags && followedTags.length < 5;
   const isLargeScreen = useIsLargeScreen();
-  const subscriptionChannelIds = subscribedChannels.map((sub) => splitBySeparator(sub.uri)[1]);
   const { push } = useHistory();
 
   const rowData: Array<RowDataItem> = GetLinksData(
@@ -80,7 +78,7 @@ function HomePage(props: Props) {
     authenticated,
     showPersonalizedChannels,
     showPersonalizedTags,
-    subscribedChannels,
+    subscribedChannelIds,
     followedTags,
     showIndividualTags,
     showNsfw
@@ -259,13 +257,13 @@ function HomePage(props: Props) {
                 <React.Fragment key={id}>
                   {!fetchingActiveLivestreams &&
                     authenticated &&
-                    subscriptionChannelIds.length > 0 &&
+                    subscribedChannelIds.length > 0 &&
                     id === 'FOLLOWING' &&
                     !hideScheduledLivestreams && (
                       <ScheduledStreams
-                        channelIds={subscriptionChannelIds}
+                        channelIds={subscribedChannelIds}
                         tileLayout
-                        liveUris={getActiveLivestreamUrisForIds(subscriptionChannelIds)}
+                        liveUris={getActiveLivestreamUrisForIds(subscribedChannelIds)}
                         limitClaimsPerChannel={2}
                       />
                     )}

--- a/ui/redux/actions/subscriptions.js
+++ b/ui/redux/actions/subscriptions.js
@@ -9,7 +9,7 @@ import { getChannelFromClaim } from 'util/claim';
 import { parseURI } from 'util/lbryURI';
 import { doAlertWaitingForSync } from 'redux/actions/app';
 import { doToast } from 'redux/actions/notifications';
-import { selectSubscriptions } from 'redux/selectors/subscriptions';
+import { selectSubscriptionIds } from 'redux/selectors/subscriptions';
 
 type SubscriptionArgs = {
   channelName: string,
@@ -97,15 +97,6 @@ export function doChannelUnsubscribe(subscription: SubscriptionArgs, followToast
 }
 
 export function doFetchLastActiveSubs(forceFetch: boolean = false, count: number = SIDEBAR_SUBS_DISPLAYED) {
-  function parseIdFromUri(uri) {
-    try {
-      const { channelClaimId } = parseURI(uri);
-      return channelClaimId;
-    } catch {
-      return '';
-    }
-  }
-
   return (dispatch: Dispatch, getState: GetState) => {
     const now = Date.now();
     if (!forceFetch && now - activeSubsLastFetchedTime < FETCH_LAST_ACTIVE_SUBS_MIN_INTERVAL_MS) {
@@ -114,8 +105,7 @@ export function doFetchLastActiveSubs(forceFetch: boolean = false, count: number
     }
 
     const state = getState();
-    const subscriptions = selectSubscriptions(state);
-    const channelIds = subscriptions.map((sub) => parseIdFromUri(sub.uri));
+    const channelIds = selectSubscriptionIds(state);
     activeSubsLastFetchedTime = now;
 
     if (channelIds.length === 0) {

--- a/ui/redux/selectors/subscriptions.js
+++ b/ui/redux/selectors/subscriptions.js
@@ -26,6 +26,14 @@ export const selectSubscriptionUris = createSelector(
   (subscriptions) => subscriptions && subscriptions.map((sub) => sub.uri)
 );
 
+export const selectSubscriptionIds = createSelector(selectSubscriptions, (subscriptions) => {
+  if (subscriptions) {
+    return subscriptions.map((sub) => parseURI(sub.uri).channelClaimId);
+  } else {
+    return [];
+  }
+});
+
 export const selectLastActiveSubscriptions = (state) => selectState(state).lastActiveSubscriptions;
 
 export const selectFollowing = createSelector(selectState, (state) => state.following && state.following);

--- a/ui/util/buildHomepage.js
+++ b/ui/util/buildHomepage.js
@@ -2,7 +2,6 @@
 import * as PAGES from 'constants/pages';
 import * as ICONS from 'constants/icons';
 import * as CS from 'constants/claim_search';
-import { parseURI } from 'util/lbryURI';
 import moment from 'moment';
 import { toCapitalCase } from 'util/string';
 import { CUSTOM_HOMEPAGE } from 'config';
@@ -124,7 +123,7 @@ export function GetLinksData(
   authenticated?: boolean,
   showPersonalizedChannels?: boolean,
   showPersonalizedTags?: boolean,
-  subscribedChannels?: Array<Subscription>,
+  subscribedChannelIds?: Array<ClaimId>,
   followedTags?: Array<Tag>,
   showIndividualTags?: boolean,
   showNsfw?: boolean
@@ -137,7 +136,7 @@ export function GetLinksData(
   let rowData: Array<RowDataItem> = [];
   const individualTagDataItems: Array<RowDataItem> = [];
 
-  if (isHomepage && showPersonalizedChannels && subscribedChannels) {
+  if (isHomepage && showPersonalizedChannels && subscribedChannelIds) {
     const RECENT_FROM_FOLLOWING = {
       id: 'FOLLOWING',
       title: __('Recent From Following'),
@@ -147,15 +146,12 @@ export function GetLinksData(
       options: {
         orderBy: CS.ORDER_BY_NEW,
         releaseTime:
-          subscribedChannels.length > 20
+          subscribedChannelIds.length > 20
             ? `>${Math.floor(moment().subtract(9, 'months').startOf('week').unix())}`
             : `>${Math.floor(moment().subtract(1, 'year').startOf('week').unix())}`,
-        pageSize: getPageSize(subscribedChannels.length > 3 ? (subscribedChannels.length > 6 ? 12 : 8) : 4),
+        pageSize: getPageSize(subscribedChannelIds.length > 3 ? (subscribedChannelIds.length > 6 ? 12 : 8) : 4),
         streamTypes: null,
-        channelIds: subscribedChannels.map((subscription: Subscription) => {
-          const { channelClaimId } = parseURI(subscription.uri);
-          if (channelClaimId) return channelClaimId;
-        }),
+        channelIds: subscribedChannelIds,
       },
     };
     // $FlowFixMe flow thinks this might not be Array<string>

--- a/ui/util/url.js
+++ b/ui/util/url.js
@@ -186,24 +186,6 @@ export function generateGoogleCacheUrl(search, path) {
   }
 }
 
-const CLAIM_ID_LENGTH = 40;
-
-export function parseClaimIdFromPermanentUrl(url, failureId = '0') {
-  // - `parseURI` is too expensive for large loops, so this serves as a lighter
-  // alternative when iterating a list of permanent URLs.
-  // - It does not verify the permanent URL format, so only use this for areas
-  // where parsing failure is not fatal (e.g. if parsing for ist of IDs to
-  // resolve, missing a few wouldn't matter since components can resolve
-  // individually).
-  if (url) {
-    const parts = url.split('#');
-    const id = parts[parts.length - 1];
-    return id && id.length === CLAIM_ID_LENGTH ? id : failureId;
-  }
-
-  return failureId;
-}
-
 export const getPathForPage = (page) => `/$/${page}/`;
 
 export const getModalUrlParam = (modal, modalParams = {}) => {


### PR DESCRIPTION
## Ticket
Closes #2659 - Channel names with "*" causes issues.

## Root
```
export function splitBySeparator(uri: string) {
  const protocolLength = 7;
  return uri.startsWith('lbry://') ? uri.slice(protocolLength).split(/[#:*]/) : uri.split(/#:\*\$/);
}
```

This function splits * (on top of # and :), and was (recently?) being used to parse subscription uris. I think * is valid in channel names?

## Related issue
`parseUri` is expensive, and we constantly re-parse the subscription uris to get the IDs.

## Change
We should only need to parse it when `subscription` changes, so create a cached `selectSubscriptionIds` for that. Most components just want the IDs anyway.

So, we use `parseUri` instead of `splitBySeparator`, and only do it once.

