### PR TITLE
useLazyLoading: on set srcLoaded if the file actually worked

### DIFF
--- a/ui/effects/use-lazy-loading.js
+++ b/ui/effects/use-lazy-loading.js
@@ -31,8 +31,12 @@ export default function useLazyLoading(
     if (target.dataset.src) {
       // $FlowFixMe
       target.src = target.dataset.src;
-      setSrcLoadedFn(true);
-      // No fallback handling here (clients have access to 'onerror' on the image ref).
+      target.onload = () => setSrcLoadedFn(true);
+
+      // We don't handle onerror() here and simply let srcLoaded hanging for
+      // flexibility since we have various clients of this hook.
+      // If the client needs to do something special when error'd, they can add
+      // an onerror() to elementRef on their side.
       return;
     }
 


### PR DESCRIPTION
## Issue
Lot of FreezeFrameLite errors in Sentry

## Root
This hook marks the the source as "loaded" without actually checking if it did, so FreezeFrameLite ended up operating on an invalid image.
