### PR TITLE
Hunt down splitBySeparator | Fix failed selector caching

### DIFF
--- a/ui/component/claimListDiscover/index.js
+++ b/ui/component/claimListDiscover/index.js
@@ -10,10 +10,9 @@ import { doClaimSearch, doResolveClaimIds, doResolveUris } from 'redux/actions/c
 import { doFetchThumbnailClaimsForCollectionIds } from 'redux/actions/collections';
 import * as SETTINGS from 'constants/settings';
 import { selectFollowedTags } from 'redux/selectors/tags';
-import { selectMutedChannels } from 'redux/selectors/blocked';
+import { selectMutedAndBlockedChannelIds } from 'redux/selectors/blocked';
 import { doFetchOdyseeMembershipForChannelIds } from 'redux/actions/memberships';
 import { selectClientSetting, selectShowMatureContent, selectLanguage } from 'redux/selectors/settings';
-import { selectModerationBlockList } from 'redux/selectors/comments';
 import ClaimListDiscover from './view';
 import { doFetchViewCount } from 'lbryinc';
 
@@ -33,9 +32,8 @@ const select = (state, props) => ({
   hideMembersOnly: resolveHideMembersOnly(selectClientSetting(state, SETTINGS.HIDE_MEMBERS_ONLY_CONTENT), props.hideMembersOnly),
   hideReposts: selectClientSetting(state, SETTINGS.HIDE_REPOSTS),
   languageSetting: selectLanguage(state),
-  mutedUris: selectMutedChannels(state),
-  blockedUris: selectModerationBlockList(state),
   searchInLanguage: selectClientSetting(state, SETTINGS.SEARCH_IN_LANGUAGE),
+  mutedAndBlockedChannelIds: selectMutedAndBlockedChannelIds(state),
 });
 
 const perform = {

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -8,7 +8,6 @@ import { MATURE_TAGS } from 'constants/tags';
 import { resolveLangForClaimSearch } from 'util/default-languages';
 import { createNormalizedClaimSearchKey } from 'util/claim';
 import { CsOptions } from 'util/claim-search';
-import { splitBySeparator } from 'util/lbryURI';
 import Button from 'component/button';
 import moment from 'moment';
 import ClaimList from 'component/claimList';
@@ -105,9 +104,8 @@ type Props = {
   showNsfw: boolean,
   hideReposts: boolean,
   languageSetting: string,
-  mutedUris: Array<string>,
-  blockedUris: Array<string>,
   searchInLanguage: boolean,
+  mutedAndBlockedChannelIds: Array<ClaimId>,
 
   // --- perform ---
   doFetchThumbnailClaimsForCollectionIds: (params: { collectionIds: Array<string> }) => void,
@@ -147,8 +145,6 @@ function ClaimListDiscover(props: Props) {
     fetchViewCount,
     history,
     location,
-    mutedUris,
-    blockedUris,
     hiddenNsfwMessage,
     defaultOrderBy,
     sortBy,
@@ -185,6 +181,7 @@ function ClaimListDiscover(props: Props) {
     searchLanguages,
     searchInLanguage,
     ignoreSearchInLanguage,
+    mutedAndBlockedChannelIds,
     limitClaimsPerChannel,
     releaseTime,
     scrollAnchor,
@@ -246,9 +243,6 @@ function ClaimListDiscover(props: Props) {
     (defaultTags && getParamFromTags(defaultTags));
   const freshnessParam = freshness || urlParams.get(CS.FRESH_KEY) || defaultFreshness;
   const sortByParam = sortBy || urlParams.get(CS.SORT_BY_KEY) || CS.SORT_BY.NEWEST.key;
-  const mutedAndBlockedChannelIds = Array.from(
-    new Set(mutedUris.concat(blockedUris).map((uri) => splitBySeparator(uri)[1]))
-  );
   const hideRepostsEffective = resolveHideReposts(hideReposts, hideRepostsOverride);
 
   const [finalUris, setFinalUris] = React.useState();

--- a/ui/util/lbryURI.js
+++ b/ui/util/lbryURI.js
@@ -332,6 +332,8 @@ export function convertToShareLink(URL: string) {
   );
 }
 
+// WARNING: do not use this to parse a permanent URI. '*' is a valid character.
+// Function retained here just in case.
 export function splitBySeparator(uri: string) {
   const protocolLength = 7;
   return uri.startsWith('lbry://') ? uri.slice(protocolLength).split(/[#:*]/) : uri.split(/#:\*\$/);

--- a/web/src/lbryURI.js
+++ b/web/src/lbryURI.js
@@ -328,6 +328,8 @@ function convertToShareLink(URL) {
   );
 }
 
+// WARNING: do not use this to parse a permanent URI. '*' is a valid character.
+// Function retained here just in case.
 function splitBySeparator(uri) {
   const protocolLength = 7;
   return uri.startsWith('lbry://') ? uri.slice(protocolLength).split(/[#:*]/) : uri.split(/#:\*\$/);


### PR DESCRIPTION
1. Using `splitBySeparator` to parse ID from uri will fail when the channel name contains `*`. Hunt down remaining uses.
2. Fix cached selector that wasn't set up properly. 
    - If the slice itself is used as the input, it will pretty much always re-evaluate.
    - Before (many calls...) :arrow_right: After (3 calls as expected -- f5, muted fetched, blocked fetched)
    - <img width="200" alt="image" src="https://user-images.githubusercontent.com/64950861/232117221-05c33e8a-512f-465f-abd6-64c59de25569.png">  :arrow_right:  <img width="200" alt="after" src="https://user-images.githubusercontent.com/64950861/232117244-049a5f3f-a8d1-4b58-97f3-baae5ac2095a.png">
