### PR TITLE
Codespace: add sshd

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,9 @@
 {
   "name": "Odysee dev w/ node.js 18 (Bullseye)",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:18-bullseye"
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:18-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  }
 }


### PR DESCRIPTION
This is usually there in the default codespace, but since we are using a customized one, we lost the functionality.

This is needed for Jetbrains Gateway.