### PR TITLE
doFetchCreatorSettings: fix unhandled catch block

### DIFF
--- a/ui/page/claim/internal/claimPageComponent/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/view.jsx
@@ -120,7 +120,7 @@ const ClaimPageComponent = (props: Props) => {
 
   React.useEffect(() => {
     if (creatorSettings === undefined && channelClaimId) {
-      doFetchCreatorSettings(channelClaimId);
+      doFetchCreatorSettings(channelClaimId).catch(() => {});
     }
   }, [channelClaimId, creatorSettings, doFetchCreatorSettings]);
 

--- a/ui/page/featuredChannels/view.jsx
+++ b/ui/page/featuredChannels/view.jsx
@@ -30,7 +30,7 @@ function FeaturedChannelsPage(props: Props) {
 
   React.useEffect(() => {
     if (!creatorSettingsFetched && claimId) {
-      doFetchCreatorSettings(claimId);
+      doFetchCreatorSettings(claimId).catch(() => {});
     }
   }, [claimId, creatorSettingsFetched, doFetchCreatorSettings]);
 

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -1829,9 +1829,13 @@ export const doUpdateCreatorSettings = (channelClaim: ChannelClaim, settings: Pe
         dispatch(doFetchCreatorSettings(channelClaim.claim_id));
       })
       .catch((err) => {
-        try {
-          dispatch(doToast({ message: err.message, isError: true }));
-        } catch (error) {}
+        dispatch(
+          doToast({
+            message: __('Failed to update settings.'),
+            subMessage: err?.message,
+            isError: true,
+          })
+        );
       });
   };
 };


### PR DESCRIPTION
## Issue
Lots of Sentry errors from this unhandled error, which is usually just due to temp network glitch.

<img width="132" alt="image" src="https://user-images.githubusercontent.com/64950861/232328843-31c46141-a370-4216-8f9d-16cdedf846d8.png"> <img width="103" alt="image" src="https://user-images.githubusercontent.com/64950861/232328869-30a6bda1-a617-48bf-955f-91710ad41d00.png">

The root-cause is that `doFetchCreatorSettings` was changed to re-throw errors so that a shortcut `then/catch` can be done directly at the React component. 

<img width="208" alt="image" src="https://user-images.githubusercontent.com/64950861/232328714-75eb9e5d-8283-4f71-9bb8-e6fbea7bb5e2.png">

Anti-pattern arguments aside, none of the callers actually handled the `catch` block, and in fact relied of the unhandled error as a means to stop the comment from being sent.

## Change
Always handle `catch` when there is a `then`. Display proper toast.
