### PR TITLE
withResolvedClaimRender: fix claimIsMine always false

### DIFF
--- a/ui/hocs/withResolvedClaimRender/index.js
+++ b/ui/hocs/withResolvedClaimRender/index.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import withResolvedClaimRender from './view';
 
 import { PREFERENCE_EMBED } from 'constants/tags';
 import { selectIsClaimBlackListedForUri, selectIsClaimFilteredForUri } from 'lbryinc';
@@ -6,7 +7,7 @@ import { selectIsClaimBlackListedForUri, selectIsClaimFilteredForUri } from 'lbr
 import {
   selectClaimForUri,
   selectHasClaimForUri,
-  selectClaimIsMineForUri,
+  selectClaimIsMine,
   selectGeoRestrictionForUri,
   makeSelectTagInClaimOrChannelForUri,
 } from 'redux/selectors/claims';
@@ -15,8 +16,6 @@ import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { doResolveUri } from 'redux/actions/claims';
 import { doBeginPublish } from 'redux/actions/publish';
 import { doOpenModal } from 'redux/actions/app';
-
-import withResolvedClaimRender from './view';
 
 const select = (state, props) => {
   const { uri } = props;
@@ -30,7 +29,7 @@ const select = (state, props) => {
     hasClaim: selectHasClaimForUri(state, uri),
     isClaimBlackListed: selectIsClaimBlackListedForUri(state, uri),
     isClaimFiltered: selectIsClaimFilteredForUri(state, uri),
-    claimIsMine: selectClaimIsMineForUri(state, claim),
+    claimIsMine: selectClaimIsMine(state, claim),
     isAuthenticated: selectUserVerifiedEmail(state),
     geoRestriction: selectGeoRestrictionForUri(state, uri),
     preferEmbed,


### PR DESCRIPTION
## Issue
Wrong function used

## Note
Fixing this means creators can now see their own geo-restricted content. If that is not desired (i.e. want a blanket block of geo-restricted content), then edit the logic in the jsx.

An upcoming PR will require claimIsMine to be correct.
