### PR TITLE
Fix portals crash when user/new fails

### DIFF
--- a/ui/page/portal/index.js
+++ b/ui/page/portal/index.js
@@ -9,7 +9,7 @@ const select = (state) => {
   const { portals } = homepageData;
   const { mainPortal } = portals || {};
   const user = selectUser(state);
-  const { global_mod, internal_feature } = user;
+  const { global_mod, internal_feature } = user || {};
   const showViews = global_mod || internal_feature;
 
   return {


### PR DESCRIPTION
Closes #2685

Don't de-reference empty `user` object. Looks like the info is just used for internal purposes, so should be safe.
