### PR TITLE
Make text on invite page less strange

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -1004,7 +1004,7 @@
   "Please %sign_in_link% to comment.": "Please %sign_in_link% to comment.",
   "Replying as %reply_channel%": "Replying as %reply_channel%",
   "Error ID: %sentryEventId%": "Error ID: %sentryEventId%",
-  "%channel_name% is waiting for you on %site_name%. %signup_link% to claim it.": "%channel_name% is waiting for you on %site_name%. %signup_link% to claim it.",
+  "%channel_name% is waiting for you on %site_name%. %signup_link% to follow them.": "%channel_name% is waiting for you on %site_name%. %signup_link% to follow them.",
   "Content freedom and a present are waiting for you. %signup_link% to claim it.": "Content freedom and a present are waiting for you. %signup_link% to claim it.",
   "Finish Account": "Finish Account",
   "Create Account": "Create Account",

--- a/ui/page/invited/internal/invited/view.jsx
+++ b/ui/page/invited/internal/invited/view.jsx
@@ -188,7 +188,7 @@ function Invited(props: Props) {
       subtitle={
         referrerIsChannel ? (
           <I18nMessage tokens={{ channel_name: channelTitle, signup_link: <SignUpButton />, site_name: SITE_NAME }}>
-            %channel_name% is waiting for you on %site_name%. %signup_link% to claim it.
+            %channel_name% is waiting for you on %site_name%. %signup_link% to follow them.
           </I18nMessage>
         ) : (
           <I18nMessage tokens={{ signup_link: <SignUpButton /> }}>


### PR DESCRIPTION
Changes the text on invite pages like: https://odysee.com/$/invite/@odysee
The current one doesn't really make sense.  