### PR TITLE
Fix attempt - (Playlists) Keep `persistedOption` up to date with `sortOption`

### DIFF
--- a/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/index.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/internal/collectionListHeader/index.jsx
@@ -12,14 +12,12 @@ type Props = {
   filterType: string,
   isTruncated: boolean,
   sortOption: { key: string, value: string },
-  persistedOption: { key: string, value: string },
   setFilterType: (type: string) => void,
   setSortOption: (params: { key: string, value: string }) => void,
-  setPersistedOption: (params: { key: string, value: string }) => void,
 };
 
 export default function CollectionsListMine(props: Props) {
-  const { filterType, isTruncated, sortOption, setFilterType, setSortOption, setPersistedOption } = props;
+  const { filterType, isTruncated, sortOption, setFilterType, setSortOption } = props;
 
   const history = useHistory();
   const {
@@ -37,7 +35,6 @@ export default function CollectionsListMine(props: Props) {
 
     const url = `?${urlParams.toString()}`;
     history.push(url);
-    setPersistedOption(sortOption);
   }
 
   function handleFilterTypeChange(value) {

--- a/ui/page/playlists/internal/collectionsListMine/view.jsx
+++ b/ui/page/playlists/internal/collectionsListMine/view.jsx
@@ -224,6 +224,10 @@ export default function CollectionsListMine(props: Props) {
     }
   }, [filterParamsChanged]);
 
+  React.useEffect(() => {
+    setPersistedOption(sortOption);
+  }, [sortOption]);
+
   return (
     <>
       <SectionLabel label={__('Your Playlists')} />
@@ -243,8 +247,6 @@ export default function CollectionsListMine(props: Props) {
           // $FlowFixMe
           sortOption={sortOption}
           setSortOption={setSortOption}
-          persistedOption={persistedOption}
-          setPersistedOption={setPersistedOption}
         />
       </CollectionsListContext.Provider>
 


### PR DESCRIPTION
Fixes this:
For some reason persisted order got always set to the previous sort order, instead of what it was switched to.

Steps to see the issue:
1. Go to https://odysee.com/$/playlists
2. Change playlist order twice (or once)
3. Go to home
4. Go to playlists
5. The order isn't what it was when left off.

