### PR TITLE
Promote dependency warnings as errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,13 +48,13 @@
     "promise/param-names": 0,
     "react/jsx-indent": 0,
     "react/jsx-no-comment-textnodes": 0,
-    "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/exhaustive-deps": "error",
     "react-hooks/rules-of-hooks": "error",
     "react/no-unescaped-entities": 0,
     "space-before-function-paren": [
-      "warn",
+      "error",
       {
-        "anonymous": "never",
+        "anonymous": "always",
         "named": "never",
         "asyncArrow": "always"
       }

--- a/extras/lbryinc/redux/actions/sync.js
+++ b/extras/lbryinc/redux/actions/sync.js
@@ -284,6 +284,7 @@ export function doSyncEncryptAndDecrypt(oldPassword, newPassword, encrypt) {
           return dispatch(doSetSync(data.oldHash, syncApplyResponse.hash, syncApplyResponse.data));
         }
       })
+      // eslint-disable-next-line no-console
       .catch(console.error);
   };
 }

--- a/extras/recsys/recsys.js
+++ b/extras/recsys/recsys.js
@@ -192,7 +192,7 @@ const recsys: Recsys = {
           }
         })
         .catch((err) => {
-          console.log('RECSYS: failed to send entry', err);
+          console.log('RECSYS: failed to send entry', err); // eslint-disable-line no-console
         });
     }
     recsys.log('sendRecsysEntry', claimId);
@@ -202,7 +202,7 @@ const recsys: Recsys = {
     if (entries) {
       if (Object.keys(recsys.entries).length !== 0) {
         // Typically called on startup only.
-        console.warn('RECSYS: sendEntries() called on non-empty state. Data will be overwritten.');
+        console.warn('RECSYS: sendEntries() called on non-empty state. Data will be overwritten.'); // eslint-disable-line no-console
       }
 
       recsys.entries = entries;
@@ -243,6 +243,7 @@ const recsys: Recsys = {
 
   log: function (callName, claimId) {
     if (recsys.debug) {
+      // eslint-disable-next-line no-console
       console.log(`Call: ***${callName}***, ClaimId: ${claimId}, Recsys Entries`, Object.assign({}, recsys.entries));
     }
   },

--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -496,13 +496,14 @@ function App(props: Props) {
     if (prefsReady && isAuthenticated && (pathname === '/' || pathname === `/$/${PAGES.HELP}`) && announcement !== '') {
       doOpenAnnouncements();
     }
-  }, [announcement, isAuthenticated, pathname, prefsReady]);
+  }, [announcement, isAuthenticated, pathname, prefsReady, doOpenAnnouncements]);
 
   useEffect(() => {
     window.clearLastViewedAnnouncement = () => {
       console.log('Clearing history. Please wait ...'); // eslint-disable-line no-console
       doSetLastViewedAnnouncement('clear');
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   // Keep this at the end to ensure initial setup effects are run first

--- a/ui/component/chat/chatComment/view.jsx
+++ b/ui/component/chat/chatComment/view.jsx
@@ -110,6 +110,7 @@ export default function ChatComment(props: Props) {
 
   React.useEffect(() => {
     if (hasUserMention) setUserMention(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: no idea if valid
   }, [activeChannelClaim]);
 
   return (

--- a/ui/component/chat/view.jsx
+++ b/ui/component/chat/view.jsx
@@ -246,7 +246,6 @@ export default function ChatLayout(props: Props) {
   React.useEffect(() => {
     if (discussionElement && commentsLength > 0) {
       // Only update comment scroll if the user hasn't scrolled up to view old comments
-      // $FlowFixMe
       if (scrollPos && (!isMobile || minScrollHeight) && scrollPos >= minScrollHeight) {
         // +ve scrollPos: not scrolled (Usually, there'll be a few pixels beyond 0).
         // -ve scrollPos: user scrolled.
@@ -300,7 +299,7 @@ export default function ChatLayout(props: Props) {
         </div>
       )
     );
-  }, [channelTitle, chatUnlocked, isLivestreamChatMembersOnly]);
+  }, [notAuthedToLiveChat, channelTitle, chatUnlocked, isLivestreamChatMembersOnly]);
 
   if (!claimId) return null;
 

--- a/ui/component/chat/view.jsx
+++ b/ui/component/chat/view.jsx
@@ -351,7 +351,6 @@ export default function ChatLayout(props: Props) {
   }
 
   function handleHyperchatClick(hyperchat: Comment) {
-    console.log('selectHyperchat: ', hyperchat);
     setSelectedHyperchat(hyperchat);
   }
 

--- a/ui/component/claimLink/internal/preview/view.jsx
+++ b/ui/component/claimLink/internal/preview/view.jsx
@@ -48,6 +48,7 @@ const ClaimLinkPreview = (props: Props) => {
           <Button button="link" label={channel + ': ' + title} navigate={cleanUri} />
         </div>
       ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
     [uri]
   );
 

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -283,7 +283,7 @@ function ClaimListDiscover(props: Props) {
         break;
 
       default:
-        console.log('Invalid or unhandled CONTENT_KEY:', contentTypeParam); // eslint-disable-line no-console
+        assert(false, 'Invalid or unhandled CONTENT_KEY:', contentTypeParam);
         break;
     }
   }
@@ -411,7 +411,7 @@ function ClaimListDiscover(props: Props) {
         }
         break;
       default:
-        console.error('Unhandled duration: ' + durationParam);
+        assert(false, 'Unhandled duration:', durationParam);
         break;
     }
   }

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -230,6 +230,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
         </Tooltip>
       </div>
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [channelSubCount]);
 
   // $FlowFixMe

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -197,6 +197,7 @@ function CommentView(props: Props) {
       fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST);
       setShowReplies(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only?
   }, []);
 
   const isSprout = channelAge && Math.round((new Date() - channelAge) / (1000 * 60 * 60 * 24)) < 7;

--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -618,6 +618,7 @@ export function CommentCreate(props: Props) {
     if (myCommentedChannelIds === undefined && claimId && myChannelClaimIds) {
       doFetchMyCommentedChannels(claimId);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [claimId, myCommentedChannelIds, myChannelClaimIds]);
 
   React.useEffect(() => {
@@ -632,6 +633,7 @@ export function CommentCreate(props: Props) {
       // $FlowFixMe
       return formFieldRef?.current?.input?.current?.focus();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [textInjection]);
 
   const notAuthedToLiveChat = Boolean(

--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -277,12 +277,14 @@ export default function CommentList(props: Props) {
         activeChannelId
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [currentFetchedPage, fetchComment, fetchTopLevelComments, linkedCommentId, page, sort, threadCommentId, uri]);
 
   React.useEffect(() => {
     if (threadCommentId) {
       refreshComments();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [threadCommentId]);
 
   // Fetch reacts

--- a/ui/component/common/file-list.jsx
+++ b/ui/component/common/file-list.jsx
@@ -46,7 +46,7 @@ function FileList(props: Props) {
 
         if (radio.state) {
           // Find selected element
-          const stop = radio.stops.find(item => item.id === radio.currentId);
+          const stop = radio.stops.find((item) => item.id === radio.currentId);
           const element = stop && stop.ref.current;
           // Only update state if new item is selected
           if (element && element.value !== radio.state) {
@@ -58,6 +58,7 @@ function FileList(props: Props) {
         }
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [radio, onChange]);
 
   return (

--- a/ui/component/common/freezeframe-wrapper.jsx
+++ b/ui/component/common/freezeframe-wrapper.jsx
@@ -32,6 +32,7 @@ const FreezeframeWrapper = (props: Props) => {
       imgRef.current?.setAttribute('src', `${THUMBNAIL_CDN_URL}s:${width}:0/quality:95/plain/${src}`);
       freezeframe.current = new Freezeframe(imgRef.current);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [src, imgRef]);
 
   return (

--- a/ui/component/creatorAnalytics/view.jsx
+++ b/ui/component/creatorAnalytics/view.jsx
@@ -46,6 +46,7 @@ export default function CreatorAnalytics(props: Props) {
       if (VideoURITopNew && VideoURITopNew.charAt(0) === '@') uris.push(VideoURITopNew);
       doResolveUris(uris);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [stats]);
 
   const channelForEffect = JSON.stringify(claim);

--- a/ui/component/header/view.jsx
+++ b/ui/component/header/view.jsx
@@ -141,6 +141,7 @@ const Header = (props: Props) => {
         }
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
     [backNavDefault, goBack, hasNavigated, push, returnPath]
   );
 

--- a/ui/component/inviteNew/view.jsx
+++ b/ui/component/inviteNew/view.jsx
@@ -42,6 +42,7 @@ function InviteNew(props: Props) {
         analytics.apiLog.publish(matchingChannel);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
     [setReferralSource]
   );
 

--- a/ui/component/livestreamLayout/view.jsx
+++ b/ui/component/livestreamLayout/view.jsx
@@ -70,6 +70,7 @@ export default function LivestreamLayout(props: Props) {
 
   React.useEffect(() => {
     if (!isCurrentClaimLive) doClearPlayingUri();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [isCurrentClaimLive]);
 
   if (!claim || !claim.signing_channel) return null;

--- a/ui/component/livestreamList/view.jsx
+++ b/ui/component/livestreamList/view.jsx
@@ -27,6 +27,7 @@ export default function LivestreamList(props: Props) {
     return () => {
       clearInterval(fetchInterval);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   if (fetchingActiveLivestreams) {

--- a/ui/component/nag/view.jsx
+++ b/ui/component/nag/view.jsx
@@ -45,6 +45,7 @@ export default function Nag(props: Props) {
     return () => {
       doUpdateVisibleNagIds(id, false);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   return (

--- a/ui/component/navigationHistoryItem/view.jsx
+++ b/ui/component/navigationHistoryItem/view.jsx
@@ -13,9 +13,9 @@ type Props = {
   claim: ?StreamClaim,
   selected: boolean,
   onSelect?: () => void,
-  resolveUri: string => void,
+  resolveUri: (string) => void,
   slim: boolean,
-  history: { push: string => void },
+  history: { push: (string) => void },
 };
 
 class NavigationHistoryItem extends React.PureComponent<Props> {
@@ -42,7 +42,7 @@ class NavigationHistoryItem extends React.PureComponent<Props> {
     const navigatePath = formatLbryUrlForWeb(uri);
     const onClick =
       onSelect ||
-      function() {
+      function () {
         history.push(navigatePath);
       };
 

--- a/ui/component/portals/view.jsx
+++ b/ui/component/portals/view.jsx
@@ -52,6 +52,7 @@ export default function Portals(props: Props) {
     if (portals && width) {
       setMarginLeft((index - 1) * (tileWidth * -1));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [portals, index, width]);
 
   useOnResize(() => {

--- a/ui/component/publish/livestream/livestreamForm/view.jsx
+++ b/ui/component/publish/livestream/livestreamForm/view.jsx
@@ -211,6 +211,7 @@ function LivestreamForm(props: Props) {
 
   useEffect(() => {
     setClearStatus(isClear);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [isClear]);
 
   useEffect(() => {
@@ -241,6 +242,7 @@ function LivestreamForm(props: Props) {
       setPreviewing(false);
       updatePublishForm({ publishError: undefined });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [publishError]);
 
   // move this to lbryinc OR to a file under ui, and/or provide a standardized livestreaming config.
@@ -374,6 +376,7 @@ function LivestreamForm(props: Props) {
       setPublishMode('New');
       updatePublishForm({ isLivestreamPublish: true, remoteFileUrl: undefined });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [editingURI, resolveUri]);
 
   useEffect(() => {
@@ -387,6 +390,7 @@ function LivestreamForm(props: Props) {
     if (publishMode === 'New') {
       updatePublishForm({ isLivestreamPublish: true, remoteFileUrl: undefined });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [publishMode]);
 
   useEffect(() => {

--- a/ui/component/publish/livestream/publishLivestream/view.jsx
+++ b/ui/component/publish/livestream/publishLivestream/view.jsx
@@ -104,6 +104,8 @@ function PublishLivestream(props: Props) {
   // Reset title when form gets cleared
   useEffect(() => {
     updatePublishForm({ title: title });
+    // ^ TODO: logic these should be at the reducer/action.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Reset title when form gets cleared
   }, [filePath]);
 
   // Initialize default file source state for each mode.
@@ -182,10 +184,12 @@ function PublishLivestream(props: Props) {
         handleFileChange(filePath);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [filePath, currentFile, doToast, updatePublishForm]);
 
   useEffect(() => {
     setOverMaxBitrate(bitRateIsOverMax);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [bitRateIsOverMax]);
 
   function updateFileInfo(duration, size, isvid) {

--- a/ui/component/publish/post/postForm/view.jsx
+++ b/ui/component/publish/post/postForm/view.jsx
@@ -212,6 +212,7 @@ function PostForm(props: Props) {
       setPreviewing(false);
       updatePublishForm({ publishError: undefined });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [publishError]);
 
   let submitLabel;

--- a/ui/component/publish/shared/publishAdditionalOptions/view.jsx
+++ b/ui/component/publish/shared/publishAdditionalOptions/view.jsx
@@ -55,6 +55,7 @@ function PublishAdditionalOptions(props: Props) {
         otherLicenseDescription: 'All rights reserved',
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [licenseType]);
 
   return (

--- a/ui/component/publish/upload/publishFile/view.jsx
+++ b/ui/component/publish/upload/publishFile/view.jsx
@@ -103,6 +103,7 @@ function PublishFile(props: Props) {
 
   useEffect(() => {
     updatePublishForm({ title: title });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reset title when file changes
   }, [filePath]);
 
   /*
@@ -131,10 +132,12 @@ function PublishFile(props: Props) {
         handleFileChange(filePath);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [filePath, currentFile, doToast, updatePublishForm]);
 
   useEffect(() => {
     setOverMaxBitrate(bitRateIsOverMax);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [bitRateIsOverMax]);
 
   // move this to lbryinc OR to a file under ui, and/or provide a standardized livestreaming config.
@@ -193,6 +196,7 @@ function PublishFile(props: Props) {
     if (activeChannelClaim && activeChannelClaim.claim_id && activeChannelName) {
       fetchLivestreams(activeChannelClaim.claim_id, activeChannelName);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [claimChannelId, activeChannelName]);
 
   useEffect(() => {

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -238,6 +238,7 @@ function UploadForm(props: Props) {
       setPreviewing(false);
       updatePublishForm({ publishError: undefined });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [publishError]);
 
   let submitLabel;

--- a/ui/component/publishProtectedContent/view.jsx
+++ b/ui/component/publishProtectedContent/view.jsx
@@ -58,6 +58,7 @@ function PublishProtectedContent(props: Props) {
     if (claimId) {
       getMembershipTiersForContentClaimId(claimId);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [claimId]);
 
   // $FlowIssue
@@ -88,6 +89,7 @@ function PublishProtectedContent(props: Props) {
         });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [protectedMembershipIds, activeChannel, isStillEditing]);
 
   function handleRestrictedMembershipChange(event) {
@@ -139,6 +141,7 @@ function PublishProtectedContent(props: Props) {
         channel_id: activeChannel.claim_id,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [activeChannel]);
 
   if (incognito) return null;

--- a/ui/component/repostCreate/view.jsx
+++ b/ui/component/repostCreate/view.jsx
@@ -193,6 +193,7 @@ function RepostCreate(props: Props) {
     if (repostTakeoverAmount) {
       setAutoRepostBid(repostTakeoverAmount);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: should include setAutoRepostBid + useCallback
   }, [enteredRepostAmount, passedRepostAmount]);
 
   // repost bid error
@@ -208,7 +209,7 @@ function RepostCreate(props: Props) {
       rBidError = __('Your deposit must be higher');
     }
     setRepostBidError(rBidError);
-  }, [setRepostBidError, repostBidError, repostBid]);
+  }, [balance, setRepostBidError, repostBidError, repostBid]);
 
   // setContentUri given enteredUri
   React.useEffect(() => {
@@ -237,7 +238,7 @@ function RepostCreate(props: Props) {
         setContentUri(``);
       }
     }
-  }, [enteredContent, setContentUri, setContentError, parseURI, isNameValid]);
+  }, [enteredContent, setContentUri, setContentError]);
 
   // setRepostName
   React.useEffect(() => {
@@ -253,7 +254,7 @@ function RepostCreate(props: Props) {
         setRepostUri(enteredRepostName);
       }
     }
-  }, [enteredRepostName, setRepostUri, parseURI]);
+  }, [enteredRepostName, setRepostUri]);
 
   const repostClaimId = contentClaimId || enteredClaimId;
 

--- a/ui/component/searchChannelField/view.jsx
+++ b/ui/component/searchChannelField/view.jsx
@@ -125,6 +125,7 @@ export default function SearchChannelField(props: Props) {
         setSearchUri('');
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [searchTerm, setSearchTermError]);
 
   return (

--- a/ui/component/searchOptions/view.jsx
+++ b/ui/component/searchOptions/view.jsx
@@ -77,6 +77,7 @@ const SearchOptions = (props: Props) => {
     if (options[SEARCH_OPTIONS.RESULT_COUNT] !== SEARCH_PAGE_SIZE) {
       setSearchOption(SEARCH_OPTIONS.RESULT_COUNT, SEARCH_PAGE_SIZE);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   function updateSearchOptions(option, value) {

--- a/ui/component/settingWalletServer/view.jsx
+++ b/ui/component/settingWalletServer/view.jsx
@@ -69,6 +69,7 @@ function SettingWalletServer(props: Props) {
         doClear();
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
     []
   );
 
@@ -76,6 +77,7 @@ function SettingWalletServer(props: Props) {
     if (hasWalletServerPrefs) {
       setAdvancedMode(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   useEffect(() => {
@@ -83,6 +85,7 @@ function SettingWalletServer(props: Props) {
       getDaemonStatus();
     }, STATUS_INTERVAL);
     return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   function doClear() {

--- a/ui/component/syncEnableFlow/view.jsx
+++ b/ui/component/syncEnableFlow/view.jsx
@@ -34,16 +34,8 @@ const SHARED_KEY = 'shared';
 const LOCAL_KEY = 'local';
 
 function SyncEnableFlow(props: Props) {
-  const {
-    setSyncEnabled,
-    getSyncError,
-    getSyncPending,
-    getSync,
-    checkSync,
-    mode,
-    closeModal,
-    updatePreferences,
-  } = props;
+  const { setSyncEnabled, getSyncError, getSyncPending, getSync, checkSync, mode, closeModal, updatePreferences } =
+    props;
 
   const [step, setStep] = React.useState(INITIAL);
   const [prefDict, setPrefDict]: [any, (any) => void] = React.useState();
@@ -118,6 +110,7 @@ function SyncEnableFlow(props: Props) {
         setStep(FETCH_FOR_DISABLE);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [mode, setPassword]);
 
   React.useEffect(() => {
@@ -146,6 +139,7 @@ function SyncEnableFlow(props: Props) {
         setStep(CONFIRM);
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [step, setPrefDict, setStep, password]);
 
   if (getSyncPending) {

--- a/ui/component/userEmailNew/view.jsx
+++ b/ui/component/userEmailNew/view.jsx
@@ -94,6 +94,7 @@ function UserEmailNew(props: Props) {
     if (emailExists) {
       handleChangeToSignIn();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [emailExists]);
 
   return (

--- a/ui/component/userSignIn/view.jsx
+++ b/ui/component/userSignIn/view.jsx
@@ -7,10 +7,10 @@ import Spinner from 'component/spinner';
 
 type Props = {
   user: ?User,
-  history: { push: string => void, replace: string => void },
+  history: { push: (string) => void, replace: (string) => void },
   location: { search: string },
   userFetchPending: boolean,
-  doUserSignIn: string => void,
+  doUserSignIn: (string) => void,
   emailToVerify: ?string,
   passwordExists: boolean,
 };
@@ -30,6 +30,7 @@ function UserSignIn(props: Props) {
     if (hasVerifiedEmail || (!showEmail && !showPassword && !showLoading)) {
       history.replace(redirect || '/');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [showEmail, showPassword, showLoading, hasVerifiedEmail]);
 
   React.useEffect(() => {

--- a/ui/component/userSignUp/view.jsx
+++ b/ui/component/userSignUp/view.jsx
@@ -135,6 +135,7 @@ function UserSignUp(props: Props) {
     if (previousHasVerifiedEmail === false && hasVerifiedEmail && prefsReady) {
       setSettingAndSync(SETTINGS.FIRST_RUN_STARTED, true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [hasVerifiedEmail, previousHasVerifiedEmail, prefsReady]);
 
   React.useEffect(() => {

--- a/ui/component/videoRenderFloating/internal/autoplayCountdown/view.jsx
+++ b/ui/component/videoRenderFloating/internal/autoplayCountdown/view.jsx
@@ -102,6 +102,7 @@ function AutoplayCountdown(props: Props) {
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   // Update countdown timer.

--- a/ui/component/viewers/videoViewer/internal/effects/use-autoplay-next.js
+++ b/ui/component/viewers/videoViewer/internal/effects/use-autoplay-next.js
@@ -83,6 +83,7 @@ export default function useAutoplayNext(playerRef: any, autoplayNext: boolean, i
         autoplayButton.setAttribute('aria-checked', autoplayNext);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [autoplayNext, isMarkdownOrComment]);
 
   React.useEffect(() => {
@@ -90,6 +91,7 @@ export default function useAutoplayNext(playerRef: any, autoplayNext: boolean, i
     if (player) {
       player.trigger(`${VJS_COMP.AUTOPLAY_NEXT_BUTTON}::onState`, autoplayNext);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- I think listening to refs don't work?
   }, [autoplayNext]);
 
   return addAutoplayNextButton;

--- a/ui/component/viewers/videoViewer/internal/effects/use-theater-mode.js
+++ b/ui/component/viewers/videoViewer/internal/effects/use-theater-mode.js
@@ -68,6 +68,7 @@ export default function useTheaterMode(playerRef: any, videoTheaterMode: boolean
         theaterButton.controlText(videoTheaterMode ? __('Default Mode (t)') : __('Theater Mode (t)'));
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- I think no need to listen to refs
   }, [videoTheaterMode]);
 
   return addTheaterModeButton;

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-http-streaming--override/playlist.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-http-streaming--override/playlist.js
@@ -1,3 +1,5 @@
+/* eslint-disable space-before-function-paren */
+
 /**
  * @file playlist.js
  *
@@ -11,7 +13,7 @@
  * @return {boolean} whether the playlist is blacklisted or not
  * @function isBlacklisted
  */
-export const isBlacklisted = function(playlist) {
+export const isBlacklisted = function (playlist) {
   return playlist.excludeUntil && playlist.excludeUntil > Date.now();
 };
 
@@ -23,7 +25,7 @@ export const isBlacklisted = function(playlist) {
  * @return {boolean} whether the playlist is incompatible or not
  * @function isIncompatible
  */
-export const isIncompatible = function(playlist) {
+export const isIncompatible = function (playlist) {
   return playlist.excludeUntil && playlist.excludeUntil === Infinity;
 };
 
@@ -34,10 +36,10 @@ export const isIncompatible = function(playlist) {
  * @return {boolean} whether the playlist is enabled or not
  * @function isEnabled
  */
-export const isEnabled = function(playlist) {
+export const isEnabled = function (playlist) {
   const blacklisted = isBlacklisted(playlist);
 
-  return (!playlist.disabled && !blacklisted);
+  return !playlist.disabled && !blacklisted;
 };
 
 /**
@@ -47,7 +49,7 @@ export const isEnabled = function(playlist) {
  * @return {boolean} whether the playlist is disabled manually or not
  * @function isDisabled
  */
-export const isDisabled = function(playlist) {
+export const isDisabled = function (playlist) {
   return playlist.disabled;
 };
 

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-i18n/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-i18n/plugin.js
@@ -26,7 +26,7 @@ const defaultOptions = {};
 
 function logError(msg) {
   // @if process.env.LOG_VIDEOJS_I18N='true'
-  console.error(msg);
+  console.error(msg); // eslint-disable-line no-console
   // @endif
 }
 

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-overlay/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-overlay/plugin.js
@@ -32,7 +32,7 @@ const registerPlugin = videojs.registerPlugin || videojs.plugin;
  */
 
 /* eslint-disable no-self-compare */
-const isNumber = n => typeof n === 'number' && n === n;
+const isNumber = (n) => typeof n === 'number' && n === n;
 /* eslint-enable no-self-compare */
 
 /**
@@ -41,7 +41,7 @@ const isNumber = n => typeof n === 'number' && n === n;
  * @param  {String} s
  * @return {Boolean}
  */
-const hasNoWhitespace = s => typeof s === 'string' && /^\S+$/.test(s);
+const hasNoWhitespace = (s) => typeof s === 'string' && /^\S+$/.test(s);
 
 /**
  * Overlay component.
@@ -53,7 +53,7 @@ class Overlay extends Component {
   constructor(player, options) {
     super(player, options);
 
-    ['start', 'end'].forEach(key => {
+    ['start', 'end'].forEach((key) => {
       const value = this.options_[key];
 
       if (isNumber(value)) {
@@ -74,8 +74,8 @@ class Overlay extends Component {
     // its GUID magic), but the anonymous function approach avoids any issues
     // caused by crappy libraries clobbering Function.prototype.bind.
     // - https://github.com/videojs/video.js/issues/3097
-    ['endListener_', 'rewindListener_', 'startListener_'].forEach(name => {
-      this[name] = e => Overlay.prototype[name].call(this, e);
+    ['endListener_', 'rewindListener_', 'startListener_'].forEach((name) => {
+      this[name] = (e) => Overlay.prototype[name].call(this, e);
     });
 
     // If the start event is a timeupdate, we need to watch for rewinds (i.e.,
@@ -306,12 +306,12 @@ videojs.registerComponent('Overlay', Overlay);
  * @function plugin
  * @param    {Object} [options={}]
  */
-const plugin = function(options) {
+const plugin = function (options) {
   const settings = videojs.mergeOptions(defaults, options);
 
   // De-initialize the plugin if it already has an array of overlays.
   if (Array.isArray(this.overlays_)) {
-    this.overlays_.forEach(overlay => {
+    this.overlays_.forEach((overlay) => {
       this.removeChild(overlay);
       if (this.controlBar) {
         this.controlBar.removeChild(overlay);
@@ -326,7 +326,7 @@ const plugin = function(options) {
   // because it doesn't make sense to pass it to each Overlay component.
   delete settings.overlays;
 
-  this.overlays_ = overlays.map(o => {
+  this.overlays_ = overlays.map((o) => {
     const mergeOptions = videojs.mergeOptions(settings, o);
     const attachToControlBar =
       typeof mergeOptions.attachToControlBar === 'string' || mergeOptions.attachToControlBar === true;

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-recsys/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-recsys/plugin.js
@@ -172,7 +172,7 @@ class RecsysPlugin extends Component {
 
   log(...args) {
     if (this.options_.debug) {
-      console.log(`Recsys Player Debug:`, JSON.stringify(args));
+      console.log(`Recsys Player Debug:`, JSON.stringify(args)); // eslint-disable-line no-console
     }
   }
 }

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-settings-menu/videojs-plus/Utils/Log.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-settings-menu/videojs-plus/Utils/Log.js
@@ -9,10 +9,10 @@ try {
 const log = (function () {
   if (logType === 'normal' || videojs.browser.IE_VERSION) {
     // log without style
-    return console.info.bind(console, '[VJS Plus]:');
+    return console.info.bind(console, '[VJS Plus]:'); // eslint-disable-line no-console
   } else if (logType) {
     // log with style
-    return console.info.bind(console, '%c[VJS Plus]:', 'font-weight: bold; color:#2196F3;');
+    return console.info.bind(console, '%c[VJS Plus]:', 'font-weight: bold; color:#2196F3;'); // eslint-disable-line no-console
   }
 
   return function () {};

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -615,7 +615,9 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     return () => {
       window.removeEventListener('keydown', keyDownHandlerRef.current);
 
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- FIX_THIS!
       const containerDiv = containerRef.current;
+
       // $FlowFixMe
       containerDiv && containerDiv.removeEventListener('wheel', videoScrollHandlerRef.current);
 
@@ -666,6 +668,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         delete window.videoFps;
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [isAudio, source, reload, userClaimId, isLivestreamClaim]);
 
   return (

--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -198,6 +198,7 @@ function VideoViewer(props: Props) {
       // save the updated watch time
       doSetContentHistoryItem(claim.permanent_url);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [isPlaying]);
 
   useEffect(() => {
@@ -206,6 +207,7 @@ function VideoViewer(props: Props) {
       return;
     }
     toggleAutoplayNext();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [localAutoplayNext]);
 
   useInterval(

--- a/ui/component/walletSwap/view.jsx
+++ b/ui/component/walletSwap/view.jsx
@@ -215,6 +215,7 @@ function WalletSwap(props: Props) {
         setNag({ msg: swapInfo.status.status, type: 'error' });
         break;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [swap, coinSwaps]);
 
   // Validate entered LBC

--- a/ui/component/wunderbarSuggestions/view.jsx
+++ b/ui/component/wunderbarSuggestions/view.jsx
@@ -48,7 +48,6 @@ type Props = {
   showMature: boolean,
   claimsByUri: { [string]: Claim },
   subscriptionUris: Array<string>,
-  doResolveUris: (string) => void,
   navigateToSearchPage: (string) => void,
   doShowSnackBar: (string) => void,
   doCloseMobileSearch: () => void,
@@ -247,6 +246,7 @@ export default function WunderBarSuggestions(props: Props) {
 
     return () => {
       if (inputRef.current) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- wrong, but unused code
         inputRef.current.removeEventListener('keydown', overrideHomeEndHandling);
       }
     };
@@ -304,6 +304,7 @@ export default function WunderBarSuggestions(props: Props) {
       window.removeEventListener('keydown', handleKeyDown);
       // @if TARGET='app'
       if (inputRef.current) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- wrong, but unused code
         inputRef.current.removeEventListener('dblclick', handleDoubleClick);
       }
       // @endif
@@ -317,6 +318,7 @@ export default function WunderBarSuggestions(props: Props) {
   }, [inputRef, isMobile]);
 
   const stringifiedResults = JSON.stringify(results);
+
   React.useEffect(() => {
     if (stringifiedResults) {
       const arrayResults = JSON.parse(stringifiedResults);
@@ -327,6 +329,7 @@ export default function WunderBarSuggestions(props: Props) {
   }, [doResolveUris, stringifiedResults]);
 
   const [subscriptionResults, setSubscriptionResults] = React.useState([]);
+
   React.useEffect(() => {
     if (subscriptionUris && term && term.length > 1) {
       let subscriptionResults = [];
@@ -343,6 +346,7 @@ export default function WunderBarSuggestions(props: Props) {
       });
       setSubscriptionResults(subscriptionResults.slice(0, isMobile ? 5 : 10));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [term]);
 
   React.useEffect(() => {

--- a/ui/effects/use-claimList-infinite-scroll.js
+++ b/ui/effects/use-claimList-infinite-scroll.js
@@ -49,6 +49,7 @@ export default function useClaimListInfiniteScroll(
       setIsLoadingPage(false);
       setPage(0);
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // -- Optional: remove the locking behavior for whatever reason:
@@ -56,7 +57,7 @@ export default function useClaimListInfiniteScroll(
     if (disableListLock) {
       setUris(allUris);
     }
-  }, [allUris]);
+  }, [disableListLock, allUris]);
 
   return { uris, page, isLoadingPage, bumpPage };
 }

--- a/ui/effects/use-component-did-mount.js
+++ b/ui/effects/use-component-did-mount.js
@@ -1,0 +1,13 @@
+// @flow
+import React from 'react';
+
+export type EffectCallback = () => void | (() => void);
+
+export default function useComponentDidMount(effectOnMount: EffectCallback) {
+  assert(typeof effectOnMount === 'function');
+
+  React.useEffect(() => {
+    return effectOnMount();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
+  }, []);
+}

--- a/ui/effects/use-get-last-visible-slot.js
+++ b/ui/effects/use-get-last-visible-slot.js
@@ -39,6 +39,7 @@ export default function useGetLastVisibleSlot(listRef: any, skipEval: boolean, c
 
       return () => clearTimeout(timer);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   return lastVisibleIndex;

--- a/ui/effects/use-get-thumbnail.js
+++ b/ui/effects/use-get-thumbnail.js
@@ -36,6 +36,7 @@ export default function useGetThumbnail(
     if (shouldFetchFileInfo) {
       getFile(repostSrcUri || uri);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [shouldFetchFileInfo, repostSrcUri, uri]);
 
   React.useEffect(() => {

--- a/ui/effects/use-lazy-loading.js
+++ b/ui/effects/use-lazy-loading.js
@@ -84,6 +84,7 @@ export default function useLazyLoading(
 
     // $FlowFixMe
     lazyLoadingObserver.observe(elementRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- PLEASE FIX
   }, deps);
 
   return srcLoaded;

--- a/ui/effects/use-screensize.js
+++ b/ui/effects/use-screensize.js
@@ -43,6 +43,7 @@ function useHasWindowWidthChangedEnough(comparisonFn: (windowSize: number) => bo
 
       return () => window.removeEventListener('resize', setSize);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [isWindowClient]);
 
   return windowSize;

--- a/ui/effects/use-stream.js
+++ b/ui/effects/use-stream.js
@@ -18,7 +18,7 @@ export default function useStream(url) {
         if (isMounted && response.statusCode >= 200 && response.statusCode < 300) {
           let chunks = [];
           // Handle stream chunk recived
-          response.on('data', function(chunk) {
+          response.on('data', function (chunk) {
             if (isMounted.current) {
               chunks.push(chunk);
             } else {

--- a/ui/hocs/withStreamClaimRender/view.jsx
+++ b/ui/hocs/withStreamClaimRender/view.jsx
@@ -174,6 +174,7 @@ const withStreamClaimRender = (StreamClaimComponent: FunctionalComponentParam) =
 
     const streamClaim = React.useCallback(() => {
       updateClaim('callback');
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
     }, [
       claimLinkId,
       collectionId,
@@ -229,6 +230,7 @@ const withStreamClaimRender = (StreamClaimComponent: FunctionalComponentParam) =
           updateClaim('!uriIsActive & !playingUriIsActive & sourceLoaded');
         }
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- SIGH
     }, [pathname, sourceLoaded]);
 
     function updateClaim(trigger: string) {

--- a/ui/logWarningConsoleMessage.js
+++ b/ui/logWarningConsoleMessage.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 export default function doLogWarningConsoleMessage() {
   const style = {
     redTitle:

--- a/ui/modal/modalAffirmPurchase/view.jsx
+++ b/ui/modal/modalAffirmPurchase/view.jsx
@@ -68,6 +68,7 @@ function ModalAffirmPurchase(props: Props) {
         clearTimeout(timeout);
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [success, uri]);
 
   React.useEffect(() => {

--- a/ui/modal/modalAnnouncements/view.jsx
+++ b/ui/modal/modalAnnouncements/view.jsx
@@ -51,6 +51,7 @@ export default function ModalAnnouncements(props: Props) {
       setShow(true);
       doSetLastViewedAnnouncement(hash);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   if (!show) {

--- a/ui/modal/modalError/view.jsx
+++ b/ui/modal/modalError/view.jsx
@@ -36,7 +36,7 @@ class ModalError extends React.PureComponent<Props> {
       if (process.env.NODE_ENV === 'production') {
         Lbryio.call('event', 'desktop_error', { error_message: errorMessage });
       } else {
-        console.log(`%c'event/desktop_error' (skipped):\n${errorMessage}`, 'color:yellow');
+        console.log(`%c'event/desktop_error' (skipped):\n${errorMessage}`, 'color:yellow'); // eslint-disable-line no-console
       }
     }
   }

--- a/ui/modal/modalPreorderAndPurchaseContent/internal/preorderAndPurchaseContentCard/view.jsx
+++ b/ui/modal/modalPreorderAndPurchaseContent/internal/preorderAndPurchaseContentCard/view.jsx
@@ -155,8 +155,6 @@ export default function PreorderAndPurchaseContentCard(props: Props) {
     return <Global styles={{ '.ReactModalPortal': { display: 'none' } }} />;
   }
 
-  console.log('pendingSdkPayment: ', pendingSdkPayment);
-
   return (
     <Form onSubmit={handleSubmit}>
       <Card

--- a/ui/page/channelsFollowing/view.jsx
+++ b/ui/page/channelsFollowing/view.jsx
@@ -38,6 +38,7 @@ function ChannelsFollowingPage(props: Props) {
 
   React.useEffect(() => {
     doFetchAllActiveLivestreamsForQuery();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   return !hasSubscribedChannels ? (

--- a/ui/page/channelsFollowing/view.jsx
+++ b/ui/page/channelsFollowing/view.jsx
@@ -12,6 +12,7 @@ import Button from 'component/button';
 import Icon from 'component/common/icon';
 import { tagSearchCsOptionsHook } from 'util/search';
 import ScheduledStreams from 'component/scheduledStreams';
+import useComponentDidMount from 'effects/use-component-did-mount';
 import usePersistedState from 'effects/use-persisted-state';
 
 type Props = {
@@ -36,10 +37,9 @@ function ChannelsFollowingPage(props: Props) {
   const hasSubscribedChannels = channelIds.length > 0;
   const [hideMembersOnly] = usePersistedState('channelPage-hideMembersOnly', false);
 
-  React.useEffect(() => {
+  useComponentDidMount(() => {
     doFetchAllActiveLivestreamsForQuery();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
-  }, []);
+  });
 
   return !hasSubscribedChannels ? (
     <ChannelsFollowingDiscoverPage />

--- a/ui/page/channelsFollowingManage/view.jsx
+++ b/ui/page/channelsFollowingManage/view.jsx
@@ -10,6 +10,7 @@ import Page from 'component/page';
 import Spinner from 'component/spinner';
 import * as ICONS from 'constants/icons';
 import { SIDEBAR_SUBS_DISPLAYED } from 'constants/subscriptions';
+import useComponentDidMount from 'effects/use-component-did-mount';
 import useClaimListInfiniteScroll from 'effects/use-claimList-infinite-scroll';
 import './style.scss';
 
@@ -60,10 +61,9 @@ export default function ChannelsFollowingManage(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Only need to respond to 'filterQuery'
   }, [filterQuery]);
 
-  React.useEffect(() => {
+  useComponentDidMount(() => {
     doFetchLastActiveSubs(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
-  }, []);
+  });
 
   return (
     <Page noFooter>

--- a/ui/page/channelsFollowingManage/view.jsx
+++ b/ui/page/channelsFollowingManage/view.jsx
@@ -62,6 +62,7 @@ export default function ChannelsFollowingManage(props: Props) {
 
   React.useEffect(() => {
     doFetchLastActiveSubs(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   return (

--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/featuredSection/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/featuredSection/view.jsx
@@ -34,7 +34,7 @@ function FeaturedSection(props: Props) {
       doResolveClaimId(claimId);
       doFetchViewCount(claimId);
     }
-  }, [uri]);
+  }, [uri, claimId, doResolveClaimId, doFetchViewCount]);
 
   if (geoRestriction) {
     return null;

--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/homeTabSection/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/internal/homeTabSection/view.jsx
@@ -83,18 +83,21 @@ function HomeTabSection(props: Props) {
       const searchOptions = JSON.parse(optionsStringified);
       doClaimSearch(searchOptions);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- DOESN'T FEEL RIGHT WITHOUT optionsStringified
   }, [doClaimSearch, shouldPerformSearch]);
 
   React.useEffect(() => {
     if (section.claim_id) {
       doResolveClaimId(section.claim_id);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [section]);
 
   React.useEffect(() => {
     if (shouldResolveCollectionClaims) {
       doResolveUris(collectionUrls);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [shouldResolveCollectionClaims]);
 
   const [searchQuery, setSearchQuery] = React.useState('');
@@ -134,6 +137,7 @@ function HomeTabSection(props: Props) {
     }, DEBOUNCE_WAIT_DURATION_MS);
 
     return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION (definitely needs channelClaimId, no?)
   }, [searchQuery]);
 
   function getTitle() {

--- a/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/tabs/homeTab/view.jsx
@@ -55,6 +55,7 @@ function HomeTab(props: Props) {
         setHome(homeTemplate);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [homepage_settings]);
 
   function handleEditCollection(e, index) {

--- a/ui/page/claim/internal/claimPageComponent/internal/channel/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channel/view.jsx
@@ -148,7 +148,7 @@ function ChannelPage(props: Props) {
     }
 
     return discussionWasMounted && currentView === CHANNEL_PAGE.VIEWS.DISCUSSION;
-  }, [discussionWasMounted, uri]);
+  }, [discussionWasMounted, currentView]);
 
   const hasUnpublishedCollections = unpublishedCollections && Object.keys(unpublishedCollections).length;
   const [filters, setFilters] = React.useState(undefined);

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -218,6 +218,7 @@ function HomePage(props: Props) {
 
   React.useEffect(() => {
     doFetchAllActiveLivestreamsForQuery();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   return (

--- a/ui/page/listBlocked/view.jsx
+++ b/ui/page/listBlocked/view.jsx
@@ -70,11 +70,13 @@ function ListBlocked(props: Props) {
     myChannelClaimIds &&
     myChannelClaimIds.some((id) => delegatorsById[id] && Object.keys(delegatorsById[id].delegators).length > 0);
 
+  const list = getList(viewMode);
+
   // **************************************************************************
 
   React.useEffect(() => {
-    doResolveUris(getList(viewMode) || []);
-  }, [getList(viewMode)]);
+    doResolveUris(list || []);
+  }, [list, doResolveUris]);
 
   function getList(view) {
     switch (view) {
@@ -277,7 +279,7 @@ function ListBlocked(props: Props) {
 
           <BlockList
             key={viewMode}
-            uris={getList(viewMode)}
+            uris={list}
             help={getHelpText(viewMode)}
             titleEmptyList={getEmptyListTitle(viewMode)}
             subtitle={getEmptyListSubtitle(viewMode)}

--- a/ui/page/send/view.jsx
+++ b/ui/page/send/view.jsx
@@ -106,7 +106,7 @@ export default function SendPage(props: Props) {
         setContentUri(``);
       }
     }
-  }, [enteredContent, setContentUri, setContentError, parseURI, isNameValid]);
+  }, [enteredContent, setContentUri, setContentError]);
 
   return (
     <Page

--- a/ui/page/settingsNotifications/view.jsx
+++ b/ui/page/settingsNotifications/view.jsx
@@ -56,6 +56,7 @@ export default function NotificationSettingsPage(props: Props) {
           setError(true);
         });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   function handleChangeTag(name, newIsEnabled) {

--- a/ui/page/signInVerify/view.jsx
+++ b/ui/page/signInVerify/view.jsx
@@ -44,6 +44,7 @@ function SignInVerifyPage(props: Props) {
     if (!authToken || !userSubmittedEmail || !verificationToken) {
       onAuthError(__('Invalid or expired sign-in link.'));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [authToken, userSubmittedEmail, verificationToken, doToast, push]);
 
   React.useEffect(() => {

--- a/ui/page/youtubeSync/view.jsx
+++ b/ui/page/youtubeSync/view.jsx
@@ -52,6 +52,7 @@ export default function YoutubeSync(props: Props) {
     }
 
     replace(`?${urlParamsInEffect.toString()}`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [pathname, search]);
 
   React.useEffect(() => {

--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -286,7 +286,7 @@ export function doMinVersionCheck() {
         }
       })
       .catch((err) => {
-        console.error(err);
+        assert(false, 'minVersion failed', err);
       });
   };
 }

--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -388,7 +388,7 @@ export function doAbandonTxo(txo: Txo, cb: (string) => void) {
     }
 
     if (!method) {
-      console.error('No "method" chosen for claim or support abandon');
+      assert(false, 'No "method" chosen for claim or support abandon');
       return;
     }
 
@@ -411,7 +411,7 @@ export function doAbandonClaim(claim: Claim, cb: (string) => any) {
     const supportToAbandon = mySupports[outpoint];
 
     if (!claimToAbandon && !supportToAbandon) {
-      console.error('No associated support or claim with txid: ', txid);
+      assert(false, 'No associated support or claim with txid: ' + txid);
       return;
     }
 
@@ -477,7 +477,7 @@ export function doAbandonClaim(claim: Claim, cb: (string) => any) {
     }
 
     if (!method) {
-      console.error('No "method" chosen for claim or support abandon');
+      assert(false, 'No "method" chosen for claim or support abandon');
       return;
     }
 

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -356,7 +356,7 @@ export function doFetchMyCommentedChannels(claimId: ?string) {
           });
         })
         .catch((err) => {
-          console.log({ err });
+          assert(false, 'doFetchMyCommentedChannels failed', err);
         });
     });
   };

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -187,7 +187,7 @@ const PUBLISH = {
         }
 
       default:
-        console.assert(false, `unhandled: "${visibility}"`);
+        assert(false, `unhandled: "${visibility}"`);
         break;
     }
   },

--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -34,7 +34,7 @@ const recsysFyp = {
       .then((response) => response.json())
       .then((result) => result)
       .catch((error) => {
-        console.log('FYP: fetch', { error, userId });
+        console.log('FYP: fetch', { error, userId }); // eslint-disable-line no-console
         return {};
       });
   },
@@ -44,7 +44,7 @@ const recsysFyp = {
       method: 'POST',
       headers: { [X_LBRY_AUTH_TOKEN]: getAuthToken() },
     }).catch((error) => {
-      console.log('FYP: mark', { error, userId, gid });
+      console.log('FYP: mark', { error, userId, gid }); // eslint-disable-line no-console
       return {};
     });
   },
@@ -61,7 +61,7 @@ const recsysFyp = {
     })
       .then((result) => result)
       .catch((error) => {
-        console.log('FYP: ignore', { error, userId, gid, claimId });
+        console.log('FYP: ignore', { error, userId, gid, claimId }); // eslint-disable-line no-console
         return {};
       });
   },
@@ -342,7 +342,7 @@ export const doRemovePersonalRecommendation = (uri: string) => (dispatch: Dispat
             );
           })
           .catch((err) => {
-            console.log('doRemovePersonalRecommendation:', err);
+            assert(false, 'recsys "ignore" failed', err);
           });
       },
     })

--- a/ui/util/debounce.js
+++ b/ui/util/debounce.js
@@ -5,7 +5,7 @@
 export default function debouce(func, wait, immediate) {
   let timeout;
 
-  return function() {
+  return function () {
     const context = this;
     const args = arguments;
     const later = () => {

--- a/ui/util/lazyImport.js
+++ b/ui/util/lazyImport.js
@@ -12,6 +12,7 @@ function componentLoader(lazyComponent, attemptsLeft) {
         setTimeout(() => {
           if (attemptsLeft === 1) {
             window.store.dispatch({ type: ACTIONS.RELOAD_REQUIRED });
+            // eslint-disable-next-line no-console
             console.error(error.message); // Spew the error so users can report to us if reloading doesn't help.
           } else {
             componentLoader(lazyComponent, attemptsLeft - 1).then(resolve, reject);

--- a/ui/util/lbryURI.js
+++ b/ui/util/lbryURI.js
@@ -189,7 +189,7 @@ const errorHistory = [];
 function logErrorOnce(err: string) {
   if (!errorHistory.includes(err)) {
     errorHistory.push(err);
-    console.error(err);
+    console.error(err); // eslint-disable-line no-console
   }
 }
 
@@ -228,7 +228,7 @@ export function buildURI(UrlObj: LbryUrlObj, includeProto: boolean = true, proto
   // @endif
 
   if (!claimName && !channelName && !streamName) {
-    console.error("'claimName', 'channelName', and 'streamName' are all empty. One must be present to build a url.");
+    assert(false, "'claimName', 'channelName', and 'streamName' are all empty. One must be present to build a url.");
   }
 
   const formattedChannelName = channelName && (channelName.startsWith('@') ? channelName : `@${channelName}`);

--- a/web/component/ad/adSticky/view.jsx
+++ b/web/component/ad/adSticky/view.jsx
@@ -60,10 +60,13 @@ export default function AdSticky(props: Props) {
       setLoads(0);
     }
     // $FlowIgnore
-  }, [location.href]);
+  }, [location.href]); // eslint-disable-line react-hooks/exhaustive-deps -- no idea
 
   React.useEffect(() => {
-    if (stickyContainer && stickyContainer.current) observer.observe(stickyContainer.current, { attributes: true });
+    if (stickyContainer && stickyContainer.current) {
+      observer.observe(stickyContainer.current, { attributes: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   React.useEffect(() => {

--- a/web/component/ad/tileA/view.jsx
+++ b/web/component/ad/tileA/view.jsx
@@ -42,13 +42,14 @@ function AdTileA(props: Props) {
         if (script) document.body.removeChild(script);
       };
     }
-  }, [shouldShowAds, AD_CONFIG]);
+  }, [shouldShowAds]);
 
   React.useEffect(() => {
     if (ref.current) {
       const mountedStyle = getComputedStyle(ref.current);
       doSetAdBlockerFound(mountedStyle?.display === 'none');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
   }, []);
 
   if (shouldShowAds) {

--- a/web/component/ad/tileB/view.jsx
+++ b/web/component/ad/tileB/view.jsx
@@ -39,7 +39,7 @@ function AdTileB(props: Props) {
         if (script) document.body.removeChild(script);
       };
     }
-  }, [shouldShowAds, AD_CONFIG]);
+  }, [shouldShowAds]);
 
   return (
     <div

--- a/web/component/openInAppLink/view.jsx
+++ b/web/component/openInAppLink/view.jsx
@@ -64,7 +64,7 @@ function OpenInAppLink(props: Props) {
       const newUrl = `${pathname}?${newParams}`;
       replace(newUrl);
     }
-  }, [hasSrcParam, search, pathname, replace]);
+  }, [hasSrcParam, search, pathname, replace, params]);
 
   React.useEffect(() => {
     const isOnDeviceToPrompt = (isAndroidUser && isAndroidDevice) || (isDesktopUser && isDesktopDevice);

--- a/web/effects/use-degraded-performance.js
+++ b/web/effects/use-degraded-performance.js
@@ -51,5 +51,6 @@ export function useDegradedPerformance(onDegradedPerformanceCallback, user) {
           onDegradedPerformanceCallback(STATUS_FAILING);
         });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [hasUser]);
 }

--- a/web/index.js
+++ b/web/index.js
@@ -17,7 +17,7 @@ app.use(async (ctx, next) => {
   try {
     await next();
   } catch (err) {
-    console.log('error: ', err);
+    console.log('error: ', err); // eslint-disable-line no-console
     ctx.status = err.status || 500;
     ctx.body = err.message;
   }

--- a/web/src/lbryURI.js
+++ b/web/src/lbryURI.js
@@ -8,7 +8,8 @@ const channelNameMinLength = 1;
 const claimIdMaxLength = 40;
 
 // see https://spec.lbry.com/#urls
-const regexInvalidURI = /[ =&#:$@%?;/\\"<>%{}|^~[\]`\u{0000}-\u{0008}\u{000b}-\u{000c}\u{000e}-\u{001F}\u{D800}-\u{DFFF}\u{FFFE}-\u{FFFF}]/u;
+const regexInvalidURI =
+  /[ =&#:$@%?;/\\"<>%{}|^~[\]`\u{0000}-\u{0008}\u{000b}-\u{000c}\u{000e}-\u{001F}\u{D800}-\u{DFFF}\u{FFFE}-\u{FFFF}]/u;
 // const regexAddress = /^(b|r)(?=[^0OIl]{32,33})[0-9A-Za-z]{32,33}$/;
 const regexPartProtocol = '^((?:lbry://)?)';
 const regexPartStreamOrChannelName = '([^:$#/]*)';
@@ -211,17 +212,18 @@ function buildURI(UrlObj, includeProto = true, protoDefault = 'lbry://') {
 
   if (!isProduction) {
     if (claimId) {
-      console.error(__("'claimId' should no longer be used. Use 'streamClaimId' or 'channelClaimId' instead"));
+      console.error(__("'claimId' should no longer be used. Use 'streamClaimId' or 'channelClaimId' instead")); // eslint-disable-line no-console
     }
     if (claimName) {
-      console.error(__("'claimName' should no longer be used. Use 'streamClaimName' or 'channelClaimName' instead"));
+      console.error(__("'claimName' should no longer be used. Use 'streamClaimName' or 'channelClaimName' instead")); // eslint-disable-line no-console
     }
     if (contentName) {
-      console.error(__("'contentName' should no longer be used. Use 'streamName' instead"));
+      console.error(__("'contentName' should no longer be used. Use 'streamName' instead")); // eslint-disable-line no-console
     }
   }
 
   if (!claimName && !channelName && !streamName) {
+    // eslint-disable-next-line no-console
     console.error(
       __("'claimName', 'channelName', and 'streamName' are all empty. One must be present to build a url.")
     );

--- a/web/stubs/fs.js
+++ b/web/stubs/fs.js
@@ -15,3 +15,10 @@ export default {
   },
   constants: {},
 };
+
+// [TODO_NEED_VERIFICATION]
+// The TODO_NEED_VERIFICATION marker indicates that the existing dependency
+// array was retained just to get lint passing.
+//  - If it was intentionally done that way, replace this tag with the reason.
+//  - If array is indeed missing some items, fix and remove the suppressor.
+//  - When making changes to the effect, ensure array is updated as needed.

--- a/web/stubs/fs.js
+++ b/web/stubs/fs.js
@@ -1,6 +1,6 @@
 function logWarning(method) {
   if (process.env.NODE_ENV !== 'production') {
-    console.error(`Called fs.${method} on lbry.tv. This should be removed.`);
+    console.error(`Called fs.${method} on lbry.tv. This should be removed.`); // eslint-disable-line no-console
   }
 }
 


### PR DESCRIPTION
## Ticket
Closes [#2635 Don't suppress effect-dependency warnings anymore ](https://github.com/OdyseeTeam/odysee-frontend/issues/2635)

## Notes
See commit messages.

@jessopb, if undesired, can leave as is.  But I think manually searching for dependency issues is becoming a pain, so the need to annotation "on mount only" is a small trade off?

Ideally, should fix all now, but I mostly just suppressed so that we don't need to test much.  This at least captures new errors moving forward.