### PR TITLE
ClaimTileDiscover: guard against pinned IDs that lead to deleted claims

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -218,6 +218,7 @@ function ClaimListDiscover(props: Props) {
         }
 
         const uri = claim.canonical_url || claim.canonical_url;
+        // looks wrong ---^----------------------^
         // $FlowFixMe
         resolvedPinUris.push(uri);
       });
@@ -693,6 +694,15 @@ function ClaimListDiscover(props: Props) {
   }
 
   function injectPinUrls(uris, order, pins, resolvedPinUris) {
+    // TODO/BEWARE if you are editing this function.
+    //
+    // This function probably does not handle all clients correctly. It's mixing
+    // mutable and immutable changes, AND there are both clients that take the
+    // return value and ones that don't.
+    //
+    // It needs to sync up with ClaimTilesDiscover, or wait until the
+    // consolidation task.
+
     if (!pins || !uris || (pins.onlyPinForOrder && pins.onlyPinForOrder !== order)) {
       return uris;
     }

--- a/ui/component/claimTilesDiscover/view.jsx
+++ b/ui/component/claimTilesDiscover/view.jsx
@@ -6,6 +6,7 @@ import ClaimPreviewTile from 'component/claimPreviewTile';
 import I18nMessage from 'component/i18nMessage';
 import useFetchViewCount from 'effects/use-fetch-view-count';
 import useGetLastVisibleSlot from 'effects/use-get-last-visible-slot';
+import useResolvePins from 'effects/use-resolve-pins';
 
 const SHOW_TIMEOUT_MSG = false;
 
@@ -54,7 +55,6 @@ type Props = {
   hideMembersOnly?: boolean, // undefined = use SETTING.HIDE_MEMBERS_ONLY_CONTENT; true/false: use this override.
   loading: boolean,
   duration?: string,
-  channelIdsParam?: Array<string>,
   // --- select ---
   location: { search: string },
   claimSearchResults: Array<string>,
@@ -83,7 +83,6 @@ function ClaimTilesDiscover(props: Props) {
     fetchViewCount,
     fetchingClaimSearch,
     hasNoSource,
-    channelIdsParam,
     // forceShowReposts = false,
     renderProperties,
     pins,
@@ -107,38 +106,12 @@ function ClaimTilesDiscover(props: Props) {
   const prevUris = React.useRef();
   const claimSearchUris = claimSearchResults || [];
   const isUnfetchedClaimSearch = claimSearchResults === undefined;
-  const hasPins = pins && (pins.claimIds || pins.urls);
-
-  const resolvedPinUris = React.useMemo(() => {
-    if (!hasPins) return undefined;
-
-    let resolvedPinUris = [];
-
-    if (pins && pins.claimIds) {
-      pins.claimIds.some((id) => {
-        const claim = claimsById[id];
-        if (!claim) {
-          resolvedPinUris = undefined;
-          return true;
-        }
-
-        const uri = claim.canonical_url || claim.canonical_url;
-        // $FlowFixMe
-        resolvedPinUris.push(uri);
-      });
-    }
-
-    return resolvedPinUris;
-  }, [claimsById, hasPins, pins]);
-
+  const resolvedPinUris = useResolvePins({ pins, claimsById, doResolveClaimIds, doResolveUris });
   const uriBuffer = useRef([]);
 
   const timedOut = claimSearchResults === null;
-  // -- pins alone will be resolved by the doResolveUris/doResolveClaimIds call
   const shouldPerformSearch =
-    hasPins && !channelIdsParam
-      ? false
-      : !fetchingClaimSearch && !timedOut && claimSearchUris.length === 0 && !claimSearchLastPageReached;
+    !fetchingClaimSearch && !timedOut && claimSearchUris.length === 0 && !claimSearchLastPageReached;
 
   const uris = (prefixUris || []).concat(claimSearchUris);
   if (prefixUris && prefixUris.length) uris.splice(prefixUris.length * -1, prefixUris.length);
@@ -154,12 +127,7 @@ function ClaimTilesDiscover(props: Props) {
   }
 
   // Show previous results while we fetch to avoid blinkies and poor CLS.
-  const finalUris =
-    resolvedPinUris && !channelIdsParam
-      ? resolvedPinUris
-      : isUnfetchedClaimSearch && prevUris.current
-      ? prevUris.current
-      : uris;
+  const finalUris = isUnfetchedClaimSearch && prevUris.current ? prevUris.current : uris;
   prevUris.current = finalUris;
 
   // --------------------------------------------------------------------------
@@ -208,18 +176,6 @@ function ClaimTilesDiscover(props: Props) {
 
   // --------------------------------------------------------------------------
   // --------------------------------------------------------------------------
-
-  React.useEffect(() => {
-    if (!hasPins) return;
-
-    // $FlowFixMe
-    if (pins.claimIds) {
-      doResolveClaimIds(pins.claimIds);
-      // $FlowFixMe
-    } else if (pins.urls) {
-      doResolveUris(pins.urls, true);
-    }
-  }, [pins, doResolveUris, doResolveClaimIds, hasPins]);
 
   useFetchViewCount(fetchViewCount, uris, claimsByUri, doFetchViewCount);
 

--- a/ui/component/claimTilesDiscover/view.jsx
+++ b/ui/component/claimTilesDiscover/view.jsx
@@ -165,32 +165,29 @@ function ClaimTilesDiscover(props: Props) {
   // --------------------------------------------------------------------------
   // --------------------------------------------------------------------------
 
+  /**
+   * Injects pinned URLs into `uris` in-place.
+   * i.e. don't use immutable functions like concat().
+   */
   function injectPinUrls(uris, pins, resolvedPinUris) {
     if (!pins || !uris) {
-      return uris;
+      return;
     }
 
     if (resolvedPinUris) {
-      if (uris.length < resolvedPinUris.length) {
-        return uris.concat(resolvedPinUris);
-      }
-
       resolvedPinUris.forEach((pin) => {
         if (uris.includes(pin)) {
-          // remove the pin from the resolved/searched uris
+          // remove the duplicate pin; we'll put it back at 2nd slot later.
           uris.splice(uris.indexOf(pin), 1);
         } else {
+          // remove to make space for the pin (maintain total count).
           uris.pop();
         }
       });
 
       // add the pins on uris starting from the 2nd index
       uris.splice(2, 0, ...resolvedPinUris);
-
-      return uris;
     }
-
-    return uris;
   }
 
   const getInjectedItem = (index) => {

--- a/ui/effects/use-resolve-pins.js
+++ b/ui/effects/use-resolve-pins.js
@@ -13,34 +13,42 @@ export default function useResolvePins(props: Props) {
   const { pins, claimsById, doResolveClaimIds, doResolveUris } = props;
 
   const [resolvedPinUris, setResolvedPinUris] = React.useState(pins ? undefined : null);
-  const [resolvingPinUris, setResolvingPinUris] = React.useState(false);
-  const hasResolvedPinUris = useFetched(resolvingPinUris);
+  const [isResolving, setIsResolving] = React.useState(false);
+  const hasResolvedPinUris = useFetched(isResolving);
 
   React.useEffect(() => {
-    if (resolvedPinUris === undefined && pins && !resolvingPinUris) {
+    if (resolvedPinUris === undefined && pins && !isResolving) {
       if (pins.claimIds) {
-        // setResolvingPinUris is only needed for claim_search.
-        // doResolveUris uses selectResolvingUris internally to prevent double call.
-        setResolvingPinUris(true);
-
-        // We can't use .then() here to grab the `claim_search` uris directly,
-        // because we skip those that are already resolved. Instead, we mark a
-        // flag here, then populate the array in the other effect below in the
-        // next render cycle (redux would be updated by then). Pretty dumb.
-        // $FlowFixMe: already checked for null `pins`, but flow can't see it when there's code above it? Wow.
-        doResolveClaimIds(pins.claimIds).finally(() => setResolvingPinUris(false));
+        setIsResolving(true);
+        // $FlowIgnore (null checked)
+        doResolveClaimIds(pins.claimIds).finally(() => setIsResolving(false));
       } else if (pins.urls) {
-        doResolveUris(pins.urls, true).finally(() => setResolvedPinUris(pins.urls));
+        setIsResolving(true);
+        // $FlowIgnore (null checked)
+        doResolveUris(pins.urls, true).finally(() => {
+          setIsResolving(false);
+          setResolvedPinUris(pins.urls);
+        });
       } else {
         setResolvedPinUris(null);
       }
     }
-  }, [resolvedPinUris, pins, doResolveUris, doResolveClaimIds, resolvingPinUris]);
+  }, [resolvedPinUris, pins, doResolveUris, doResolveClaimIds, isResolving]);
 
   React.useEffect(() => {
     if (hasResolvedPinUris) {
       if (pins && pins.claimIds) {
-        setResolvedPinUris(pins.claimIds.map<string>((id) => claimsById[id]?.canonical_url));
+        const uris = [];
+
+        pins.claimIds.forEach((id) => {
+          const uri = claimsById[id]?.canonical_url;
+          if (uri) {
+            // The pinned IDs could lead to deleted claims. Discard nulls.
+            uris.push(uri);
+          }
+        });
+
+        setResolvedPinUris(uris.length > 0 ? uris : null);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Only do this over a false->true->false transition for hasResolvedPinUris.

--- a/ui/effects/use-resolve-pins.js
+++ b/ui/effects/use-resolve-pins.js
@@ -1,0 +1,50 @@
+// @flow
+import React from 'react';
+import useFetched from 'effects/use-fetched';
+
+type Props = {
+  pins?: { urls?: Array<string>, claimIds?: Array<string>, onlyPinForOrder?: string },
+  claimsById: { [string]: Claim },
+  doResolveClaimIds: (Array<string>) => Promise<any>,
+  doResolveUris: (Array<string>, boolean) => Promise<any>,
+};
+
+export default function useResolvePins(props: Props) {
+  const { pins, claimsById, doResolveClaimIds, doResolveUris } = props;
+
+  const [resolvedPinUris, setResolvedPinUris] = React.useState(pins ? undefined : null);
+  const [resolvingPinUris, setResolvingPinUris] = React.useState(false);
+  const hasResolvedPinUris = useFetched(resolvingPinUris);
+
+  React.useEffect(() => {
+    if (resolvedPinUris === undefined && pins && !resolvingPinUris) {
+      if (pins.claimIds) {
+        // setResolvingPinUris is only needed for claim_search.
+        // doResolveUris uses selectResolvingUris internally to prevent double call.
+        setResolvingPinUris(true);
+
+        // We can't use .then() here to grab the `claim_search` uris directly,
+        // because we skip those that are already resolved. Instead, we mark a
+        // flag here, then populate the array in the other effect below in the
+        // next render cycle (redux would be updated by then). Pretty dumb.
+        // $FlowFixMe: already checked for null `pins`, but flow can't see it when there's code above it? Wow.
+        doResolveClaimIds(pins.claimIds).finally(() => setResolvingPinUris(false));
+      } else if (pins.urls) {
+        doResolveUris(pins.urls, true).finally(() => setResolvedPinUris(pins.urls));
+      } else {
+        setResolvedPinUris(null);
+      }
+    }
+  }, [resolvedPinUris, pins, doResolveUris, doResolveClaimIds, resolvingPinUris]);
+
+  React.useEffect(() => {
+    if (hasResolvedPinUris) {
+      if (pins && pins.claimIds) {
+        setResolvedPinUris(pins.claimIds.map<string>((id) => claimsById[id]?.canonical_url));
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only do this over a false->true->false transition for hasResolvedPinUris.
+  }, [hasResolvedPinUris]);
+
+  return resolvedPinUris;
+}

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -154,7 +154,6 @@ function HomePage(props: Props) {
     const claimTiles = (
       <ClaimTilesDiscover
         {...options}
-        channelIdsParam={(options.channelIds && options.channelIds.length > 0 && options.channelIds) || undefined}
         showNoSourceClaims={ENABLE_NO_SOURCE_CLAIMS}
         hideMembersOnly={id !== 'FOLLOWING'}
         hasSource

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -158,7 +158,7 @@ function HomePage(props: Props) {
         hideMembersOnly={id !== 'FOLLOWING'}
         hasSource
         prefixUris={options.channelIds && getActiveLivestreamUrisForIds(options.channelIds)}
-        // pins={{ urls: pinUrls, claimIds: pinnedClaimIds }}
+        pins={{ urls: pinUrls, claimIds: pinnedClaimIds }}
         injectedItem={index === topGrid && !hasPremiumPlus && { node: <Ad type="tileA" tileLayout /> }}
         forceShowReposts={id !== 'FOLLOWING'}
         loading={id === 'FOLLOWING' ? fetchingActiveLivestreams : false}


### PR DESCRIPTION
Aside:  aren't pins supposed to appear in Category Pages (ClaimListDiscover) too on some filters?  Not seeing them despite seeing pins being processed.  Anyway, it's a different issue.