### PR TITLE
Fix `duration` being applied to non-AV `claim_search`

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -64,7 +64,7 @@ type Props = {
   streamType?: string | Array<string>,
   defaultStreamType?: string | Array<string>,
 
-  contentType?: string | Array<string>,
+  contentType?: string,
 
   empty?: string,
   feeAmount?: string,
@@ -288,7 +288,7 @@ function ClaimListDiscover(props: Props) {
     }
   }
 
-  const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION_ALL], 'durUser', null);
+  const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION.ALL], 'durUser', null);
   const [minDurationMinutes] = usePersistedState(`minDurUserMinutes-${location.pathname}`, null);
   const [maxDurationMinutes] = usePersistedState(`maxDurUserMinutes-${location.pathname}`, null);
   const [hideAnonymous] = usePersistedState(`hideAnonymous-${location.pathname}`, false);
@@ -304,6 +304,7 @@ function ClaimListDiscover(props: Props) {
     'orderUser',
     CS.ORDER_BY_TRENDING
   );
+  const durationOption = CsOptions.duration(durationParam, duration, minDurationMinutes, maxDurationMinutes);
 
   let options: ClaimSearchOptions = {
     page_size: dynamicPageSize,
@@ -317,6 +318,7 @@ function ClaimListDiscover(props: Props) {
     not_tags: CsOptions.not_tags(notTagInput),
     order_by: resolveOrderByOption(orderParam, sortByParam),
     remove_duplicates: isChannel ? undefined : true,
+    ...(durationOption ? { duration: durationOption } : {}),
   };
 
   if (ENABLE_NO_SOURCE_CLAIMS && hasNoSource) {
@@ -387,32 +389,6 @@ function ClaimListDiscover(props: Props) {
         // Hack for at least the New page until https://github.com/lbryio/lbry-sdk/issues/2591 is fixed
         options.release_time = `<${Math.floor(moment().startOf('minute').unix())}`;
       }
-    }
-  }
-
-  if (durationParam) {
-    switch (durationParam) {
-      case CS.DURATION_ALL:
-        options.duration = duration || undefined;
-        break;
-      case CS.DURATION_SHORT:
-        options.duration = '<=240';
-        break;
-      case CS.DURATION_LONG:
-        options.duration = '>=1200';
-        break;
-      case CS.DURATION_CUSTOM:
-        options.duration = [];
-        if (minDurationMinutes) {
-          options.duration.push(`>=${minDurationMinutes * 60}`);
-        }
-        if (maxDurationMinutes) {
-          options.duration.push(`<=${maxDurationMinutes * 60}`);
-        }
-        break;
-      default:
-        assert(false, 'Unhandled duration:', durationParam);
-        break;
     }
   }
 

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -304,7 +304,13 @@ function ClaimListDiscover(props: Props) {
     'orderUser',
     CS.ORDER_BY_TRENDING
   );
-  const durationOption = CsOptions.duration(durationParam, duration, minDurationMinutes, maxDurationMinutes);
+  const durationOption = CsOptions.duration(
+    contentTypeParam,
+    durationParam,
+    duration,
+    minDurationMinutes,
+    maxDurationMinutes
+  );
 
   let options: ClaimSearchOptions = {
     page_size: dynamicPageSize,

--- a/ui/component/claimListHeader/view.jsx
+++ b/ui/component/claimListHeader/view.jsx
@@ -97,7 +97,7 @@ function ClaimListHeader(props: Props) {
   const showHideAnonymous = isDiscoverPage || isRabbitHolePage;
   const [hideAnonymous, setHideAnonymous] = usePersistedState(`hideAnonymous-${location.pathname}`, false);
 
-  const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION_ALL], 'durUser', null);
+  const durationParam = usePersistentUserParam([urlParams.get(CS.DURATION_KEY) || CS.DURATION.ALL], 'durUser', null);
   const [minDurationMinutes, setMinDurationMinutes] = usePersistedState(`minDurUserMinutes-${location.pathname}`, null);
   const [maxDurationMinutes, setMaxDurationMinutes] = usePersistedState(`maxDurUserMinutes-${location.pathname}`, null);
   const [minMinutes, setMinMinutes] = React.useState(minDurationMinutes);
@@ -204,7 +204,7 @@ function ClaimListHeader(props: Props) {
         }
         break;
       case CS.DURATION_KEY:
-        if (delta.value === CS.DURATION_ALL) {
+        if (delta.value === CS.DURATION.ALL) {
           newUrlParams.delete(CS.DURATION_KEY);
         } else {
           newUrlParams.set(CS.DURATION_KEY, delta.value);
@@ -438,7 +438,7 @@ function ClaimListHeader(props: Props) {
                           streamTypeParam === CS.FILE_VIDEO
                         )
                       }
-                      value={durationParam || CS.DURATION_ALL}
+                      value={durationParam || CS.DURATION.ALL}
                       onChange={(e) =>
                         handleChange({
                           key: CS.DURATION_KEY,
@@ -447,17 +447,17 @@ function ClaimListHeader(props: Props) {
                       }
                     >
                       {CS.DURATION_TYPES.map((dur) => (
-                        <option key={dur} value={dur}>
+                        <option key={String(dur)} value={dur}>
                           {/* i18fixme */}
-                          {dur === CS.DURATION_SHORT && __('Short (< 4 minutes)')}
-                          {dur === CS.DURATION_LONG && __('Long (> 20 min)')}
-                          {dur === CS.DURATION_ALL && __('Any')}
-                          {dur === CS.DURATION_CUSTOM && __('Custom')}
+                          {dur === CS.DURATION.SHORT && __('Short (< 4 minutes)')}
+                          {dur === CS.DURATION.LONG && __('Long (> 20 min)')}
+                          {dur === CS.DURATION.ALL && __('Any')}
+                          {dur === CS.DURATION.CUSTOM && __('Custom')}
                         </option>
                       ))}
                     </FormField>
                   </div>
-                  {durationParam === CS.DURATION_CUSTOM && (
+                  {durationParam === CS.DURATION.CUSTOM && (
                     <div className="claim-search__duration-inputs-container">
                       <div className="claim-search__input-container">
                         <FormField

--- a/ui/constants/claim_search.js
+++ b/ui/constants/claim_search.js
@@ -1,3 +1,5 @@
+// @flow
+
 export const PAGE_SIZE = 20;
 
 export const FRESH_KEY = 'fresh';
@@ -45,11 +47,9 @@ export const ORDER_BY_NAME_ASC_VALUE = ['^name'];
 // @note: These are used to build the default controls available on claim listings.
 export const ORDER_BY_TYPES = [ORDER_BY_NEW, ORDER_BY_TRENDING, ORDER_BY_TOP];
 
-export const DURATION_SHORT = 'short';
-export const DURATION_LONG = 'long';
-export const DURATION_ALL = 'all';
-export const DURATION_CUSTOM = 'custom';
-export const DURATION_TYPES = [DURATION_ALL, DURATION_SHORT, DURATION_LONG, DURATION_CUSTOM];
+export type Duration = 'all' | 'short' | 'long' | 'custom';
+export const DURATION = { SHORT: 'short', LONG: 'long', ALL: 'all', CUSTOM: 'custom' };
+export const DURATION_TYPES = Object.values(DURATION);
 
 export const SORT_BY = {
   // key: Enumeration; can be anything as long as unique. Also used as URLParam.

--- a/ui/util/claim-search.js
+++ b/ui/util/claim-search.js
@@ -25,13 +25,29 @@ export const CsOptions = {
   /**
    * duration
    *
+   * @param contentType
    * @param duration Duration type
    * @param durationVal Only applicable is 'duration === all';
    * @param minMinutes Only for 'duration === custom'
    * @param maxMinutes Only for 'duration === custom'
    * @returns {?string|Array<string>}
    */
-  duration: (duration: Duration, durationVal?: string, minMinutes?: number, maxMinutes?: number) => {
+  duration: (
+    contentType: ?string,
+    duration: Duration,
+    durationVal?: string,
+    minMinutes?: number,
+    maxMinutes?: number
+  ) => {
+    if (
+      contentType !== CS.FILE_VIDEO &&
+      contentType !== CS.FILE_AUDIO &&
+      contentType !== null && // Any
+      contentType !== undefined // Any
+    ) {
+      return undefined;
+    }
+
     let x: ?string | Array<string>;
 
     switch (duration) {

--- a/ui/util/claim-search.js
+++ b/ui/util/claim-search.js
@@ -1,4 +1,7 @@
 // @flow
+import type { Duration } from 'constants/claim_search';
+
+import * as CS from 'constants/claim_search';
 import { MATURE_TAGS, MEMBERS_ONLY_CONTENT_TAG } from 'constants/tags';
 
 /**
@@ -17,5 +20,45 @@ export const CsOptions = {
     }
 
     return not_tags;
+  },
+
+  /**
+   * duration
+   *
+   * @param duration Duration type
+   * @param durationVal Only applicable is 'duration === all';
+   * @param minMinutes Only for 'duration === custom'
+   * @param maxMinutes Only for 'duration === custom'
+   * @returns {?string|Array<string>}
+   */
+  duration: (duration: Duration, durationVal?: string, minMinutes?: number, maxMinutes?: number) => {
+    let x: ?string | Array<string>;
+
+    switch (duration) {
+      case CS.DURATION.ALL:
+        x = durationVal || undefined;
+        break;
+      case CS.DURATION.SHORT:
+        x = '<=240';
+        break;
+      case CS.DURATION.LONG:
+        x = '>=1200';
+        break;
+      case CS.DURATION.CUSTOM:
+        x = [];
+        if (minMinutes) {
+          x.push(`>=${minMinutes * 60}`);
+        }
+        if (maxMinutes) {
+          x.push(`<=${maxMinutes * 60}`);
+        }
+        assert(minMinutes || maxMinutes, 'custom duration but no limits given');
+        break;
+      default:
+        assert(false, 'invalid duration type', duration);
+        break;
+    }
+
+    return x;
   },
 };

--- a/ui/util/claim-search.js
+++ b/ui/util/claim-search.js
@@ -61,14 +61,15 @@ export const CsOptions = {
         x = '>=1200';
         break;
       case CS.DURATION.CUSTOM:
-        x = [];
-        if (minMinutes) {
-          x.push(`>=${minMinutes * 60}`);
+        if (minMinutes || maxMinutes) {
+          x = [];
+          if (minMinutes) {
+            x.push(`>=${minMinutes * 60}`);
+          }
+          if (maxMinutes) {
+            x.push(`<=${maxMinutes * 60}`);
+          }
         }
-        if (maxMinutes) {
-          x.push(`<=${maxMinutes * 60}`);
-        }
-        assert(minMinutes || maxMinutes, 'custom duration but no limits given');
         break;
       default:
         assert(false, 'invalid duration type', duration);


### PR DESCRIPTION
Closes #2690

`Test`: salt

@keikari, can you give it a test?
