### PR TITLE
Fix excessive render in Home component

### DIFF
--- a/flow-typed/livestream.js
+++ b/flow-typed/livestream.js
@@ -83,3 +83,6 @@ declare type LivestreamInfo = {
 declare type LivestreamInfoByCreatorIds = {
   [creatorId: string]: LivestreamInfo,
 };
+
+declare type LivestreamByCreatorId = { [creatorId: string]: ?LivestreamActiveClaim };
+declare type LivestreamViewersById = { [claimId: string]: number };

--- a/ui/page/home/index.js
+++ b/ui/page/home/index.js
@@ -2,7 +2,11 @@ import { connect } from 'react-redux';
 import * as SETTINGS from 'constants/settings';
 import { doOpenModal } from 'redux/actions/app';
 import { doFetchAllActiveLivestreamsForQuery } from 'redux/actions/livestream';
-import { selectIsFetchingActiveLivestreams, selectFilteredActiveLivestreamUris } from 'redux/selectors/livestream';
+import {
+  selectIsFetchingActiveLivestreams,
+  selectActiveLivestreamByCreatorId,
+  selectViewersById,
+} from 'redux/selectors/livestream';
 import { selectFollowedTags } from 'redux/selectors/tags';
 import { selectHomepageFetched, selectUserVerifiedEmail } from 'redux/selectors/user';
 import { selectUserHasValidOdyseeMembership, selectUserHasOdyseePremiumPlus } from 'redux/selectors/memberships';
@@ -29,7 +33,8 @@ const select = (state) => ({
   homepageOrder: selectClientSetting(state, SETTINGS.HOMEPAGE_ORDER),
   userHasOdyseeMembership: selectUserHasValidOdyseeMembership(state),
   hasPremiumPlus: selectUserHasOdyseePremiumPlus(state),
-  getActiveLivestreamUrisForIds: (channelIds) => selectFilteredActiveLivestreamUris(state, channelIds),
+  activeLivestreamByCreatorId: selectActiveLivestreamByCreatorId(state),
+  livestreamViewersById: selectViewersById(state),
 });
 
 const perform = (dispatch) => ({

--- a/ui/page/home/view.jsx
+++ b/ui/page/home/view.jsx
@@ -17,6 +17,7 @@ import RecommendedPersonal from 'component/recommendedPersonal';
 import Yrbl from 'component/yrbl';
 import { useIsLargeScreen } from 'effects/use-screensize';
 import { GetLinksData } from 'util/buildHomepage';
+import { filterActiveLivestreamUris } from 'util/livestream';
 import ScheduledStreams from 'component/scheduledStreams';
 import Ad from 'web/component/ad/ad';
 import Meme from 'web/component/meme';
@@ -43,6 +44,8 @@ type Props = {
   userHasOdyseeMembership: ?boolean,
   hasPremiumPlus: boolean,
   currentTheme: string,
+  activeLivestreamByCreatorId: LivestreamByCreatorId,
+  livestreamViewersById: LivestreamViewersById,
   getActiveLivestreamUrisForIds: (Array<string>) => Array<string>,
 };
 
@@ -62,7 +65,8 @@ function HomePage(props: Props) {
     doOpenModal,
     userHasOdyseeMembership,
     hasPremiumPlus,
-    getActiveLivestreamUrisForIds,
+    activeLivestreamByCreatorId: al, // yup, unreadable name, but we are just relaying here.
+    livestreamViewersById: lv,
   } = props;
 
   const showPersonalizedChannels = (authenticated || !IS_WEB) && subscribedChannelIds.length > 0;
@@ -71,26 +75,68 @@ function HomePage(props: Props) {
   const isLargeScreen = useIsLargeScreen();
   const { push } = useHistory();
 
-  const rowData: Array<RowDataItem> = GetLinksData(
-    homepageData,
-    isLargeScreen,
-    true,
+  const sortedRowData: Array<RowDataItem> = React.useMemo(() => {
+    const rowData: Array<RowDataItem> = GetLinksData(
+      homepageData,
+      isLargeScreen,
+      true,
+      authenticated,
+      showPersonalizedChannels,
+      showPersonalizedTags,
+      subscribedChannelIds,
+      followedTags,
+      showIndividualTags,
+      showNsfw
+    );
+    return getSortedRowData(authenticated, userHasOdyseeMembership, homepageOrder, homepageData, rowData);
+  }, [
     authenticated,
+    followedTags,
+    homepageData,
+    homepageOrder,
+    isLargeScreen,
+    showIndividualTags,
+    showNsfw,
     showPersonalizedChannels,
     showPersonalizedTags,
     subscribedChannelIds,
-    followedTags,
-    showIndividualTags,
-    showNsfw
-  );
-
-  const sortedRowData: Array<RowDataItem> = getSortedRowData(
-    authenticated,
     userHasOdyseeMembership,
-    homepageOrder,
-    homepageData,
-    rowData
-  );
+  ]);
+
+  type Cache = {
+    topGrid: number,
+    hasBanner: boolean,
+    [homepageId: string]: {
+      livestreamUris: ?Array<string>,
+    },
+  };
+
+  const cache: Cache = React.useMemo(() => {
+    const cache = { topGrid: -1, hasBanner: false };
+    if (homepageFetched) {
+      sortedRowData.forEach((row: RowDataItem, index: number) => {
+        // -- Find index of first row with a title if not already:
+        if (cache.topGrid === -1 && Boolean(row.title)) {
+          cache.topGrid = index;
+        }
+        // -- Find Bruce Banner if not already:
+        if (!cache.hasBanner && row.id === 'BANNER') {
+          cache.hasBanner = true;
+        }
+        // -- Find livestreams related to the category:
+        const rowChannelIds = row.options?.channelIds;
+        cache[row.id] = {
+          livestreamUris:
+            row.id === 'FOLLOWING'
+              ? filterActiveLivestreamUris(subscribedChannelIds, null, al, lv)
+              : rowChannelIds
+              ? filterActiveLivestreamUris(rowChannelIds, null, al, lv)
+              : null,
+        };
+      });
+    }
+    return cache;
+  }, [homepageFetched, sortedRowData, subscribedChannelIds, al, lv]);
 
   type SectionHeaderProps = {
     title: string,
@@ -98,13 +144,6 @@ function HomePage(props: Props) {
     icon?: string,
     help?: string,
   };
-
-  const topGrid = sortedRowData.findIndex((row) => row.title);
-  const hasBanner = Boolean(
-    sortedRowData.filter((obj) => {
-      return obj.id === 'BANNER';
-    }).length
-  );
 
   const SectionHeader = ({ title, navigate = '/', icon = '', help }: SectionHeaderProps) => {
     return (
@@ -157,9 +196,9 @@ function HomePage(props: Props) {
         showNoSourceClaims={ENABLE_NO_SOURCE_CLAIMS}
         hideMembersOnly={id !== 'FOLLOWING'}
         hasSource
-        prefixUris={options.channelIds && getActiveLivestreamUrisForIds(options.channelIds)}
+        prefixUris={cache[id].livestreamUris}
         pins={{ urls: pinUrls, claimIds: pinnedClaimIds }}
-        injectedItem={index === topGrid && !hasPremiumPlus && { node: <Ad type="tileA" tileLayout /> }}
+        injectedItem={index === cache.topGrid && !hasPremiumPlus && { node: <Ad type="tileA" tileLayout /> }}
         forceShowReposts={id !== 'FOLLOWING'}
         loading={id === 'FOLLOWING' ? fetchingActiveLivestreams : false}
       />
@@ -172,11 +211,11 @@ function HomePage(props: Props) {
 
       return (
         <>
-          {index === topGrid && <Meme meme={homepageMeme} />}
+          {index === cache.topGrid && <Meme meme={homepageMeme} />}
           {title && typeof title === 'string' && (
             <div className="homePage-wrapper__section-title">
               <SectionHeader title={__(resolveTitleOverride(title))} navigate={route || link} icon={icon} help={help} />
-              {index === topGrid && <CustomizeHomepage />}
+              {index === cache.topGrid && <CustomizeHomepage />}
             </div>
           )}
         </>
@@ -233,7 +272,7 @@ function HomePage(props: Props) {
         </div>
       )}
 
-      {hasBanner &&
+      {cache.hasBanner &&
         getRowElements(
           'BANNER',
           undefined,
@@ -263,7 +302,7 @@ function HomePage(props: Props) {
                       <ScheduledStreams
                         channelIds={subscribedChannelIds}
                         tileLayout
-                        liveUris={getActiveLivestreamUrisForIds(subscribedChannelIds)}
+                        liveUris={cache[id].livestreamUris}
                         limitClaimsPerChannel={2}
                       />
                     )}

--- a/ui/redux/reducers/livestream.js
+++ b/ui/redux/reducers/livestream.js
@@ -5,10 +5,10 @@ import { handleActions } from 'util/redux-utils';
 
 export type LivestreamState = {
   livestreamInfoByCreatorId: LivestreamInfoByCreatorIds,
-  activeLivestreamByCreatorId: { [creatorId: string]: ?LivestreamActiveClaim },
+  activeLivestreamByCreatorId: LivestreamByCreatorId,
   futureLivestreamsByCreatorId: { [creatorId: string]: ?Array<LivestreamActiveClaim> },
   pastLivestreamsByCreatorId: { [creatorId: string]: ?Array<LivestreamActiveClaim> },
-  viewersById: { [claimId: string]: number },
+  viewersById: LivestreamViewersById,
   isLiveFetchingIds: Array<string>,
   activeLivestreamsFetchingQueries: Array<string>,
   activeCreatorLivestreamsByQuery: {


### PR DESCRIPTION
`Test:`  salt

## Issue
```
getActiveLivestreamUrisForIds: (channelIds) => selectFilteredActiveLivestreamUris(state, channelIds),
```

1. The anonymous function in the prop construction causes this component to render on _any_ redux state change. This in turn triggers N lists of ClaimTileDiscovers, which is pretty heavy
    <sub>_The amount of renders from changing Theme alone_</sub>
    <img width="300" alt="image" src="https://user-images.githubusercontent.com/64950861/233803781-58203d73-797c-4d99-a7a3-38acdb4d3028.png">
2. In the jsx code, `sortedRowData` is being looped several times for different pieces of data.

## Investigation
The anonymous function method was probably used as a workaround to pass the selector itself to the jsx so it can be re-used for each homepage row.

## Fix
See commit message.