### PR TITLE
Improve buildURI assertions

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -201,7 +201,7 @@ function App(props: Props) {
     // here queryString and startTime are "removed" from the buildURI process
     // to build only the uri itself
     const { queryString, startTime, ...parsedUri } = parseURI(path);
-    uri = buildURI({ ...parsedUri });
+    uri = buildURI({ ...parsedUri }, true);
   } catch (e) {
     const match = path.match(/[#/:]/);
 

--- a/ui/component/publish/livestream/livestreamForm/view.jsx
+++ b/ui/component/publish/livestream/livestreamForm/view.jsx
@@ -346,13 +346,13 @@ function LivestreamForm(props: Props) {
     // We are only going to store the full uri, but we need to resolve the uri with and without the channel name
     let uri;
     try {
-      uri = name && buildURI({ streamName: name, activeChannelName });
+      uri = name && buildURI({ streamName: name, activeChannelName }, true);
     } catch (e) {}
 
     if (activeChannelName && name) {
       // resolve without the channel name so we know the winning bid for it
       try {
-        const uriLessChannel = buildURI({ streamName: name });
+        const uriLessChannel = buildURI({ streamName: name }, true);
         resolveUri(uriLessChannel);
       } catch (e) {}
     }

--- a/ui/component/publish/post/postForm/view.jsx
+++ b/ui/component/publish/post/postForm/view.jsx
@@ -272,13 +272,13 @@ function PostForm(props: Props) {
     // We are only going to store the full uri, but we need to resolve the uri with and without the channel name
     let uri;
     try {
-      uri = name && buildURI({ streamName: name, activeChannelName });
+      uri = name && buildURI({ streamName: name, activeChannelName }, true);
     } catch (e) {}
 
     if (activeChannelName && name) {
       // resolve without the channel name so we know the winning bid for it
       try {
-        const uriLessChannel = buildURI({ streamName: name });
+        const uriLessChannel = buildURI({ streamName: name }, true);
         resolveUri(uriLessChannel);
       } catch (e) {}
     }

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -298,13 +298,13 @@ function UploadForm(props: Props) {
     // We are only going to store the full uri, but we need to resolve the uri with and without the channel name
     let uri;
     try {
-      uri = name && buildURI({ streamName: name, activeChannelName });
+      uri = name && buildURI({ streamName: name, activeChannelName }, true);
     } catch (e) {}
 
     if (activeChannelName && name) {
       // resolve without the channel name so we know the winning bid for it
       try {
-        const uriLessChannel = buildURI({ streamName: name });
+        const uriLessChannel = buildURI({ streamName: name }, true);
         resolveUri(uriLessChannel);
       } catch (e) {}
     }

--- a/ui/component/publishBidField/view.jsx
+++ b/ui/component/publishBidField/view.jsx
@@ -25,7 +25,7 @@ function PublishName(props: Props) {
   const { name, bid } = params;
 
   React.useEffect(() => {
-    if (name && isNameValid(name)) doResolveUri(buildURI({ streamName: name }), true);
+    if (name && isNameValid(name)) doResolveUri(buildURI({ streamName: name }, true), true);
   }, [doResolveUri, name]);
 
   return (

--- a/ui/page/embedWrapper/index.js
+++ b/ui/page/embedWrapper/index.js
@@ -82,6 +82,7 @@ function getUriFromMatch(match) {
       try {
         return buildURI({ claimName, claimId });
       } catch (error) {}
+      // ^-------- why twice?
     }
 
     if (isCanonicalUriFormat) {

--- a/ui/page/wallet/transactionListTableItem/view.jsx
+++ b/ui/page/wallet/transactionListTableItem/view.jsx
@@ -103,10 +103,10 @@ class TransactionListTableItem extends React.PureComponent<Props, State> {
     try {
       if (name.startsWith('@')) {
         ({ claimName } = parseURI(name));
-        uri = buildURI({ channelName: claimName, channelClaimId: claimId });
+        uri = buildURI({ channelName: claimName, channelClaimId: claimId }, true);
       } else {
         ({ claimName } = parseURI(name));
-        uri = buildURI({ streamName: claimName, streamClaimId: claimId });
+        uri = buildURI({ streamName: claimName, streamClaimId: claimId }, true);
       }
     } catch (e) {}
 

--- a/ui/redux/actions/search.js
+++ b/ui/redux/actions/search.js
@@ -134,7 +134,7 @@ const processLighthouseResults = (results: Array<any>) => {
         urlObj.streamClaimId = claimId;
       }
 
-      const url = buildURI(urlObj);
+      const url = buildURI(urlObj, true);
       if (isURIValid(url)) {
         uris.push(url);
       }

--- a/ui/util/url.js
+++ b/ui/util/url.js
@@ -148,7 +148,7 @@ export const generateShareUrl = (
     ...(channelClaimId ? { channelClaimId } : {}),
   };
 
-  const encodedUrl = buildURI(uriParts, false);
+  const encodedUrl = buildURI(uriParts, false, false);
   const lbryWebUrl = encodedUrl.replace(/#/g, ':');
 
   const url = `${domain}/${lbryWebUrl}` + (urlParamsString === '' ? '' : `?${urlParamsString}`);

--- a/web/src/html.js
+++ b/web/src/html.js
@@ -395,7 +395,7 @@ async function getHtml(ctx) {
 
     try {
       parsedUri = parseURI(normalizeClaimUrl(requestPath.slice(1)));
-      claimUri = buildURI({ ...parsedUri, startTime: undefined });
+      claimUri = buildURI({ ...parsedUri, startTime: undefined }, true);
     } catch (err) {
       ctx.status = 404;
       return err.message;

--- a/web/src/lbryURI.js
+++ b/web/src/lbryURI.js
@@ -195,7 +195,7 @@ function parseURIModifier(modSeperator, modValue) {
  *
  * The channelName key will accept names with or without the @ prefix.
  */
-function buildURI(UrlObj, includeProto = true, protoDefault = 'lbry://') {
+function buildURI(UrlObj, suppressErrors = false, includeProto = true, protoDefault = 'lbry://') {
   const {
     streamName,
     streamClaimId,
@@ -210,23 +210,25 @@ function buildURI(UrlObj, includeProto = true, protoDefault = 'lbry://') {
   } = UrlObj;
   const { claimId, claimName, contentName } = deprecatedParts;
 
-  if (!isProduction) {
-    if (claimId) {
-      console.error(__("'claimId' should no longer be used. Use 'streamClaimId' or 'channelClaimId' instead")); // eslint-disable-line no-console
+  if (!suppressErrors) {
+    if (!isProduction) {
+      if (claimId) {
+        console.error(__("'claimId' should no longer be used. Use 'streamClaimId' or 'channelClaimId' instead")); // eslint-disable-line no-console
+      }
+      if (claimName) {
+        console.error(__("'claimName' should no longer be used. Use 'streamClaimName' or 'channelClaimName' instead")); // eslint-disable-line no-console
+      }
+      if (contentName) {
+        console.error(__("'contentName' should no longer be used. Use 'streamName' instead")); // eslint-disable-line no-console
+      }
     }
-    if (claimName) {
-      console.error(__("'claimName' should no longer be used. Use 'streamClaimName' or 'channelClaimName' instead")); // eslint-disable-line no-console
-    }
-    if (contentName) {
-      console.error(__("'contentName' should no longer be used. Use 'streamName' instead")); // eslint-disable-line no-console
-    }
-  }
 
-  if (!claimName && !channelName && !streamName) {
-    // eslint-disable-next-line no-console
-    console.error(
-      __("'claimName', 'channelName', and 'streamName' are all empty. One must be present to build a url.")
-    );
+    if (!claimName && !channelName && !streamName) {
+      // eslint-disable-next-line no-console
+      console.error(
+        __("'claimName', 'channelName', and 'streamName' are all empty. One must be present to build a url.")
+      );
+    }
   }
 
   const formattedChannelName = channelName && (channelName.startsWith('@') ? channelName : `@${channelName}`);
@@ -325,6 +327,7 @@ function convertToShareLink(URL) {
       secondaryBidPosition,
       secondaryClaimSequence,
     },
+    false,
     true,
     'https://open.lbry.com/'
   );


### PR DESCRIPTION
The typical usage of buildURI is to wrap it inside a try-catch or check the results with isURIValid.

New users typically don't know this, but previously we just warn using a console message.

After we moved to asserts, we have to disable asserts for those correct usages (already checking output), but continue to assert on the rest.
