### PR TITLE
Fix Object.fromEntries not supported in older browsers

### DIFF
--- a/ui/page/odyseeMembership/view.jsx
+++ b/ui/page/odyseeMembership/view.jsx
@@ -48,9 +48,8 @@ const OdyseeMembershipPage = (props: Props) => {
   const stillWaitingFromBackend = membershipOptions === undefined || !mineFetched;
 
   const urlSearchParams = new URLSearchParams(window.location.search);
-  const params = Object.fromEntries(urlSearchParams.entries());
-
-  const { interval, plan: planValue } = params;
+  const interval = urlSearchParams.get('interval') || undefined;
+  const planValue = urlSearchParams.get('plan') || undefined;
 
   // add a bit of a delay otherwise it's a bit jarring
   const timeoutValue = 300;


### PR DESCRIPTION
Kept seeing this in Sentry every once a while. Informed, but seems like still there.
There is no need to use that function in the first place.