### PR TITLE
Example: type-safety for Component props

### DIFF
--- a/ui/component/claimAuthor/index.js
+++ b/ui/component/claimAuthor/index.js
@@ -1,5 +1,7 @@
+// @flow
 import { connect } from 'react-redux';
 import { selectChannelForClaimUri } from 'redux/selectors/claims';
+import type { Props } from './view';
 import ClaimAuthor from './view';
 
 const select = (state, props) => {
@@ -10,4 +12,4 @@ const select = (state, props) => {
   };
 };
 
-export default connect(select)(ClaimAuthor);
+export default connect<_, Props, _, _, _, _>(select, {})(ClaimAuthor);

--- a/ui/component/claimAuthor/view.jsx
+++ b/ui/component/claimAuthor/view.jsx
@@ -2,14 +2,19 @@
 import * as React from 'react';
 import ClaimPreview from 'component/claimPreview';
 
-type Props = {
+export type Props = {|
+  uri: ?string,
   hideActions?: boolean,
   channelSubCount?: number,
-  // redux
-  channelUri: string,
-};
+|};
 
-export default function ClaimAuthor(props: Props) {
+type StateProps = {|
+  channelUri: ?string,
+|};
+
+type DispatchProps = {||};
+
+export default function ClaimAuthor(props: Props & StateProps & DispatchProps) {
   const { channelUri, hideActions, channelSubCount } = props;
 
   return channelUri ? (


### PR DESCRIPTION
## Issue
- Not getting warnings on prop mistakes (e.g. typos, wrong types, missing props, extra props).
- When using the components, the IDE sometimes doesn't show autocomplete options for the props because the component goes through the `connect` HOC.

## Fix
<details>
  <summary>Details  :heavy_plus_sign: </summary>

1. In `view.jsx`: 
    - Split the component `Props` into 3
        - Each type must be 'exact', i.e. `{| ... |}`. 
        - Export the client-facing `Prop`. The other two can remain local. 
            ``` 
            export type Props = {| 
                hideActions?: boolean, 
                channelSubCount?: number, 
            |};

            type StateProps = {|
                channelUri: string,
            |};

            type DispatchProps = {||};
            ```
    - Combine these 3 when used in the component.
        ```
        function ClaimAuthor(props: Props & StateProps & DispatchProps) {
        ```
2. In `index.js`: 
    - Add `// @flow`. 
    - Import type. 
        - `import type { Props } './view';` 
    - Annotate `connect`. 
        - `export default connect<_, Props, _, _, _, _>(select, {})(ClaimAuthor);`

</details>

That's it. Flow might take a while to catch up, but you can run `yarn flow` to confirm the status.

## Comments
- It's a bit more work and more verbose, but I like it that props are now separated between client and redux props; no more need for markers like `// -- redux:`.

## Sample
<details>
  <summary>Details  :heavy_plus_sign: </summary>

1. Accidentally adding extra `tileLayout` prop:
    - ![image](https://user-images.githubusercontent.com/64950861/235069652-e23d6c55-d74c-4210-bf11-f215208e359f.png)
2. Typo ("uri" vs "uris") or missing props:
    - ![image](https://user-images.githubusercontent.com/64950861/235070195-e728f5ef-f931-4127-84dc-ca8f2e9e0c51.png)
3. Wrong type:
    - ![image](https://user-images.githubusercontent.com/64950861/235070022-0e076cc1-4bd1-4ae0-924f-b8b700b64fc3.png)

</details>

