### PR TITLE
QualitySelector: use latest states instead of the one during init

### DIFF
--- a/flow-typed/content.js
+++ b/flow-typed/content.js
@@ -35,6 +35,6 @@ declare type PlayingCollection = {
   shuffle?: ?{ newUrls: Array<string> },
 };
 
-declare type OdyseeState = {|
+declare type VideojsClientState = {|
   defaultQuality?: string,
 |};

--- a/flow-typed/content.js
+++ b/flow-typed/content.js
@@ -37,4 +37,5 @@ declare type PlayingCollection = {
 
 declare type VideojsClientState = {|
   defaultQuality?: string,
+  originalVideoHeight?: number,
 |};

--- a/flow-typed/videojs-hls-quality-selector.js
+++ b/flow-typed/videojs-hls-quality-selector.js
@@ -3,7 +3,7 @@
 declare type HlsQualitySelectorOptions = {|
   defaultQuality?: string,
   displayCurrentQuality: boolean,
-  originalHeight?: number,
+  originalVideoHeight?: number,
   placementIndex?: number, // controlBar placement index
   vjsIconClass?: string,
 |};

--- a/flow-typed/videojs-hls-quality-selector.js
+++ b/flow-typed/videojs-hls-quality-selector.js
@@ -6,8 +6,4 @@ declare type HlsQualitySelectorOptions = {|
   originalHeight?: number,
   placementIndex?: number, // controlBar placement index
   vjsIconClass?: string,
-  // These two are from React.useState(), so it tightly couples the plugin to the view.
-  initialQualityChange?: boolean, // "used to notify about default quality setting"
-  setInitialQualityChange?: (any) => void,
-  doToast: (params: ToastParams) => void,
 |};

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/ConcreteMenuItem.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/ConcreteMenuItem.js
@@ -36,7 +36,7 @@ export default class ConcreteMenuItem extends VideoJsMenuItemClass {
     }
 
     // Set this menu item to selected, and set quality.
-    this.plugin.setQuality(this.item.value);
+    this.plugin.setQuality(this.item.value, true);
     this.selected(true);
   }
 }

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
@@ -199,7 +199,7 @@ class HlsQualitySelectorPlugin {
     }
 
     const player = this.player;
-    const { defaultQuality } = player.odyseeState;
+    const { defaultQuality } = player.appState;
     const levelItems = [];
 
     const selectOriginal = defaultQuality ? defaultQuality === QUALITY_OPTIONS.ORIGINAL : false;

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
@@ -363,23 +363,15 @@ class HlsQualitySelectorPlugin {
    * Sets quality (based on media height)
    *
    * @param {number} height - A number representing HLS playlist.
+   * @param {boolean} fromUser - true if the change is from the user (click), false if called internally.
    */
-  setQuality(height) {
+  setQuality(height, fromUser = false) {
     if (this.setQualityIOS(height)) {
+      this.player.trigger(fromUser ? 'hlsQualitySelector:changed:user' : 'hlsQualitySelector:changed:internal');
       return;
     }
 
     const qualityList = this.player.qualityLevels();
-    const { initialQualityChange, setInitialQualityChange, doToast } = this.config;
-
-    if (!initialQualityChange && setInitialQualityChange) {
-      doToast({
-        message: __('You can also change your default quality on settings.'),
-        linkText: __('Settings'),
-        linkTarget: '/settings',
-      });
-      setInitialQualityChange(true);
-    }
 
     // Set quality on plugin
     this._currentQuality = height;
@@ -422,6 +414,7 @@ class HlsQualitySelectorPlugin {
     }
 
     this._qualityButton.unpressButton();
+    this.player.trigger(fromUser ? 'hlsQualitySelector:changed:user' : 'hlsQualitySelector:changed:internal');
   }
 
   /**
@@ -493,6 +486,12 @@ const onPlayerReady = (player, options) => {
  * instance. You cannot rely on the player being in a "ready" state here,
  * depending on how the plugin is invoked. This may or may not be important
  * to you; if not, remove the wait for "ready"!
+ *
+ * ====================================
+ * --Spewed events--
+ *   "hlsQualitySelector:changed:internal" - Selection changed from internal event, e.g. new video loaded.
+ *   "hlsQualitySelector:changed:user"     - Selection changed by the user.
+ * ====================================
  *
  * @function hlsQualitySelector
  * @param    {Object} [options={}]

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-hls-quality-selector/plugin.js
@@ -79,6 +79,14 @@ class HlsQualitySelectorPlugin {
     }
   }
 
+  updateConfig() {
+    this.config = {
+      ...this.config,
+      defaultQuality: this.player.appState.defaultQuality,
+      originalVideoHeight: this.player.appState.originalVideoHeight,
+    };
+  }
+
   /**
    * Deprecated, returns VHS plugin
    *
@@ -103,6 +111,7 @@ class HlsQualitySelectorPlugin {
    */
   bindPlayerEvents() {
     this.player.qualityLevels().on('addqualitylevel', this.onAddQualityLevel.bind(this));
+    this.player.on(VJS_EVENTS.SRC_CHANGED, this.updateConfig.bind(this));
     this.player.on(VJS_EVENTS.PLAYER_CLOSED, this.playerClosed.bind(this));
   }
 
@@ -133,11 +142,13 @@ class HlsQualitySelectorPlugin {
   }
 
   resolveOriginalQualityLabel(abbreviatedForm, includeResolution) {
-    if (includeResolution && this.config.originalHeight) {
+    const { originalVideoHeight: videoHeight } = this.config;
+
+    if (includeResolution && videoHeight) {
       return abbreviatedForm
-        ? __('Orig (%quality%) --[Video quality popup. Short form.]--', { quality: this.config.originalHeight + 'p' })
+        ? __('Orig (%quality%) --[Video quality popup. Short form.]--', { quality: videoHeight + 'p' })
         : __('Original (%quality%) --[Video quality popup. Long form.]--', {
-            quality: this.config.originalHeight + 'p',
+            quality: videoHeight + 'p',
           });
     } else {
       // The allocated space for the button is fixed and happened to fit
@@ -199,7 +210,7 @@ class HlsQualitySelectorPlugin {
     }
 
     const player = this.player;
-    const { defaultQuality } = player.appState;
+    const { defaultQuality } = this.config;
     const levelItems = [];
 
     const selectOriginal = defaultQuality ? defaultQuality === QUALITY_OPTIONS.ORIGINAL : false;

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -634,8 +634,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
           window.cast.framework.CastContext.getInstance().getCurrentSession().endSession(false);
         } catch {}
 
-        window.player.switchedFromDefaultQuality = false;
-
         window.player.userActive(false);
         window.player.pause();
 

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -41,7 +41,7 @@ require('@silvermine/videojs-airplay')(videojs);
 
 export type Player = {
   // -- custom --
-  odyseeState?: OdyseeState,
+  appState?: VideojsClientState,
   claimSrcOriginal: ?{ src: string, type: string },
   claimSrcVhs: ?{ src: string, type: string },
   isLivestream?: boolean,
@@ -285,7 +285,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       // this seems like a weird thing to have to check for here
       if (!player) return;
 
-      player.odyseeState = {};
+      player.appState = {};
 
       player.reloadSourceOnError({ errorInterval: 10 });
 
@@ -519,8 +519,8 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       }
 
       // Pass data required by plugins from redux to player, then trigger.
-      vjsPlayer.odyseeState = {
-        ...vjsPlayer.odyseeState,
+      vjsPlayer.appState = {
+        ...vjsPlayer.appState,
         defaultQuality: defaultQuality,
       };
 

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -301,12 +301,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       player.i18n();
       player.settingsMenu();
       player.timeMarkerPlugin();
-
-      player.hlsQualitySelector({
-        displayCurrentQuality: true,
-        originalHeight: claimValues?.video?.height,
-        defaultQuality,
-      });
+      player.hlsQualitySelector({ displayCurrentQuality: true });
 
       // Add recsys plugin
       if (shareTelemetry) {
@@ -522,6 +517,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
       vjsPlayer.appState = {
         ...vjsPlayer.appState,
         defaultQuality: defaultQuality,
+        originalVideoHeight: claimValues?.video?.height,
       };
 
       vjsPlayer.trigger(VJS_EVENTS.SRC_CHANGED);

--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -31,8 +31,6 @@ import snapshotButton from './plugins/videojs-snapshot-button/plugin';
 import videojs from 'video.js';
 import { useIsMobile } from 'effects/use-screensize';
 import { platform } from 'util/platform';
-import { EmbedContext } from 'contexts/embed';
-import usePersistedState from 'effects/use-persisted-state';
 import Lbry from 'lbry';
 
 import { getStripeEnvironment } from 'util/stripe';
@@ -118,7 +116,6 @@ type Props = {
   isLivestreamClaim: boolean,
   userClaimId: ?string,
   activeLivestreamForChannel: ?LivestreamActiveClaim,
-  doToast: ({ message: string, linkText: string, linkTarget: string }) => void,
   isPurchasableContent: boolean,
   isRentableContent: boolean,
   isProtectedContent: boolean,
@@ -187,21 +184,11 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     userClaimId,
     isLivestreamClaim,
     activeLivestreamForChannel,
-    doToast,
     isPurchasableContent,
     isRentableContent,
     isProtectedContent,
     doSetVideoSourceLoaded,
   } = props;
-
-  const isEmbed = React.useContext(EmbedContext);
-
-  // used to notify about default quality setting
-  // if already has a quality set, no need to notify
-  const [initialQualityChange, setInitialQualityChange] = usePersistedState(
-    'initial-quality-change',
-    Boolean(defaultQuality)
-  );
 
   const isMobile = useIsMobile();
 
@@ -319,9 +306,6 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         displayCurrentQuality: true,
         originalHeight: claimValues?.video?.height,
         defaultQuality,
-        initialQualityChange,
-        setInitialQualityChange: !isEmbed && setInitialQualityChange,
-        doToast,
       });
 
       // Add recsys plugin

--- a/ui/constants/player.js
+++ b/ui/constants/player.js
@@ -26,7 +26,7 @@ export const VJS_COMP = Object.freeze({
 
 // Custom videojs event names
 export const VJS_EVENTS = Object.freeze({
-  // Triggered just before load() is called, with player.odyseeState updated.
+  // Triggered just before load() is called, with 'player.appState' updated.
   // Plugins should update per new states.
   SRC_CHANGED: 'src_changed',
   // Player removed but not disposed. Plugins should perform cleanup.


### PR DESCRIPTION
`Test:`  salt

## Issues/Ticket
1. Closes #2134
2. "Original (xxxP)" not updated correctly when moving from landscape to portrait (shorts) video.

## Change
Small steps to put things in the right place before we consider the abstraction layer.
See commit messages for details