### PR TITLE
Fix crash on muted uris with spaces

### DIFF
--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -1,5 +1,4 @@
 // @flow
-import { Lbryio } from 'lbryinc';
 import * as Sentry from '@sentry/react';
 import { apiLog } from 'analytics/apiLog';
 import { events } from 'analytics/events';
@@ -11,6 +10,9 @@ import type { Watchman } from 'analytics/watchman';
 
 const isProduction = process.env.NODE_ENV === 'production';
 let gAnalyticsEnabled = false;
+
+// ****************************************************************************
+// ****************************************************************************
 
 export type Analytics = {
   init: () => void,
@@ -32,6 +34,9 @@ export type Analytics = {
   log: (error: Error | string, options?: LogOptions, label?: string) => Promise<?LogId>,
 };
 
+// ****************************************************************************
+// ****************************************************************************
+
 const analytics: Analytics = {
   init: () => {
     sentryWrapper.init();
@@ -47,15 +52,7 @@ const analytics: Analytics = {
   event: events,
   video: watchman,
   error: (message) => {
-    return new Promise((resolve) => {
-      if (gAnalyticsEnabled && isProduction) {
-        return Lbryio.call('event', 'desktop_error', { error_message: message }).then(() => {
-          resolve(true);
-        });
-      } else {
-        resolve(false);
-      }
-    });
+    return analytics.apiLog.desktopError(message);
   },
   log: (error: Error | string, options?: LogOptions, label?: string) => {
     return sentryWrapper.log(error, { ...options }, label);

--- a/ui/analytics/apiLog.js
+++ b/ui/analytics/apiLog.js
@@ -1,8 +1,30 @@
 // @flow
-import { Lbryio } from 'lbryinc';
-
 const isProduction = process.env.NODE_ENV === 'production';
 const devInternalApis = process.env.LBRY_API_URL && process.env.LBRY_API_URL.includes('dev');
+
+const Lbryio = {
+  importPromise: undefined,
+
+  loadModule: () => {
+    if (!Lbryio.importPromise) {
+      Lbryio.importPromise = import('lbryinc')
+        .then((module) => module.Lbryio)
+        .catch((err) => console.log(err)); // eslint-disable-line no-console
+    }
+  },
+
+  call: (resource, action, params = {}, method = 'post') => {
+    if (!Lbryio.importPromise) {
+      Lbryio.loadModule();
+    }
+    return (
+      Lbryio.importPromise
+        // $FlowIgnore
+        .then((Lbryio) => Lbryio.call(resource, action, params, method))
+        .catch((err) => assert(false, 'lbryio did not load', err))
+    );
+  },
+};
 
 type LogPublishParams = {|
   uri: string,

--- a/ui/redux/selectors/blocked.js
+++ b/ui/redux/selectors/blocked.js
@@ -1,6 +1,7 @@
 // @flow
 import { createSelector } from 'reselect';
 import { parseURI } from 'util/lbryURI';
+import analytics from 'analytics';
 
 type State = { blocked: BlocklistState, comments: CommentsState };
 
@@ -26,6 +27,8 @@ export const selectMutedAndBlockedChannelIds = createSelector(
         uniqueSet.add(parseURI(u).channelClaimId);
       } catch {}
     });
+
+    analytics.log('blah');
 
     return Array.from(uniqueSet).sort();
   }


### PR DESCRIPTION
## Issue
LBRY-DESKTOP-WEB-19GB

## Notes
I can't tell from the stack trace whether it's from SDK or Commentron, but I'm betting on the former.

This change will filter out bad URIs on load, and writes to the wallet on the next sync. I think that should be fine -- if it's invalid, migth as well purge it?
