### PR TITLE
Add lbryinc lazy-loader to address circular dependency problem

### DIFF
--- a/ui/analytics.js
+++ b/ui/analytics.js
@@ -1,5 +1,4 @@
 // @flow
-import { Lbryio } from 'lbryinc';
 import * as Sentry from '@sentry/react';
 import { apiLog } from 'analytics/apiLog';
 import { events } from 'analytics/events';
@@ -11,6 +10,9 @@ import type { Watchman } from 'analytics/watchman';
 
 const isProduction = process.env.NODE_ENV === 'production';
 let gAnalyticsEnabled = false;
+
+// ****************************************************************************
+// ****************************************************************************
 
 export type Analytics = {
   init: () => void,
@@ -32,6 +34,9 @@ export type Analytics = {
   log: (error: Error | string, options?: LogOptions, label?: string) => Promise<?LogId>,
 };
 
+// ****************************************************************************
+// ****************************************************************************
+
 const analytics: Analytics = {
   init: () => {
     sentryWrapper.init();
@@ -47,15 +52,7 @@ const analytics: Analytics = {
   event: events,
   video: watchman,
   error: (message) => {
-    return new Promise((resolve) => {
-      if (gAnalyticsEnabled && isProduction) {
-        return Lbryio.call('event', 'desktop_error', { error_message: message }).then(() => {
-          resolve(true);
-        });
-      } else {
-        resolve(false);
-      }
-    });
+    return analytics.apiLog.desktopError(message);
   },
   log: (error: Error | string, options?: LogOptions, label?: string) => {
     return sentryWrapper.log(error, { ...options }, label);


### PR DESCRIPTION
## Ticket
Closes [Fix extras/ dependency problem #764](https://github.com/OdyseeTeam/odysee-frontend/issues/764)

## Repro
Add `analytics.log('blah')` inside `selectMutedAndBlockedChannelIds`.  The app doesn't load.

## Workaround approach
Lazy-load lbryinc so that the circular dependency doesn't interfere clients that uses `import analytics from 'analytics';`

Added a wrapper so that the existing calls don't need to change.

![image](https://user-images.githubusercontent.com/64950861/235317094-7d13ef1b-7fe6-4a5b-a1c0-7d2c6f6162d5.png)
