### PR TITLE
ContainerUtil - helper functions for arrays and objects

### DIFF
--- a/ui/redux/selectors/blocked.js
+++ b/ui/redux/selectors/blocked.js
@@ -1,5 +1,6 @@
 // @flow
 import { createSelector } from 'reselect';
+import { Container } from 'util/container';
 import { parseURI } from 'util/lbryURI';
 
 type State = { blocked: BlocklistState, comments: CommentsState };
@@ -27,6 +28,6 @@ export const selectMutedAndBlockedChannelIds = createSelector(
       } catch {}
     });
 
-    return Array.from(uniqueSet).sort();
+    return Container.Arr.useStableEmpty(Array.from(uniqueSet).sort());
   }
 );

--- a/ui/redux/selectors/subscriptions.js
+++ b/ui/redux/selectors/subscriptions.js
@@ -11,6 +11,7 @@ import {
 } from 'redux/selectors/claims';
 import { swapKeyAndValue } from 'util/swap-json';
 import { getChannelFromClaim, isChannelClaim } from 'util/claim';
+import { Container } from 'util/container';
 
 // Returns the entire subscriptions state
 const selectState = (state) => state.subscriptions || {};
@@ -28,9 +29,9 @@ export const selectSubscriptionUris = createSelector(
 
 export const selectSubscriptionIds = createSelector(selectSubscriptions, (subscriptions) => {
   if (subscriptions) {
-    return subscriptions.map((sub) => parseURI(sub.uri).channelClaimId);
+    return Container.Arr.useStableEmpty(subscriptions.map((sub) => parseURI(sub.uri).channelClaimId));
   } else {
-    return [];
+    return Container.Arr.EMPTY;
   }
 });
 

--- a/ui/util/container.js
+++ b/ui/util/container.js
@@ -1,0 +1,27 @@
+// @flow
+
+export class Container {
+  static Arr = class {
+    static EMPTY: Array<any> = Object.freeze([]);
+
+    static isEmpty(input: Array<any>) {
+      return input.length === 0;
+    }
+
+    static useStableEmpty(input: Array<any>): Array<any> {
+      return input.length === 0 ? Container.Arr.EMPTY : input;
+    }
+  };
+
+  static Obj = class {
+    static EMPTY: { ... } = Object.freeze({});
+
+    static isEmpty(input: { ... }) {
+      return Object.keys(input).length === 0;
+    }
+
+    static useStableEmpty(input: { ... }) {
+      return Object.keys(input).length === 0 ? Container.Obj.EMPTY : input;
+    }
+  };
+}


### PR DESCRIPTION
@jessopb, would this help, or too verbose?

----

## Objectives
Primary: to provide a stable empty reference for props.

Secondary: to have some helpers for common queries like `isEmpty`, which usually requires verbose syntax like `Object.keys(x).length`

## Considerations
- The name "Collection" would be a better name to represent "Arrays and Objects", but that has been used for playlist claims.
- Dropped the word "Util" from "ContainerUtil" to keep things short.
- Flow did not like the overloaded function, so had to split into two
