### PR TITLE
clean up uriIndicator

### DIFF
--- a/ui/component/uriIndicator/index.js
+++ b/ui/component/uriIndicator/index.js
@@ -1,23 +1,16 @@
 import { connect } from 'react-redux';
-import { normalizeURI } from 'util/lbryURI';
 import { selectIsUriResolving, selectClaimForUri } from 'redux/selectors/claims';
 import { selectOdyseeMembershipForChannelId } from 'redux/selectors/memberships';
 import { getChannelIdFromClaim } from 'util/claim';
 import UriIndicator from './view';
 
 const select = (state, props) => {
-  let uri = null;
-  try {
-    uri = normalizeURI(props.uri);
-  } catch {}
-
   const claim = selectClaimForUri(state, props.uri);
 
   return {
     claim,
     odyseeMembership: selectOdyseeMembershipForChannelId(state, getChannelIdFromClaim(claim)),
     isResolvingUri: selectIsUriResolving(state, props.uri),
-    uri,
   };
 };
 

--- a/ui/component/uriIndicator/view.jsx
+++ b/ui/component/uriIndicator/view.jsx
@@ -9,7 +9,6 @@ import { stripLeadingAtSign } from 'util/string';
 type ChannelInfo = { uri: string, name: string, title: string };
 
 type Props = {
-  uri: string,
   channelInfo: ?ChannelInfo, // Direct channel info to use, bypassing the need to resolve 'uri'.
   link: ?boolean,
   external?: boolean,
@@ -66,7 +65,6 @@ class UriIndicator extends React.PureComponent<Props> {
 
   render() {
     const {
-      uri,
       channelInfo,
       link,
       isResolvingUri,
@@ -87,7 +85,7 @@ class UriIndicator extends React.PureComponent<Props> {
     if (!channelInfo && !claim && !showHiddenAsAnonymous) {
       return (
         <span className={classnames('empty', className)}>
-          {uri === null ? '---' : isResolvingUri || claim === undefined ? __('Validating...') : __('[Removed]')}
+          {claim === null ? '---' : isResolvingUri || claim === undefined ? __('Validating...') : __('[Removed]')}
         </span>
       );
     }

--- a/ui/redux/selectors/memberships.js
+++ b/ui/redux/selectors/memberships.js
@@ -259,6 +259,7 @@ export const selectUserHasOdyseePremiumPlus = createSelector(selectMyValidOdysee
 
 export const selectOdyseeMembershipForChannelId = (state: State, channelId: string) =>
   selectMembershipForCreatorIdAndChannelId(state, ODYSEE_CHANNEL.ID, channelId);
+
 export const selectOdyseeMembershipIsPremiumPlus = (state: State, channelId: string) =>
   selectOdyseeMembershipForChannelId(state, channelId) === MEMBERSHIP_CONSTS.ODYSEE_TIER_NAMES.PREMIUM_PLUS;
 


### PR DESCRIPTION
The current component only uses the 'uri' prop to check for a bad uri. We can just use the claim instead.