### PR TITLE
Disable nativeTextTrack in all Safari

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -244,6 +244,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     responsive: true,
     controls: true,
     html5: {
+      nativeTextTracks: !videojs.browser.IS_ANY_SAFARI,
       vhs: {
         overrideNative: overrideNativeVhs, // !videojs.browser.IS_ANY_SAFARI,
         enableLowInitialPlaylist: false,


### PR DESCRIPTION
`Test:`  salt

## Issue
Closes #2734
Don't know the full details, but iOS/iPAD/Mac is crashing at the default text-track handler when transitioning on some videos.

Since it only happens for some videos, I assume those have custom text-tracks embedded.

I also vaguely recall this was originally disabled, and maybe enabled during the livestream player changes, without testing on iOS?
