### PR TITLE
2nd attempt: disable nativeTextTracks for any Safari

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -244,6 +244,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     responsive: true,
     controls: true,
     html5: {
+      ...(videojs.browser.IS_ANY_SAFARI ? { nativeTextTracks: false } : {}),
       vhs: {
         overrideNative: overrideNativeVhs, // !videojs.browser.IS_ANY_SAFARI,
         enableLowInitialPlaylist: false,


### PR DESCRIPTION
The previous attempt inadvertently forced it on for other browsers; should leave it untouched so it's the default, whatever that is (seems different for each browser).

Closes #2734