### PR TITLE
Disable CORS for app-strings

### DIFF
--- a/ui/redux/actions/settings.js
+++ b/ui/redux/actions/settings.js
@@ -293,7 +293,7 @@ async function fetchAndStoreLanguage(language: string) {
       window.i18n_messages[language] = j;
     })
     .catch((err) => {
-      // assert(false, `Failed: "${language}" from (${url})`, err);
+      assert(false, `Failed: "${language}" from (${url})`, err);
       throw err;
     });
 }

--- a/web/index.js
+++ b/web/index.js
@@ -4,6 +4,7 @@ const Koa = require('koa');
 const serve = require('koa-static');
 const logger = require('koa-logger');
 const router = require('./src/routes');
+const appStringsMiddleWare = require('./middleware/app-strings');
 const redirectMiddleware = require('./middleware/redirect');
 const cacheControlMiddleware = require('./middleware/cache-control');
 const iframeDestroyerMiddleware = require('./middleware/iframe-destroyer');
@@ -27,8 +28,8 @@ app.use(logger());
 app.use(cacheControlMiddleware);
 app.use(redirectMiddleware);
 app.use(iframeDestroyerMiddleware);
+app.use(appStringsMiddleWare);
 
-// Check if the request url matches any assets inside of /dist
 app.use(
   serve(DIST_ROOT, {
     maxage: 3600000, // set a cache time of one hour, helpful for mobile dev

--- a/web/middleware/app-strings.js
+++ b/web/middleware/app-strings.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+async function appStringsMiddleware(ctx, next) {
+  const { path: requestPath } = ctx;
+
+  if (/^\/app-strings\/.+\.json$/.test(requestPath)) {
+    try {
+      ctx.set('Access-Control-Allow-Origin', '*');
+      ctx.body = fs.readFileSync(path.join(__dirname, `../dist${requestPath}`), 'utf8');
+      ctx.set('Content-Type', 'application/json');
+    } catch {
+      ctx.status = 404;
+      ctx.body = 'Resource not found';
+    }
+  } else {
+    return next();
+  }
+}
+
+module.exports = appStringsMiddleware;


### PR DESCRIPTION
`Test:`  salt

## Issue
Troublesome to test language-related changes when localhost and dev instances can't get the strings.
Not sure what happened that CORS'd it (maybe security-tightening).

## Change
Remove CORS for app-string files.
