### PR TITLE
Fix - Sometimes blank signInVerify page

### DIFF
--- a/ui/page/signInVerify/view.jsx
+++ b/ui/page/signInVerify/view.jsx
@@ -30,7 +30,7 @@ function SignInVerifyPage(props: Props) {
   const userSubmittedEmail = urlParams.get('email');
   const verificationToken = urlParams.get('verification_token');
   const needsRecaptcha = urlParams.get('needs_recaptcha') === 'true';
-  const [verificationTried, setVerificationTried] = useState(needsRecaptcha);
+  const [verificationTried, setVerificationTried] = useState(needsRecaptcha || verificationApiHistory.called);
 
   const successful = isAuthenticationSuccess || verificationApiHistory.successful;
 


### PR DESCRIPTION
## Fixes

Sometimes when using non-english language for Odysee, the signInVerify page is blank. This seemed to happen because language change reseted the `verificationTried` to the initial state(at least seemed to).

Steps to force the issue(running into it in normal use seemed to happen very randomly):
1. Be logged in
2. Open some old verification link in a new tab
3. See log in failed text
4. Change page language in the other tab
5. Login failed changed to blank page

Should be safe to merge, just a minor fix to something I wasn't aware of when making the changes to signInVerify page