### PR TITLE
Code-split chunk improvements

### DIFF
--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -195,7 +195,9 @@ const webConfig = {
     path: path.join(__dirname, `${output.DIR}/public`),
     publicPath: '/public/',
     chunkFilename: ({ chunk }) => {
-      return chunk.name && chunk.name.startsWith('locale-') ? 'locales/[name]-[chunkhash].js' : '[name]-[chunkhash].js';
+      return chunk.name && chunk.name.startsWith('locale-')
+        ? 'locales/[name]-[contenthash].js'
+        : '[name]-[contenthash].js';
     },
     assetModuleFilename: 'img/[name][ext]',
   },

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -40,6 +40,7 @@ let baseConfig = {
         },
       }),
     ],
+    moduleIds: 'deterministic',
   },
   node: {
     __dirname: false,


### PR DESCRIPTION
## Issue
Occasional chunk-load errors (not those from connection issues, but ones that fixes itself by clearing the cache).

## Changes
These are changes per Webpack 5 guide.

## Status:  `draft`
Will test it on salt first with actual production env for several builds (shadowing master) to see the produced output.
Locally, it looks more stable than previous configuration.

Meanwhile, feel free to review/comment.