### PR TITLE
Fix memoization for Recommendations

### DIFF
--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -340,7 +340,7 @@ export default function CommentList(props: Props) {
 
       const rect = spinnerRef.current.getBoundingClientRect(); // $FlowFixMe
       const windowH = window.innerHeight || document.documentElement.clientHeight; // $FlowFixMe
-      const windowW = window.innerWidth || document.documentElement.clientWidth; // $FlowFixMe
+      const windowW = window.innerWidth || document.documentElement.clientWidth;
 
       const isApproachingViewport = yPrefetchPx !== 0 && rect.top < windowH + scaleToDevicePixelRatio(yPrefetchPx);
 
@@ -349,9 +349,7 @@ export default function CommentList(props: Props) {
         rect.height > 0 &&
         rect.bottom >= 0 &&
         rect.right >= 0 &&
-        // $FlowFixMe
         rect.top <= windowH &&
-        // $FlowFixMe
         rect.left <= windowW;
 
       return (isInViewport || isApproachingViewport) && page < topLevelTotalPages;

--- a/ui/util/redux-utils.js
+++ b/ui/util/redux-utils.js
@@ -1,16 +1,19 @@
+// @flow
+
 // util for creating reducers
 // based off of redux-actions
 // https://redux-actions.js.org/docs/api/handleAction.html#handleactions
+export const handleActions =
+  (actionMap: any, defaultState: any) =>
+  (state: any = defaultState, action: any) => {
+    const handler = actionMap[action.type];
 
-export const handleActions = (actionMap, defaultState) => (state = defaultState, action) => {
-  const handler = actionMap[action.type];
+    if (handler) {
+      const newState = handler(state, action);
+      return Object.assign({}, state, newState);
+    }
 
-  if (handler) {
-    const newState = handler(state, action);
-    return Object.assign({}, state, newState);
-  }
-
-  // just return the original state if no handler
-  // returning a copy here breaks redux-persist
-  return state;
-};
+    // just return the original state if no handler
+    // returning a copy here breaks redux-persist
+    return state;
+  };

--- a/ui/util/redux-utils.js
+++ b/ui/util/redux-utils.js
@@ -17,3 +17,47 @@ export const handleActions =
     // returning a copy here breaks redux-persist
     return state;
   };
+
+/**
+ * A createSelector() optimizer that checks if the new result (object) has the
+ * same values as the previous results.
+ *
+ * Assumptions:
+ * (1) The keys are not compared. We assume that if the 'value' is pointing to
+ * the same reference as the previous result, the 'key' is most likely the same
+ * too.
+ *
+ * @param prev
+ * @param curr
+ * @returns {boolean|*}
+ */
+export function objSelectorEqualityCheck(prev: any, curr: any) {
+  if (!Array.isArray(prev) && !Array.isArray(curr) && typeof prev === 'object' && typeof curr === 'object') {
+    const prevValues = Object.values(prev);
+    const currValues = Object.values(curr);
+
+    if (prevValues.length === currValues.length) {
+      return prevValues.every((p, index) => p === currValues[index]);
+    }
+  }
+
+  return prev === curr;
+}
+
+/**
+ * A createSelector() optimizer that checks if the new array has the same values
+ * as the previous array.
+ *
+ * @param prev
+ * @param curr
+ * @returns {boolean|*}
+ */
+export function arrSelectorEqualityCheck(prev: any, curr: any) {
+  if (Array.isArray(prev) && Array.isArray(curr)) {
+    if (prev.length === curr.length) {
+      return prev.every((p, index) => p === curr[index]);
+    }
+  }
+
+  return prev === curr;
+}


### PR DESCRIPTION
## Issue
`selectRecommendedContentForUri` is an expensive one that is doing multiple loops. Also, the memoization did not work because `claimsById` will be invalidated for every `claim_search` that happens.

Before:
<img width="300" alt="image" src="https://github.com/OdyseeTeam/odysee-frontend/assets/64950861/1b65ca10-5e0c-49f8-899c-20abff4bf824">

After
<img width="300" alt="image" src="https://github.com/OdyseeTeam/odysee-frontend/assets/64950861/a56a8158-0866-4e84-a218-d1dd722320a1">


## Change
1. Break the selector into several parts. - The blocklist-filtering should not be in the same selector as the re-sort one, since the former only needs to run once. - Add another part that saves the subset `claimsById` that we need.
2. Fix the `claimsById` invalidation problem by checking and memoizing the subset. - This is not efficient given that work is already done anyway, but looking at the overall flow, the amount of work saved later (in both Redux and React) makes it worthwhile.

## Other things considered
1. Why always re-run the blocklist filtering?
     - Hm ... I just retained the old logic. One benefit of doing so is that if I unblock someone without refreshing, the recs will appear as expected.
2. Why filter the blocklist here?  Each tile is doing the filtering too ...
    - No idea. Maybe it's too late by then ... or can try in another PR.
