### PR TITLE
Fix autoplay-next looping between 2 claims

### DIFF
--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -50,7 +50,6 @@ export const selectRepostError = (state: State) => selectState(state).repostErro
 export const selectLatestByUri = (state: State) => selectState(state).latestByUri;
 export const selectResolvedCollectionsById = (state: State) => selectState(state).resolvedCollectionsById;
 export const selectMyCollectionClaimIds = (state: State) => selectState(state).myCollectionClaimIds;
-export const selectCostInfosById = (state: State) => selectState(state).costInfosById;
 
 export const selectMyCollectionClaimsById = createSelector(
   selectResolvedCollectionsById,
@@ -1137,10 +1136,7 @@ export const selectCostInfoForUri = (state: State, uri: string) => {
   const claimId = selectClaimIdForUri(state, uri);
   if (!claimId) return claimId;
 
-  const byId = selectCostInfosById(state);
-  const costInfo = byId[claimId];
-
-  return costInfo;
+  return state.claims.costInfosById[claimId];
 };
 
 export const selectSdkFeePendingForUri = (state: State, uri: string) => {


### PR DESCRIPTION
## Ticket
Closes #2637

## Root
e1b13013 removed the cost-by-uri map and the cleanup broke the meaning of the code here, since:
1. costInfo is an object, not number
2. it should be checking the cost of the recs, not itself

## Changes
1. Use the new cost-by-id map.
2. Start removing unnecessary selectors that have no transformation (https://redux.js.org/usage/deriving-data-selectors#balance-selector-usage)
