### PR TITLE
fix view log duplicates

### DIFF
--- a/extras/lbryinc/lbryio.js
+++ b/extras/lbryinc/lbryio.js
@@ -42,6 +42,12 @@ Lbryio.call = (resource, action, params = {}, method = 'post') => {
         let error;
         if (json.error) {
           error = new Error(json.error);
+        } else if (json.success === false) {
+          if (json.data) {
+            error = new Error(json.data);
+          } else {
+            error = new Error('Unknown API error signature');
+          }
         } else {
           error = new Error('Unknown API error signature');
         }

--- a/ui/component/streamClaimRenderInline/view.jsx
+++ b/ui/component/streamClaimRenderInline/view.jsx
@@ -52,9 +52,13 @@ class StreamClaimRenderInline extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { renderMode, embedded } = this.props;
+    const { renderMode, embedded, doAnalyticsViewForUri, uri, claimRewards, streamingUrl } = this.props;
     analytics.event.playerLoaded(renderMode, embedded);
 
+    if (uri && streamingUrl) {
+      this.setState({ prevUri: uri });
+      doAnalyticsViewForUri(uri).then(claimRewards);
+    }
     // @if TARGET='app'
     window.addEventListener('keydown', this.escapeListener, true);
     // @endif
@@ -67,8 +71,8 @@ class StreamClaimRenderInline extends React.PureComponent<Props, State> {
   }
 
   componentDidUpdate() {
-    const { doAnalyticsViewForUri, uri, claimRewards } = this.props;
-    if (uri && uri !== this.state.prevUri) {
+    const { doAnalyticsViewForUri, uri, claimRewards, streamingUrl } = this.props;
+    if (uri && streamingUrl && uri !== this.state.prevUri) {
       this.setState({ prevUri: uri });
       doAnalyticsViewForUri(uri).then(claimRewards);
     }

--- a/ui/component/streamClaimRenderInline/view.jsx
+++ b/ui/component/streamClaimRenderInline/view.jsx
@@ -39,11 +39,16 @@ type Props = {
   claimRewards: () => void,
 };
 
-class StreamClaimRenderInline extends React.PureComponent<Props> {
+type State = {
+  prevUri?: string,
+};
+
+class StreamClaimRenderInline extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
     (this: any).escapeListener = this.escapeListener.bind(this);
+    this.state = { prevUri: undefined };
   }
 
   componentDidMount() {
@@ -61,6 +66,14 @@ class StreamClaimRenderInline extends React.PureComponent<Props> {
     // @endif
   }
 
+  componentDidUpdate() {
+    const { doAnalyticsViewForUri, uri, claimRewards } = this.props;
+    if (uri && uri !== this.state.prevUri) {
+      this.setState({ prevUri: uri });
+      doAnalyticsViewForUri(uri).then(claimRewards);
+    }
+  }
+
   escapeListener(e: SyntheticKeyboardEvent<*>) {
     if (e.keyCode === KEYCODES.ESCAPE) {
       e.preventDefault();
@@ -74,19 +87,8 @@ class StreamClaimRenderInline extends React.PureComponent<Props> {
   }
 
   renderViewer() {
-    const {
-      currentTheme,
-      contentType,
-      downloadPath,
-      fileExtension,
-      streamingUrl,
-      uri,
-      renderMode,
-      doAnalyticsViewForUri,
-      claimRewards,
-    } = this.props;
+    const { currentTheme, contentType, downloadPath, fileExtension, streamingUrl, uri, renderMode } = this.props;
     const source = streamingUrl;
-    doAnalyticsViewForUri(uri).then(claimRewards);
 
     switch (renderMode) {
       case RENDER_MODES.IMAGE:


### PR DESCRIPTION
#2784
Tried using prevProps in componentDidUpdate, but it didn't seem to work.
Fires view log on every PDF once, even while navigating during floating player.