### PR TITLE
Only use short-urls for unlisted claims.

### DIFF
--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -12,7 +12,7 @@ import classnames from 'classnames';
 import { Menu, MenuButton, MenuList, MenuItem } from '@reach/menu-button';
 import { COLLECTION_PAGE as CP } from 'constants/urlParams';
 import Icon from 'component/common/icon';
-import { generateShareUrl, generateRssUrl, generateLbryContentUrl, generateShareUrlMaybeShortened } from 'util/url';
+import { generateShareUrl, generateRssUrl, generateLbryContentUrl, generateShortShareUrl } from 'util/url';
 import { useHistory } from 'react-router';
 import { getChannelIdFromClaim } from 'util/claim';
 import { buildURI, parseURI } from 'util/lbryURI';
@@ -264,7 +264,7 @@ function ClaimMenuList(props: Props) {
           if (accessKey === null) {
             throw new Error();
           } else {
-            generateShareUrlMaybeShortened(SHARE_DOMAIN, lbryUrl, null, null, false, null, null, accessKey)
+            generateShortShareUrl(SHARE_DOMAIN, lbryUrl, null, null, false, null, null, accessKey)
               .then((result) => {
                 copyToClipboard(result, 'Unlisted link copied.', 'Failed to copy link.');
               })

--- a/ui/component/socialShare/view.jsx
+++ b/ui/component/socialShare/view.jsx
@@ -17,7 +17,7 @@ import {
   generateLbryContentUrl,
   generateLbryWebUrl,
   generateEncodedLbryURL,
-  generateShareUrlMaybeShortened,
+  generateShortShareUrl,
   generateRssUrl,
 } from 'util/url';
 import { URL as SITE_URL, TWITTER_ACCOUNT, SHARE_DOMAIN_URL } from 'config';
@@ -123,9 +123,8 @@ function SocialShare(props: SocialShareStateProps) {
   const [showClaimLinks, setShowClaimLinks] = React.useState(false);
   const [includeStartTime, setincludeStartTime]: [boolean, any] = React.useState(false);
   const [startTime, setStartTime]: [string, any] = React.useState(secondsToHms(position));
-  const isUnlisted = isClaimUnlisted(claim);
   const showAdditionalShareOptions =
-    !isUnlisted && !isClaimPrivate(claim) && getClaimScheduledState(claim) === 'non-scheduled';
+    !isClaimUnlisted(claim) && !isClaimPrivate(claim) && getClaimScheduledState(claim) === 'non-scheduled';
   const startTimeSeconds: number = hmsToSeconds(startTime);
   const isMobile = useIsMobile();
 
@@ -222,7 +221,7 @@ function SocialShare(props: SocialShareStateProps) {
   }, [includeStartTime, shareUrl, startTimeSeconds]);
 
   React.useEffect(() => {
-    generateShareUrlMaybeShortened(
+    generateShortShareUrl(
       SHARE_DOMAIN,
       lbryUrl,
       referralCode,
@@ -230,8 +229,7 @@ function SocialShare(props: SocialShareStateProps) {
       includeStartTime,
       startTimeSeconds,
       includedCollectionId,
-      uriAccessKey,
-      isUnlisted
+      uriAccessKey
     )
       .then((result) => setShareUrl(result))
       .catch((err) => assert(false, 'SocialShare', err));

--- a/ui/component/socialShare/view.jsx
+++ b/ui/component/socialShare/view.jsx
@@ -17,6 +17,7 @@ import {
   generateLbryContentUrl,
   generateLbryWebUrl,
   generateEncodedLbryURL,
+  generateShareUrl,
   generateShortShareUrl,
   generateRssUrl,
 } from 'util/url';
@@ -147,7 +148,19 @@ function SocialShare(props: SocialShareStateProps) {
     startTimeSeconds,
     includedCollectionId
   );
-  const [shareUrl, setShareUrl] = React.useState('');
+  const [shareUrl, setShareUrl] = React.useState(() => {
+    return uriAccessKey
+      ? ''
+      : generateShareUrl(
+          SHARE_DOMAIN,
+          lbryUrl,
+          referralCode,
+          rewardsApproved,
+          includeStartTime,
+          startTimeSeconds,
+          includedCollectionId
+        );
+  });
   const downloadUrl = `${generateDownloadUrl(name, claimId)}`;
   const claimLinkElements: Array<Node> = getClaimLinkElements();
 
@@ -221,18 +234,20 @@ function SocialShare(props: SocialShareStateProps) {
   }, [includeStartTime, shareUrl, startTimeSeconds]);
 
   React.useEffect(() => {
-    generateShortShareUrl(
-      SHARE_DOMAIN,
-      lbryUrl,
-      referralCode,
-      rewardsApproved,
-      includeStartTime,
-      startTimeSeconds,
-      includedCollectionId,
-      uriAccessKey
-    )
-      .then((result) => setShareUrl(result))
-      .catch((err) => assert(false, 'SocialShare', err));
+    if (uriAccessKey) {
+      generateShortShareUrl(
+        SHARE_DOMAIN,
+        lbryUrl,
+        referralCode,
+        rewardsApproved,
+        includeStartTime,
+        startTimeSeconds,
+        includedCollectionId,
+        uriAccessKey
+      )
+        .then((result) => setShareUrl(result))
+        .catch((err) => assert(false, 'SocialShare', err));
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount
   }, []);
 

--- a/ui/util/url.js
+++ b/ui/util/url.js
@@ -164,7 +164,8 @@ export const generateShareUrl = (
   return url;
 };
 
-export const generateShareUrlMaybeShortened = async (
+// @flow
+export const generateShortShareUrl = async (
   domain,
   lbryUrl,
   referralCode,
@@ -172,8 +173,7 @@ export const generateShareUrlMaybeShortened = async (
   includeStartTime,
   startTime,
   listId,
-  uriAccessKey?: UriAccessKey,
-  shouldShorten
+  uriAccessKey?: UriAccessKey
 ) => {
   type Params = Array<[string, ?string]>;
 
@@ -184,7 +184,9 @@ export const generateShareUrlMaybeShortened = async (
     ['r', referralCode && rewardsApproved ? referralCode : null],
   ];
 
-  const paramsToRetain: Params = [['t', includeStartTime ? startTime.toString() : null]];
+  const paramsToRetain: Params = [
+    ['t', includeStartTime ? startTime.toString() : null],
+  ];
 
   // -- Build base URL with claim gists:
   const { streamName, streamClaimId, channelName, channelClaimId } = parseURI(lbryUrl);
@@ -208,10 +210,6 @@ export const generateShareUrlMaybeShortened = async (
       urlToShorten.searchParams.set(p[0], p[1]);
     }
   });
-
-  if (!shouldShorten) {
-    return urlToShorten.toString();
-  }
 
   // -- Fetch the short url:
   const shortUrl = await ShortUrl.createFrom(urlToShorten.toString())


### PR DESCRIPTION
Patch for #2794 -- just needed to split the calls.