### PR TITLE
CommentView: add type-safety

### DIFF
--- a/ui/component/comment/index.js
+++ b/ui/component/comment/index.js
@@ -1,8 +1,10 @@
+// @flow
+import type { Props } from './view';
+import Comment from './view';
 import { connect } from 'react-redux';
 import {
   selectStakedLevelForChannelUri,
   selectClaimForUri,
-  selectThumbnailForUri,
   selectHasChannels,
   selectMyClaimIdsRaw,
   selectTitleForUri,
@@ -26,7 +28,6 @@ import { selectActiveChannelClaim } from 'redux/selectors/app';
 import { selectPlayingUri } from 'redux/selectors/content';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { getChannelIdFromClaim } from 'util/claim';
-import Comment from './view';
 
 const select = (state, props) => {
   const { comment, uri } = props;
@@ -43,7 +44,6 @@ const select = (state, props) => {
   return {
     myChannelIds: selectMyClaimIdsRaw(state),
     claim,
-    thumbnail: channel_url && selectThumbnailForUri(state, channel_url),
     commentingEnabled: Boolean(selectUserVerifiedEmail(state)),
     othersReacts: selectOthersReactsForComment(state, reactionKey),
     activeChannelClaim,
@@ -53,10 +53,10 @@ const select = (state, props) => {
     linkedCommentAncestors: selectFetchedCommentAncestors(state),
     totalReplyPages: makeSelectTotalReplyPagesForParentId(comment_id)(state),
     odyseeMembership: selectOdyseeMembershipForChannelId(state, channel_id),
-    creatorMembership: selectMembershipForCreatorOnlyIdAndChannelId(state, creatorId, channel_id),
+    creatorMembership: selectMembershipForCreatorOnlyIdAndChannelId(state, creatorId || '', channel_id) || '',
     repliesFetching: selectIsFetchingCommentsForParentId(state, comment_id),
     fetchedReplies: selectRepliesForParentId(state, comment_id),
-    authorTitle: selectTitleForUri(state, channel_url),
+    authorTitle: channel_url ? selectTitleForUri(state, channel_url) : null,
     channelAge,
   };
 };
@@ -69,4 +69,4 @@ const perform = {
   doToast,
 };
 
-export default connect(select, perform)(Comment);
+export default connect<_, Props, _, _, _, _>(select, perform)(Comment);

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -52,51 +52,58 @@ import { lazyImport } from 'util/lazyImport';
 const AUTO_EXPAND_ALL_REPLIES = false;
 const CommentCreate = lazyImport(() => import('component/commentCreate' /* webpackChunkName: "comments" */));
 
-type Props = {
+// ****************************************************************************
+// ****************************************************************************
+
+export type Props = {|
   comment: Comment,
-  myChannelIds: ?Array<string>,
-  forceDisplayDeadComment?: boolean,
-  doClearPlayingUri: () => void,
   uri: string,
-  claim: StreamClaim,
-  claimIsMine: boolean, // if you control the claim which this comment was posted on
-  updateComment: (string, string) => void,
-  fetchReplies: (string, string, number, number, number) => void,
-  totalReplyPages: number,
-  commentModBlock: (string) => void,
+  forceDisplayDeadComment?: boolean,
   linkedCommentId?: string,
-  threadCommentId?: string,
-  linkedCommentAncestors: { [string]: Array<string> },
-  hasChannels: boolean,
-  commentingEnabled: boolean,
-  doToast: ({ message: string }) => void,
+  threadCommentId?: ?string,
   isTopLevel?: boolean,
   hideActions?: boolean,
   hideContextMenu?: boolean,
-  othersReacts: ?{
-    like: number,
-    dislike: number,
-  },
-  commentIdentityChannel: any,
-  activeChannelClaim: ?ChannelClaim,
-  playingUri: PlayingUri,
-  stakedLevel: number,
-  supportDisabled: boolean,
-  setQuickReply: (any) => void,
-  quickReply: any,
-  odyseeMembership: ?string,
-  creatorMembership: ?string,
-  fetchedReplies: Array<Comment>,
-  repliesFetching: boolean,
+  supportDisabled?: boolean,
+  setQuickReply?: (any) => void,
+  quickReply?: any,
   threadLevel?: number,
   threadDepthLevel?: number,
-  authorTitle: string,
-  channelAge?: any,
   disabled?: boolean,
-  doClearPlayingSource: () => void,
-};
+|};
 
-function CommentView(props: Props) {
+type StateProps = {|
+  fetchedReplies: Array<Comment>,
+  othersReacts: ?{ like: number, dislike: number },
+  linkedCommentAncestors: { [string]: Array<string> },
+  totalReplyPages: number,
+  repliesFetching: boolean,
+  activeChannelClaim: ?ChannelClaim,
+  claim: StreamClaim,
+  authorTitle: ?string,
+  channelAge?: any,
+  myChannelIds: ?Array<string>,
+  hasChannels: boolean,
+  odyseeMembership: ?string,
+  creatorMembership: ?string,
+  commentingEnabled: boolean,
+  playingUri: PlayingUri,
+  stakedLevel: number,
+|};
+
+type DispatchProps = {|
+  doClearPlayingUri: () => void,
+  doClearPlayingSource: () => void,
+  updateComment: (string, string) => void,
+  fetchReplies: (string, string, number, number, number) => void,
+  doToast: (ToastParams) => void,
+|};
+
+// ****************************************************************************
+// Comment
+// ****************************************************************************
+
+function CommentView(props: Props & StateProps & DispatchProps) {
   const {
     comment,
     myChannelIds,

--- a/ui/component/commentsList/index.js
+++ b/ui/component/commentsList/index.js
@@ -1,3 +1,6 @@
+// @flow
+import type { Props } from './view';
+import CommentsList from './view';
 import { connect } from 'react-redux';
 import {
   selectClaimForUri,
@@ -30,7 +33,6 @@ import {
   doFetchChannelMembershipsForChannelIds,
 } from 'redux/actions/memberships';
 import { selectUserHasValidMembershipForCreatorId } from 'redux/selectors/memberships';
-import CommentsList from './view';
 
 const select = (state, props) => {
   const { uri, threadCommentId, linkedCommentId } = props;
@@ -50,11 +52,13 @@ const select = (state, props) => {
     claimId: claim && claim.claim_id,
     claimIsMine: selectClaimIsMine(state, claim),
     fetchingChannels: selectFetchingMyChannels(state),
+    // $FlowFixMe
     isAChannelMember: selectUserHasValidMembershipForCreatorId(state, channelId),
     isFetchingComments: selectIsFetchingComments(state),
     isFetchingReacts: selectIsFetchingReacts(state),
     isFetchingTopLevelComments: selectIsFetchingTopLevelComments(state),
     linkedCommentAncestors: selectCommentAncestorsForId(state, linkedCommentId),
+    // $FlowFixMe
     commentsEnabledSetting: selectCommentsEnabledSettingForChannelId(state, channelId),
     myReactsByCommentId: selectMyReacts(state),
     othersReactsById: selectOthersReacts(state),
@@ -78,4 +82,4 @@ const perform = {
   doPopOutInlinePlayer,
 };
 
-export default connect(select, perform)(CommentsList);
+export default connect<_, Props, _, _, _, _>(select, perform)(CommentsList);

--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -34,31 +34,43 @@ function scaleToDevicePixelRatio(value) {
   return Math.ceil(value * devicePixelRatio);
 }
 
-type Props = {
-  allCommentIds: any,
-  pinnedComments: Array<Comment>,
-  topLevelComments: Array<Comment>,
-  topLevelTotalPages: number,
+// ****************************************************************************
+// ****************************************************************************
+
+export type Props = {|
   uri: string,
-  claimId?: string,
-  channelId?: string,
-  claimIsMine: boolean,
+  linkedCommentId?: string,
+  commentsAreExpanded?: boolean,
+  threadCommentId: ?string,
+  notInDrawer?: boolean,
+|};
+
+type StateProps = {|
+  topLevelComments: Array<Comment>,
+  pinnedComments: Array<Comment>,
+  allCommentIds: Array<CommentId>,
+  threadComment: ?Comment, // comment object for 'threadCommentId'
+  totalComments: number,
+  topLevelTotalPages: number,
+  threadCommentAncestors: ?Array<string>,
+  linkedCommentAncestors: ?Array<string>,
+  myReactsByCommentId: ?{ [string]: Array<string> }, // "CommentId:MyChannelId" -> reaction array (note the ID concatenation)
+  othersReactsById: ?{ [string]: { [REACTION_TYPES.LIKE | REACTION_TYPES.DISLIKE]: number } },
+  commentsEnabledSetting: ?boolean,
+  claimId: ?string,
+  channelId: ?string,
+  claimIsMine: ?boolean,
+  activeChannelId: ?string,
   isFetchingComments: boolean,
   isFetchingTopLevelComments: boolean,
   isFetchingReacts: boolean,
-  linkedCommentId?: string,
-  totalComments: number,
   fetchingChannels: boolean,
-  myReactsByCommentId: ?{ [string]: Array<string> }, // "CommentId:MyChannelId" -> reaction array (note the ID concatenation)
-  othersReactsById: ?{ [string]: { [REACTION_TYPES.LIKE | REACTION_TYPES.DISLIKE]: number } },
-  activeChannelId: ?string,
-  commentsEnabledSetting: ?boolean,
-  commentsAreExpanded?: boolean,
-  threadCommentId: ?string,
-  threadComment: ?Comment,
-  notInDrawer?: boolean,
-  threadCommentAncestors: ?Array<string>,
-  linkedCommentAncestors: ?Array<string>,
+  chatCommentsRestrictedToChannelMembers: boolean,
+  isAChannelMember: boolean,
+  scheduledState: ClaimScheduledState,
+|};
+
+type DispatchProps = {|
   fetchTopLevelComments: (
     uri: string,
     parentId: ?string,
@@ -67,19 +79,19 @@ type Props = {
     sortBy: number,
     isLivestream?: boolean
   ) => void,
-  fetchComment: (commentId: string) => void,
-  fetchReacts: (commentIds: Array<string>) => Promise<any>,
-  resetComments: (claimId: string) => void,
+  fetchComment: (CommentId) => void,
+  fetchReacts: (Array<CommentId>) => Promise<any>,
+  resetComments: (ClaimId) => void,
   doFetchOdyseeMembershipForChannelIds: (claimIds: ClaimIds) => void,
-  doPopOutInlinePlayer: (param: { source: string }) => void,
   doFetchChannelMembershipsForChannelIds: (channelId: string, claimIds: Array<string>) => void,
-  creatorsMemberships: Array<Membership>,
-  chatCommentsRestrictedToChannelMembers: boolean,
-  isAChannelMember: boolean,
-  scheduledState: ClaimScheduledState,
-};
+  doPopOutInlinePlayer: (param: { source: string }) => void,
+|};
 
-export default function CommentList(props: Props) {
+// ****************************************************************************
+// CommentList
+// ****************************************************************************
+
+export default function CommentList(props: Props & StateProps & DispatchProps) {
   const {
     allCommentIds,
     uri,

--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -382,11 +382,11 @@ export default function CommentList(props: Props) {
   const commentProps = {
     isTopLevel: true,
     uri,
-    claimIsMine,
     linkedCommentId,
     threadCommentId,
     threadDepthLevel,
   };
+
   const actionButtonsProps = {
     uri,
     totalComments,
@@ -442,10 +442,15 @@ export default function CommentList(props: Props) {
           >
             {readyToDisplayComments && (
               <>
-                {pinnedComments && !threadCommentId && (
-                  <CommentElements comments={pinnedComments} disabled={notAuthedToChat} {...commentProps} />
-                )}
-                <CommentElements comments={topLevelComments} disabled={notAuthedToChat} {...commentProps} />
+                {pinnedComments &&
+                  !threadCommentId &&
+                  pinnedComments.map((c) => (
+                    <CommentView key={c.comment_id} comment={c} disabled={notAuthedToChat} {...commentProps} />
+                  ))}
+
+                {topLevelComments.map((c) => (
+                  <CommentView key={c.comment_id} comment={c} disabled={notAuthedToChat} {...commentProps} />
+                ))}
               </>
             )}
           </ul>
@@ -493,19 +498,6 @@ export default function CommentList(props: Props) {
     />
   );
 }
-
-type CommentProps = {
-  comments: Array<Comment>,
-  disabled?: boolean,
-};
-
-const CommentElements = (commentProps: CommentProps) => {
-  const { comments, disabled, ...commentsProps } = commentProps;
-
-  return comments.map((comment) => (
-    <CommentView key={comment.comment_id} comment={comment} disabled={disabled} {...commentsProps} />
-  ));
-};
 
 type ActionButtonsProps = {
   uri: string,

--- a/ui/component/commentsReplies/index.js
+++ b/ui/component/commentsReplies/index.js
@@ -1,6 +1,8 @@
+// @flow
+import type { Props } from './view';
+import CommentsReplies from './view';
 import { connect } from 'react-redux';
 import { selectIsFetchingCommentsForParentId, selectRepliesForParentId } from 'redux/selectors/comments';
-import CommentsReplies from './view';
 
 const select = (state, props) => {
   const { parentId } = props;
@@ -11,4 +13,4 @@ const select = (state, props) => {
   };
 };
 
-export default connect(select)(CommentsReplies);
+export default connect<_, Props, _, _, _, _>(select, {})(CommentsReplies);

--- a/ui/component/commentsReplies/index.js
+++ b/ui/component/commentsReplies/index.js
@@ -1,14 +1,12 @@
 import { connect } from 'react-redux';
-import { selectClaimIsMineForUri } from 'redux/selectors/claims';
 import { selectIsFetchingCommentsForParentId, selectRepliesForParentId } from 'redux/selectors/comments';
 import CommentsReplies from './view';
 
 const select = (state, props) => {
-  const { uri, parentId } = props;
+  const { parentId } = props;
 
   return {
     fetchedReplies: selectRepliesForParentId(state, parentId),
-    claimIsMine: selectClaimIsMineForUri(state, uri),
     isFetching: selectIsFetchingCommentsForParentId(state, parentId),
   };
 };

--- a/ui/component/commentsReplies/view.jsx
+++ b/ui/component/commentsReplies/view.jsx
@@ -4,22 +4,34 @@ import Comment from 'component/comment';
 import React from 'react';
 import Spinner from 'component/spinner';
 
-type Props = {
+// ****************************************************************************
+// ****************************************************************************
+
+export type Props = {|
   uri: string,
+  parentId: CommentId,
   linkedCommentId?: string,
-  threadCommentId?: string,
+  threadCommentId?: ?string,
   numDirectReplies: number, // Total replies for parentId as reported by 'comment[replies]'. Includes blocked items.
   hasMore: boolean,
-  supportDisabled: boolean,
+  supportDisabled?: boolean,
   threadDepthLevel?: number,
   onShowMore?: () => void,
-  // redux
-  fetchedReplies: Array<Comment>,
   threadLevel: number,
-  isFetching: boolean,
-};
+|};
 
-export default function CommentsReplies(props: Props) {
+type StateProps = {|
+  fetchedReplies: Array<Comment>,
+  isFetching: boolean,
+|};
+
+type DispatchProps = {||};
+
+// ****************************************************************************
+// CommentsReplies
+// ****************************************************************************
+
+export default function CommentsReplies(props: Props & StateProps & DispatchProps) {
   const {
     uri,
     fetchedReplies,

--- a/ui/component/commentsReplies/view.jsx
+++ b/ui/component/commentsReplies/view.jsx
@@ -15,7 +15,6 @@ type Props = {
   onShowMore?: () => void,
   // redux
   fetchedReplies: Array<Comment>,
-  claimIsMine: boolean,
   threadLevel: number,
   isFetching: boolean,
 };
@@ -24,7 +23,6 @@ export default function CommentsReplies(props: Props) {
   const {
     uri,
     fetchedReplies,
-    claimIsMine,
     linkedCommentId,
     threadCommentId,
     numDirectReplies,
@@ -41,10 +39,11 @@ export default function CommentsReplies(props: Props) {
       <ul className="comment__replies">
         {fetchedReplies.map((comment) => (
           <Comment
+            // $FlowIgnore
             key={comment.comment_id}
             uri={uri}
+            // $FlowIgnore
             comment={comment}
-            claimIsMine={claimIsMine}
             linkedCommentId={linkedCommentId}
             threadCommentId={threadCommentId}
             supportDisabled={supportDisabled}

--- a/ui/component/reportContent/view.jsx
+++ b/ui/component/reportContent/view.jsx
@@ -782,6 +782,7 @@ export default function ReportContent(props: Props) {
   function getCommentPreviews(comment: ?Comment) {
     return comment ? (
       <div className="section non-clickable">
+        {/* $FlowIgnore: null comment handled */}
         <Comment comment={comment} isTopLevel hideActions hideContextMenu />
       </div>
     ) : null;

--- a/ui/modal/modalRemoveComment/view.jsx
+++ b/ui/modal/modalRemoveComment/view.jsx
@@ -34,6 +34,7 @@ function ModalRemoveComment(props: Props) {
   function getCommentPreview(comment: ?Comment) {
     return comment ? (
       <div className="section comment-preview non-clickable">
+        {/* $FlowIgnore: null comment handled */}
         <Comment comment={comment} isTopLevel hideActions hideContextMenu forceDisplayDeadComment />
       </div>
     ) : null;

--- a/ui/page/ownComments/view.jsx
+++ b/ui/page/ownComments/view.jsx
@@ -127,7 +127,7 @@ export default function OwnComments(props: Props) {
 
       const rect = spinnerRef.current.getBoundingClientRect(); // $FlowFixMe
       const windowH = window.innerHeight || document.documentElement.clientHeight; // $FlowFixMe
-      const windowW = window.innerWidth || document.documentElement.clientWidth; // $FlowFixMe
+      const windowW = window.innerWidth || document.documentElement.clientWidth;
 
       const isApproachingViewport = yPrefetchPx !== 0 && rect.top < windowH + scaleToDevicePixelRatio(yPrefetchPx);
 
@@ -136,9 +136,7 @@ export default function OwnComments(props: Props) {
         rect.height > 0 &&
         rect.bottom >= 0 &&
         rect.right >= 0 &&
-        // $FlowFixMe
         rect.top <= windowH &&
-        // $FlowFixMe
         rect.left <= windowW;
 
       return (isInViewport || isApproachingViewport) && page < topLevelTotalPages;


### PR DESCRIPTION
Sorry, I dislike major movements like these too, but type-safety is required for the upcoming optimization rework to find all usages.

This commit is primarily just:
- moving the prop types into their respective groups.
- fixing potential bad scenarios that Flow found.
- removing unused items that Flow found.
