### PR TITLE
PDF: manually fetch so that Origin is sent

### DIFF
--- a/ui/component/IframeReact/view.jsx
+++ b/ui/component/IframeReact/view.jsx
@@ -1,14 +1,22 @@
 // @flow
 import React from 'react';
+import Spinner from 'component/spinner';
+import FileExporter from 'component/common/file-exporter';
+import { platform } from 'util/platform';
 
 type Props = {
-  fullHeight: boolean,
-  src: string,
+  src: ?string,
   title: string,
+  useDirectFetch?: boolean, // Fetch from application domain and pass the blob to the iframe
 };
 
 export default function I18nMessage(props: Props) {
-  const { src, title } = props;
+  const { src, title, useDirectFetch } = props;
+
+  // undefined = go fetch; null = skip fetch or failed;
+  const [blob, setBlob] = React.useState(useDirectFetch ? undefined : null);
+
+  const blobInIFrameNotAllowed = platform.isAndroid() && platform.isMobileChrome();
 
   // const iframeRef = useRef();
 
@@ -27,9 +35,56 @@ export default function I18nMessage(props: Props) {
     */
   }
 
+  function getFileNameFromUrl(url: string) {
+    return url.split(/[=/_]/).pop();
+  }
+
+  React.useEffect(() => {
+    if (src && blob === undefined) {
+      fetch(src)
+        .then((response) => {
+          if (response.ok) {
+            return response.blob();
+          } else {
+            assert(false, 'Failed to fetch', { src, response });
+            throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
+          }
+        })
+        .then((blob) => setBlob(blob))
+        .catch(() => setBlob(null));
+    }
+  }, [blob, src]);
+
+  // We try the blob method first to allow sending the Origin header.
+  // If that fails (blob === null), we use the original method
+  // (i.e. load src directly).
+
+  if (blob === undefined) {
+    return (
+      <div className="main--empty">
+        <Spinner small />
+      </div>
+    );
+  }
+
+  if (blobInIFrameNotAllowed && blob && src) {
+    return (
+      <FileExporter
+        data={blob}
+        mimeType="application/pdf"
+        label={__('Open')}
+        tooltip={__('Open PDF')}
+        defaultFileName={`${getFileNameFromUrl(src)}.pdf`}
+      />
+    );
+  }
+
   return (
-    // style={{height: iframeHeight}}
-    // ref={iframeRef}
-    <iframe src={src} title={title} onLoad={onLoad} sandbox={!IS_WEB} />
+    <iframe
+      src={blob ? (window.URL || window.webkitURL).createObjectURL(blob) : src}
+      title={title}
+      onLoad={onLoad}
+      sandbox={!IS_WEB}
+    />
   );
 }

--- a/ui/component/common/file-exporter.jsx
+++ b/ui/component/common/file-exporter.jsx
@@ -7,6 +7,7 @@ import Spinner from 'component/spinner';
 
 type Props = {
   data: any,
+  mimeType?: string,
   label: string,
   tooltip?: string,
   defaultFileName?: string,
@@ -23,10 +24,10 @@ class FileExporter extends React.PureComponent<Props> {
   }
 
   handleDownload() {
-    const { data, defaultFileName } = this.props;
+    const { data, mimeType, defaultFileName } = this.props;
 
     const element = document.createElement('a');
-    const file = new Blob([data], { type: 'text/plain' });
+    const file = new Blob([data], { type: mimeType || 'text/plain' });
     element.href = URL.createObjectURL(file);
     element.download = defaultFileName || 'file.txt';
     // $FlowFixMe

--- a/ui/component/viewers/pdfViewer.jsx
+++ b/ui/component/viewers/pdfViewer.jsx
@@ -2,22 +2,21 @@
 import * as React from 'react';
 import IframeReact from 'component/IframeReact';
 
-type Props = {
+type Props = {|
   source: string,
-};
+|};
 
-class PdfViewer extends React.PureComponent<Props> {
-  render() {
-    const { source } = this.props;
-    const src = IS_WEB ? source : `file://${source}`;
-    return (
-      <div className="file-viewer file-viewer--document">
-        <div className="file-viewer file-viewer--iframe">
-          <IframeReact title={__('File preview')} src={src} />
-        </div>
+function PdfViewer(props: Props) {
+  const { source } = props;
+  const src = IS_WEB ? source : `file://${source}`;
+
+  return (
+    <div className="file-viewer file-viewer--document">
+      <div className="file-viewer file-viewer--iframe">
+        <IframeReact title={__('File preview')} src={src} />
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 export default PdfViewer;

--- a/ui/component/viewers/pdfViewer.jsx
+++ b/ui/component/viewers/pdfViewer.jsx
@@ -13,7 +13,7 @@ function PdfViewer(props: Props) {
   return (
     <div className="file-viewer file-viewer--document">
       <div className="file-viewer file-viewer--iframe">
-        <IframeReact title={__('File preview')} src={src} />
+        <IframeReact title={__('File preview')} src={src} useDirectFetch />
       </div>
     </div>
   );


### PR DESCRIPTION
## Ticket
Closes #2783

The backend needs the Origin header to serve the PDF, but on the app, PDFs are being sandboxed in an iframe (isolated origin or null).

## Change
Manually fetch the file from the application domain, then pass the blob to the iframe.

Fall back to original method if that fails.
