### PR TITLE
Prevent uncaught ad errors being treated as "crash"

### DIFF
--- a/ui/component/app/view.jsx
+++ b/ui/component/app/view.jsx
@@ -556,14 +556,10 @@ function App(props: Props) {
           {!hasPremiumPlus && !embedPath && <Ad type="sticky" uri={uri} />}
           <Router uri={uri} />
           <ModalRouter />
-
           <React.Suspense fallback={null}>{renderFiledrop && <FileDrop />}</React.Suspense>
-
           {!embedPath && <VideoRenderFloating />}
-
           <React.Suspense fallback={null}>
             {isEnhancedLayout && <Yrbl className="yrbl--enhanced" />}
-
             <YoutubeWelcome />
             {!shouldHideNag && <NagContinueFirstRun />}
             {fromLbrytvParam && !seenSunsestMessage && !shouldHideNag && (
@@ -572,8 +568,6 @@ function App(props: Props) {
             {getStatusNag()}
             {useDebugLog && <DebugLog />}
           </React.Suspense>
-
-          <AdBlockTester />
         </AppContext.Provider>
       )}
     </div>

--- a/web/component/ad/adErrorBoundary.jsx
+++ b/web/component/ad/adErrorBoundary.jsx
@@ -1,0 +1,41 @@
+/**
+ * - Prevents uncaught ad errors from being propagated and shown as a "crash".
+ * - Errors will still be reported to Sentry.
+ * - JSX fallbacks to null (show nothing).
+ */
+
+// @flow
+import React from 'react';
+import * as Sentry from '@sentry/react';
+
+const beforeCapture = (scope) => {
+  scope.setTag('_origin', 'adErrorBoundary');
+};
+
+// ****************************************************************************
+// ****************************************************************************
+
+export type Props = {|
+  type: 'tileA' | 'tileB' | 'sticky' | 'aboveComments',
+  children: any,
+|};
+
+// ****************************************************************************
+// ****************************************************************************
+
+function AdErrorBoundary(props: Props) {
+  const { type, children } = props;
+
+  const handleError = React.useCallback(
+    (err) => assert(false, `Suppressed uncaught Ad error from "${type}"`, err),
+    [type]
+  );
+
+  return (
+    <Sentry.ErrorBoundary fallback={null} beforeCapture={beforeCapture} onError={handleError}>
+      {children}
+    </Sentry.ErrorBoundary>
+  );
+}
+
+export default AdErrorBoundary;

--- a/web/component/ad/index.js
+++ b/web/component/ad/index.js
@@ -1,9 +1,11 @@
+// @flow
+import type { Props } from './view';
+import Ad from './view';
 import { connect } from 'react-redux';
 import { selectShouldShowAds } from 'redux/selectors/app';
 import { selectHomepageCategoryChannelIds } from 'redux/selectors/settings';
 import { selectClaimForUri } from 'redux/selectors/claims';
 import { getChannelIdFromClaim } from 'util/claim';
-import Ad from './view';
 
 const select = (state, props) => {
   const claim = selectClaimForUri(state, props.uri);
@@ -15,4 +17,4 @@ const select = (state, props) => {
   };
 };
 
-export default connect(select)(Ad);
+export default connect<_, Props, _, _, _, _>(select, {})(Ad);

--- a/web/component/ad/tileA/index.js
+++ b/web/component/ad/tileA/index.js
@@ -3,14 +3,11 @@ import type { Props } from './view';
 import AdTileA from './view';
 import { connect } from 'react-redux';
 import { selectShouldShowAds } from 'redux/selectors/app';
-import { doSetAdBlockerFound } from 'redux/actions/app';
 
 const select = (state, props) => ({
   shouldShowAds: selectShouldShowAds(state),
 });
 
-const perform = {
-  doSetAdBlockerFound,
-};
+const perform = {};
 
 export default connect<_, Props, _, _, _, _>(select, perform)(AdTileA);

--- a/web/component/ad/tileA/index.js
+++ b/web/component/ad/tileA/index.js
@@ -1,7 +1,9 @@
+// @flow
+import type { Props } from './view';
+import AdTileA from './view';
 import { connect } from 'react-redux';
 import { selectShouldShowAds } from 'redux/selectors/app';
 import { doSetAdBlockerFound } from 'redux/actions/app';
-import AdTileA from './view';
 
 const select = (state, props) => ({
   shouldShowAds: selectShouldShowAds(state),
@@ -11,4 +13,4 @@ const perform = {
   doSetAdBlockerFound,
 };
 
-export default connect(select, perform)(AdTileA);
+export default connect<_, Props, _, _, _, _>(select, perform)(AdTileA);

--- a/web/component/ad/tileA/index.js
+++ b/web/component/ad/tileA/index.js
@@ -1,12 +1,9 @@
 import { connect } from 'react-redux';
 import { selectShouldShowAds } from 'redux/selectors/app';
-import { makeSelectClaimForUri, selectClaimIsNsfwForUri } from 'redux/selectors/claims';
 import { doSetAdBlockerFound } from 'redux/actions/app';
 import AdTileA from './view';
 
 const select = (state, props) => ({
-  claim: makeSelectClaimForUri(props.uri)(state),
-  isMature: selectClaimIsNsfwForUri(state, props.uri),
   shouldShowAds: selectShouldShowAds(state),
 });
 

--- a/web/component/ad/tileA/view.jsx
+++ b/web/component/ad/tileA/view.jsx
@@ -19,17 +19,14 @@ type StateProps = {|
   shouldShowAds: boolean,
 |};
 
-type DispatchProps = {|
-  doSetAdBlockerFound: (boolean) => void,
-|};
+type DispatchProps = {||};
 
 // ****************************************************************************
 // Ads
 // ****************************************************************************
 
 function AdTileA(props: Props & StateProps & DispatchProps) {
-  const { tileLayout, shouldShowAds, noFallback, doSetAdBlockerFound } = props;
-  const ref = React.useRef();
+  const { tileLayout, shouldShowAds, noFallback } = props;
 
   React.useEffect(() => {
     if (shouldShowAds) {
@@ -48,21 +45,12 @@ function AdTileA(props: Props & StateProps & DispatchProps) {
     }
   }, [shouldShowAds]);
 
-  React.useEffect(() => {
-    if (ref.current) {
-      const mountedStyle = getComputedStyle(ref.current);
-      doSetAdBlockerFound(mountedStyle?.display === 'none');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
-  }, []);
-
   if (shouldShowAds) {
     return (
       <li className="claim-preview--tile">
         <div
           className="rc_tile"
           id="rc-widget-fceddd"
-          ref={ref}
           data-rc-widget
           data-widget-host="habitat"
           data-endpoint="//trends.revcontent.com"

--- a/web/component/ad/tileA/view.jsx
+++ b/web/component/ad/tileA/view.jsx
@@ -2,32 +2,37 @@
 import React from 'react';
 import PremiumPlusTile from 'component/premiumPlusTile';
 
-const DISABLE_VIDEO_AD = false;
-
 // prettier-ignore
 const AD_CONFIG = Object.freeze({
   url: 'https://assets.revcontent.com/master/delivery.js',
 });
 
 // ****************************************************************************
+// ****************************************************************************
+
+export type Props = {|
+  tileLayout?: boolean,
+  noFallback?: boolean,
+|};
+
+type StateProps = {|
+  shouldShowAds: boolean,
+|};
+
+type DispatchProps = {|
+  doSetAdBlockerFound: (boolean) => void,
+|};
+
+// ****************************************************************************
 // Ads
 // ****************************************************************************
 
-type Props = {
-  tileLayout?: boolean,
-  className?: string,
-  noFallback?: boolean,
-  // --- redux ---
-  shouldShowAds: boolean,
-  doSetAdBlockerFound: (boolean) => void,
-};
-
-function AdTileA(props: Props) {
+function AdTileA(props: Props & StateProps & DispatchProps) {
   const { tileLayout, shouldShowAds, noFallback, doSetAdBlockerFound } = props;
   const ref = React.useRef();
 
   React.useEffect(() => {
-    if (shouldShowAds && !DISABLE_VIDEO_AD) {
+    if (shouldShowAds) {
       let script;
       try {
         script = document.createElement('script');

--- a/web/component/ad/view.jsx
+++ b/web/component/ad/view.jsx
@@ -14,16 +14,27 @@ const AD_CONFIG = Object.freeze({
   },
 });
 
-type Props = {
-  type: string,
-  uri?: string,
+// ****************************************************************************
+// ****************************************************************************
+
+export type Props = {|
+  type: 'tileA' | 'tileB' | 'sticky' | 'aboveComments',
+  uri?: ClaimUri,
   tileLayout?: boolean,
+|};
+
+type StateProps = {|
   shouldShowAds: boolean,
   channelIdWhitelist?: ?any,
-  channelId: any,
-};
+  channelId: ?ChannelId,
+|};
 
-function Ad(props: Props) {
+type DispatchProps = {||};
+
+// ****************************************************************************
+// ****************************************************************************
+
+function Ad(props: Props & StateProps & DispatchProps) {
   const { type, uri, tileLayout, shouldShowAds, channelIdWhitelist, channelId } = props;
   const device = useIsMobile() ? 'mobile' : 'desktop';
   const provider = channelIdWhitelist && channelIdWhitelist.includes(channelId) ? 'publir' : 'revcontent';

--- a/web/component/ad/view.jsx
+++ b/web/component/ad/view.jsx
@@ -4,6 +4,7 @@ import AdTileA from './tileA';
 import AdTileB from './tileB';
 import AdSticky from './adSticky';
 import AdAboveComments from './aboveComments';
+import AdErrorBoundary from './adErrorBoundary';
 import { useIsMobile } from 'effects/use-screensize';
 
 const AD_CONFIG = Object.freeze({
@@ -70,14 +71,14 @@ function Ad(props: Props & StateProps & DispatchProps) {
   }
 
   return (
-    <>
+    <AdErrorBoundary type={type}>
       {type === 'tileA' && <AdTileA tileLayout={tileLayout} />}
       {type === 'tileB' && <AdTileB provider={provider} device={device} />}
       {type === 'sticky' && <AdSticky uri={uri} />}
       {type === 'aboveComments' && (
         <AdAboveComments provider={provider} device={device} shouldShowAds={shouldShowAds} />
       )}
-    </>
+    </AdErrorBoundary>
   );
 }
 


### PR DESCRIPTION
## Issue
Closes #2833, `LBRY-DESKTOP-WEB-1AQS`
With the ad being a react component, any uncaught error will be treated like our own and crashes the site.

## Change
- Use error-boundary to capture and stop propagation of ad errors.
- Info will still go to Sentry, but the view will simply fallback to null and the rest of the site unaffected.
