### PR TITLE
Don't crash from ad js errors

### DIFF
--- a/web/component/ad/aboveComments/view.jsx
+++ b/web/component/ad/aboveComments/view.jsx
@@ -1,6 +1,9 @@
 // @flow
 import React from 'react';
-import { PublirAdsProvider, AdSlot } from '../publir-react-plugin/';
+import { importPublir } from '../util/importPublir';
+
+const PublirAdsProvider = importPublir('PublirAdsProvider');
+const AdSlot = importPublir('AdSlot');
 
 // prettier-ignore
 const AD_CONFIG = Object.freeze({
@@ -69,9 +72,11 @@ function AdAboveComments(props: Props) {
         />
       )}
       {provider === 'publir' && (
-        <PublirAdsProvider publisherId="1391">
-          <AdSlot id={AD_CONFIG.PUBLIR.slotId[device]} />
-        </PublirAdsProvider>
+        <React.Suspense fallback={null}>
+          <PublirAdsProvider publisherId="1391">
+            <AdSlot id={AD_CONFIG.PUBLIR.slotId[device]} />
+          </PublirAdsProvider>
+        </React.Suspense>
       )}
     </>
   );

--- a/web/component/ad/tileB/view.jsx
+++ b/web/component/ad/tileB/view.jsx
@@ -1,7 +1,10 @@
 // @flow
 import React from 'react';
-import { PublirAdsProvider, AdSlot } from '../publir-react-plugin/';
 import classnames from 'classnames';
+import { importPublir } from '../util/importPublir';
+
+const PublirAdsProvider = importPublir('PublirAdsProvider');
+const AdSlot = importPublir('AdSlot');
 
 const DISABLE_VIDEO_AD = false;
 
@@ -64,9 +67,11 @@ function AdTileB(props: Props) {
         />
       )}
       {provider === 'publir' && (
-        <PublirAdsProvider publisherId="1391">
-          <AdSlot id={AD_CONFIG.PUBLIR.slotId[device]} />
-        </PublirAdsProvider>
+        <React.Suspense fallback={null}>
+          <PublirAdsProvider publisherId="1391">
+            <AdSlot id={AD_CONFIG.PUBLIR.slotId[device]} />
+          </PublirAdsProvider>
+        </React.Suspense>
       )}
     </>
   );

--- a/web/component/ad/util/importPublir.jsx
+++ b/web/component/ad/util/importPublir.jsx
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react';
+import analytics from 'analytics';
+
+export function importPublir(componentName: 'PublirAdsProvider' | 'AdSlot') {
+  return React.lazy<any>(() => {
+    return import('../publir-react-plugin')
+      .then((module) => ({ default: module['componentName'] }))
+      .catch((err) => {
+        assert(false, `Failed to load publir-react-plugin::${componentName}`, err);
+        analytics.log(err, { tags: { origin: 'publir-import' } }, 'publir-import');
+
+        const FallbackComponent = () => <div />;
+        return { default: FallbackComponent };
+      });
+  });
+}


### PR DESCRIPTION
The prior commit handles the React lifecycle errors. This one handles the js side

## Ticket
The `globalThis` issue, and potentially future others.

## Approach
Lazy-load (but no code-split) the publir component. This allows us to catch js errors and fallback to nothing.
