### PR TITLE
ScheduledStream: don't update when transitioning to a new search

### DIFF
--- a/ui/component/scheduledStreams/index.js
+++ b/ui/component/scheduledStreams/index.js
@@ -1,7 +1,8 @@
 // @flow
 import moment from 'moment';
 import { connect } from 'react-redux';
-import { createCachedSelector } from 're-reselect';
+import { createSelector } from 'reselect';
+import { objSelectorEqualityCheck } from 'util/redux-utils';
 import type { Props } from './view';
 import ScheduledStreams from './view';
 
@@ -16,7 +17,7 @@ import { SCHEDULED_TAGS } from 'constants/tags';
 import { createNormalizedClaimSearchKey } from 'util/claim';
 import { CsOptHelper } from 'util/claim-search';
 
-const selectOptions = createCachedSelector(
+const selectOptions = createSelector(
   (state) => state.comments.moderationBlockList,
   (state) => selectMutedAndBlockedChannelIds(state),
   (state, name, channelIds) => channelIds,
@@ -41,8 +42,11 @@ const selectOptions = createCachedSelector(
       ...(isLivestream ? { has_no_source: true } : { has_source: true }),
       ...(isLivestream && limitPerChannel ? { limit_claims_per_channel: limitPerChannel } : {}),
     };
+  },
+  {
+    memoizeOptions: { maxSize: 10, resultEqualityCheck: objSelectorEqualityCheck },
   }
-)((state, name, channelIds, isLivestream, limitPerChannel) => `${name}:${isLivestream ? 'l' : 's'}`);
+);
 
 // *****************************************************************************
 // ScheduledStreams

--- a/ui/component/scheduledStreams/index.js
+++ b/ui/component/scheduledStreams/index.js
@@ -60,6 +60,7 @@ const select = (state, props) => {
   const loKey = livestreamOptions ? createNormalizedClaimSearchKey(livestreamOptions) : '';
   const soKey = scheduledOptions ? createNormalizedClaimSearchKey(scheduledOptions) : '';
 
+  // Note: ensure new props are compared in areStatePropsEqual below.
   return {
     livestreamOptions,
     scheduledOptions,
@@ -74,4 +75,20 @@ const perform = (dispatch) => ({
   doShowSnackBar: (message) => dispatch(doToast({ isError: false, message })),
 });
 
-export default connect<_, Props, _, _, _, _>(select, perform)(ScheduledStreams);
+export default connect<_, Props, _, _, _, _>(select, perform, null, {
+  areStatePropsEqual: (next: any, prev: any) => {
+    if (
+      (prev.livestreamUris !== undefined && next.livestreamUris === undefined) ||
+      (prev.scheduledUris !== undefined && next.scheduledUris === undefined)
+    ) {
+      return true;
+    } else {
+      return (
+        prev.livestreamOptions === next.livestreamOptions &&
+        prev.scheduledOptions === next.scheduledOptions &&
+        prev.livestreamUris === next.livestreamUris &&
+        prev.scheduledUris === next.scheduledUris
+      );
+    }
+  },
+})(ScheduledStreams);


### PR DESCRIPTION


## Issue
If blocklists come in late for example, the search results is `undefined` because we have a new query. But most of the time, the results are the same, causing unnecessary erasure.

## Change
Skip this update. Eventually, the results will either be [...] or null, which then a new render display the right results.

## Note
I couldn't figure out how to ensure type safety, so one must ensure new props are compared in `areEqual`
