### PR TITLE
Optimize comment-reaction fetching

### DIFF
--- a/flow-typed/Comment.js
+++ b/flow-typed/Comment.js
@@ -37,6 +37,7 @@ declare type CommentSubmitParams = {
 
 declare type DoCommentListActions = {|
   resolveCommenters?: boolean,
+  fetchReactions?: boolean,
 |};
 
 // ****************************************************************************

--- a/flow-typed/Comment.js
+++ b/flow-typed/Comment.js
@@ -35,6 +35,10 @@ declare type CommentSubmitParams = {
   is_protected?: boolean,
 };
 
+declare type DoCommentListActions = {|
+  resolveCommenters?: boolean,
+|};
+
 // ****************************************************************************
 // Sections
 // ****************************************************************************

--- a/ui/component/chat/view.jsx
+++ b/ui/component/chat/view.jsx
@@ -44,7 +44,7 @@ type Props = {
     page: number,
     pageSize: number,
     sortBy: ?number,
-    isLivestream: boolean
+    actions: ?DoCommentListActions
   ) => void,
   doFetchChannelMembershipsForChannelIds: (channelId: string, claimIds: ClaimIds) => void,
   doFetchOdyseeMembershipForChannelIds: (claimIds: ClaimIds) => void,
@@ -222,7 +222,7 @@ export default function ChatLayout(props: Props) {
 
   React.useEffect(() => {
     if (claimId && contentUnlocked) {
-      doCommentList(uri, undefined, 1, 75, undefined, true);
+      doCommentList(uri, undefined, 1, 75, undefined, { resolveCommenters: false });
       doHyperChatList(uri);
     }
   }, [claimId, contentUnlocked, doCommentList, doHyperChatList, uri]);

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -95,7 +95,7 @@ type DispatchProps = {|
   doClearPlayingUri: () => void,
   doClearPlayingSource: () => void,
   updateComment: (string, string) => void,
-  fetchReplies: (string, string, number, number, number) => void,
+  fetchReplies: (string, string, number, number, number, DoCommentListActions) => void,
   doToast: (ToastParams) => void,
 |};
 
@@ -203,7 +203,7 @@ function CommentView(props: Props & StateProps & DispatchProps) {
 
   React.useEffect(() => {
     if (threadLevel === 0 && comment.replies && uri) {
-      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST);
+      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST, { resolveCommenters: true });
       setShowReplies(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only?
@@ -243,7 +243,7 @@ function CommentView(props: Props & StateProps & DispatchProps) {
 
   useEffect(() => {
     if (uri && page > 0) {
-      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST);
+      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST, { resolveCommenters: true });
     }
   }, [page, uri, commentId, fetchReplies]);
 

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -203,7 +203,10 @@ function CommentView(props: Props & StateProps & DispatchProps) {
 
   React.useEffect(() => {
     if (threadLevel === 0 && comment.replies && uri) {
-      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST, { resolveCommenters: true });
+      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST, {
+        resolveCommenters: true,
+        fetchReactions: true,
+      });
       setShowReplies(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only?
@@ -243,7 +246,10 @@ function CommentView(props: Props & StateProps & DispatchProps) {
 
   useEffect(() => {
     if (uri && page > 0) {
-      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST, { resolveCommenters: true });
+      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST, {
+        resolveCommenters: true,
+        fetchReactions: true,
+      });
     }
   }, [page, uri, commentId, fetchReplies]);
 

--- a/ui/component/commentReactions/view.jsx
+++ b/ui/component/commentReactions/view.jsx
@@ -73,6 +73,15 @@ export default function CommentReactions(props: Props) {
     }
     return count;
   };
+
+  const getCountStrForReact = (type) => {
+    if (othersReacts === undefined || myReacts === undefined) {
+      return ' ';
+    }
+
+    return getCountForReact(type);
+  };
+
   const shouldHide = !canCreatorReact && hideCreatorLike;
   const creatorLiked = getCountForReact(REACTION_TYPES.CREATOR_LIKE) > 0;
   const likeIcon = SIMPLE_SITE
@@ -118,7 +127,7 @@ export default function CommentReactions(props: Props) {
           'comment__action--active': myReacts && myReacts.includes(REACTION_TYPES.LIKE),
         })}
         onClick={handleCommentLike}
-        label={<span className="comment__reaction-count">{getCountForReact(REACTION_TYPES.LIKE)}</span>}
+        label={<span className="comment__reaction-count">{getCountStrForReact(REACTION_TYPES.LIKE)}</span>}
       />
       <Button
         requiresAuth={IS_WEB}
@@ -129,7 +138,7 @@ export default function CommentReactions(props: Props) {
           'comment__action--active': myReacts && myReacts.includes(REACTION_TYPES.DISLIKE),
         })}
         onClick={handleCommentDislike}
-        label={<span className="comment__reaction-count">{getCountForReact(REACTION_TYPES.DISLIKE)}</span>}
+        label={<span className="comment__reaction-count">{getCountStrForReact(REACTION_TYPES.DISLIKE)}</span>}
       />
 
       {!shouldHide && ENABLE_CREATOR_REACTIONS && (canCreatorReact || creatorLiked) && (

--- a/ui/component/commentsList/index.js
+++ b/ui/component/commentsList/index.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import {
   selectClaimForUri,
   selectClaimIsMine,
-  selectFetchingMyChannels,
   selectScheduledStateForUri,
   selectProtectedContentTagForUri,
 } from 'redux/selectors/claims';
@@ -14,19 +13,14 @@ import {
   selectTopLevelTotalPagesForUri,
   selectIsFetchingComments,
   selectIsFetchingTopLevelComments,
-  selectIsFetchingReacts,
   selectTotalCommentsCountForUri,
-  selectOthersReacts,
-  selectMyReacts,
-  selectCommentIdsForUri,
   selectCommentsEnabledSettingForChannelId,
   selectPinnedCommentsForUri,
   selectCommentForCommentId,
   selectCommentAncestorsForId,
 } from 'redux/selectors/comments';
-import { doCommentReset, doCommentList, doCommentById, doCommentReactList } from 'redux/actions/comments';
+import { doCommentReset, doCommentList, doCommentById } from 'redux/actions/comments';
 import { doPopOutInlinePlayer } from 'redux/actions/content';
-import { selectActiveChannelClaim } from 'redux/selectors/app';
 import { getChannelIdFromClaim } from 'util/claim';
 import {
   doFetchOdyseeMembershipForChannelIds,
@@ -40,28 +34,20 @@ const select = (state, props) => {
   const claim = selectClaimForUri(state, uri);
   const channelId = getChannelIdFromClaim(claim);
 
-  const activeChannelClaim = selectActiveChannelClaim(state);
   const threadComment = selectCommentForCommentId(state, threadCommentId);
-  const activeChannelId = activeChannelClaim && activeChannelClaim.claim_id;
 
   return {
-    activeChannelId,
-    allCommentIds: selectCommentIdsForUri(state, uri),
     channelId,
     chatCommentsRestrictedToChannelMembers: Boolean(selectProtectedContentTagForUri(state, uri)),
     claimId: claim && claim.claim_id,
     claimIsMine: selectClaimIsMine(state, claim),
-    fetchingChannels: selectFetchingMyChannels(state),
     // $FlowFixMe
     isAChannelMember: selectUserHasValidMembershipForCreatorId(state, channelId),
     isFetchingComments: selectIsFetchingComments(state),
-    isFetchingReacts: selectIsFetchingReacts(state),
     isFetchingTopLevelComments: selectIsFetchingTopLevelComments(state),
     linkedCommentAncestors: selectCommentAncestorsForId(state, linkedCommentId),
     // $FlowFixMe
     commentsEnabledSetting: selectCommentsEnabledSettingForChannelId(state, channelId),
-    myReactsByCommentId: selectMyReacts(state),
-    othersReactsById: selectOthersReacts(state),
     pinnedComments: selectPinnedCommentsForUri(state, uri),
     threadComment,
     threadCommentAncestors: selectCommentAncestorsForId(state, threadCommentId),
@@ -75,7 +61,6 @@ const select = (state, props) => {
 const perform = {
   fetchTopLevelComments: doCommentList,
   fetchComment: doCommentById,
-  fetchReacts: doCommentReactList,
   resetComments: doCommentReset,
   doFetchOdyseeMembershipForChannelIds,
   doFetchChannelMembershipsForChannelIds,

--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -77,7 +77,7 @@ type DispatchProps = {|
     page: number,
     pageSize: number,
     sortBy: number,
-    isLivestream?: boolean
+    actions: ?DoCommentListActions
   ) => void,
   fetchComment: (CommentId) => void,
   fetchReacts: (Array<CommentId>) => Promise<any>,
@@ -278,7 +278,7 @@ export default function CommentList(props: Props & StateProps & DispatchProps) {
         }
       }
 
-      fetchTopLevelComments(uri, undefined, page, COMMENT_PAGE_SIZE_TOP_LEVEL, sort, false);
+      fetchTopLevelComments(uri, undefined, page, COMMENT_PAGE_SIZE_TOP_LEVEL, sort, { resolveCommenters: true });
     }
   }, [currentFetchedPage, fetchComment, fetchTopLevelComments, linkedCommentId, page, sort, threadCommentId, uri]);
 

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -1,4 +1,5 @@
 // @flow
+import { ENABLE_COMMENT_REACTIONS } from 'config';
 import * as ACTIONS from 'constants/action_types';
 import * as REACTION_TYPES from 'constants/reactions';
 import * as PAGES from 'constants/pages';
@@ -123,6 +124,21 @@ export function doCommentList(
               .then(() => result)
               .catch((err) => {
                 assert(false, 'doCommentList: ignoring resolve errors', err);
+                return result;
+              });
+          }
+        }
+        return result;
+      })
+      .then((result: CommentListResponse) => {
+        if (actions?.fetchReactions && ENABLE_COMMENT_REACTIONS) {
+          const { items: comments } = result;
+          if (comments) {
+            const commentIds = comments.map((c) => c.comment_id || '');
+            return dispatch(doCommentReactList(commentIds))
+              .then(() => result)
+              .catch((err) => {
+                assert(false, 'doCommentList: ignoring reaction errors', err);
                 return result;
               });
           }

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -50,7 +50,7 @@ export function doCommentList(
   page: number = 1,
   pageSize: number = 99999,
   sortBy: ?number = SORT_BY.NEWEST,
-  isLivestream?: boolean
+  actions: ?DoCommentListActions = null
 ) {
   return async (dispatch: Dispatch, getState: GetState) => {
     const state = getState();
@@ -132,7 +132,7 @@ export function doCommentList(
 
         // Batch resolve comment authors
         const commentChannelIds = comments && comments.map((comment) => comment.channel_id || '');
-        if (commentChannelIds && !isLivestream) {
+        if (commentChannelIds && actions?.resolveCommenters) {
           return dispatch(doResolveClaimIds(commentChannelIds)).finally(() => returnResult());
         }
 

--- a/ui/redux/selectors/comments.js
+++ b/ui/redux/selectors/comments.js
@@ -24,9 +24,7 @@ export const selectCommentsById = (state: State) => selectState(state).commentBy
 export const selectCommentIdsByClaimId = (state: State) => selectState(state).byId;
 export const selectIsFetchingComments = (state: State) => selectState(state).isLoading;
 export const selectIsFetchingCommentsByParentId = (state: State) => selectState(state).isLoadingByParentId;
-export const selectIsFetchingReacts = (state: State) => selectState(state).isFetchingReacts;
 
-export const selectMyReacts = (state: State) => state.comments.myReactsByCommentId;
 export const selectMyReactsForComment = (state: State, commentIdChannelId: string) => {
   // @commentIdChannelId: Format = 'commentId:MyChannelId'
   return state.comments.myReactsByCommentId && state.comments.myReactsByCommentId[commentIdChannelId];
@@ -40,7 +38,6 @@ export const selectIsFetchingTopLevelComments = (state: State) => {
   return isFetching && notFetchingReplies;
 };
 
-export const selectOthersReacts = (state: State) => state.comments.othersReactsByCommentId;
 export const selectOthersReactsForComment = (state: State, id: string) => {
   return state.comments.othersReactsByCommentId && state.comments.othersReactsByCommentId[id];
 };


### PR DESCRIPTION
## Ticket
Part of  #2770

## Results (debug mode)
Before and after when loading http://localhost:9090/@AlphaNerd:8/youtube-is-blocking-ad-blockers:a:

<img width="259" alt="image" src="https://github.com/OdyseeTeam/odysee-frontend/assets/64950861/2ee5863c-b1ce-4a59-bc3a-c8c3d28cc81b">   :arrow_right:    <img width="133" alt="image" src="https://github.com/OdyseeTeam/odysee-frontend/assets/64950861/d88d5bd8-a9fd-465d-9d18-9e557a5e1d46">

## Changes
Various; see commit message.  Notable ones:
- [x] Is caching `channel_sign` a valid thing to do?

