### PR TITLE
Fix livestream form disabled when restriction is selected

### DIFF
--- a/flow-typed/publish.js
+++ b/flow-typed/publish.js
@@ -85,6 +85,7 @@ declare type PublishState = {|
   nsfw: boolean,
   channel: string,
   channelId: ?string,
+  channelClaimId: ?ChannelId, // TODO: figure out why channelId isn't used instead
   name: string,
   nameError: ?string,
   bid: number,

--- a/ui/redux/reducers/publish.js
+++ b/ui/redux/reducers/publish.js
@@ -61,6 +61,7 @@ const defaultState: PublishState = {
   nsfw: false,
   channel: CHANNEL_ANONYMOUS,
   channelId: '',
+  channelClaimId: '',
   name: '',
   nameError: undefined,
   bid: 0.001,
@@ -184,9 +185,9 @@ export const publishReducer = handleActions(
       // -- remoteFileUrl
       if (!data.hasOwnProperty('remoteFileUrl')) {
         const nonReplayChosen = data.hasOwnProperty('liveEditType') && data.liveEditType !== 'use_replay';
-        const activeChannelChanged = data.hasOwnProperty('channelClaimId');
+        const activeChanChanged = data.hasOwnProperty('channelClaimId') && data.channelClaimId !== state.channelClaimId;
 
-        if (nonReplayChosen || activeChannelChanged) {
+        if (nonReplayChosen || activeChanChanged) {
           // Purge remoteFileUrl selection on these cases.
           auto.remoteFileUrl = undefined;
         }


### PR DESCRIPTION
## Root
`remoteFileUrl` was being purged internally when that happens, hence the graying out.

## Change
Verify that the active channel actually changed before purging.
