### PR TITLE
Stop enforcing "set to future date" on elapsed Scheduled claim

### DIFF
--- a/ui/redux/reducers/publish.js
+++ b/ui/redux/reducers/publish.js
@@ -144,6 +144,7 @@ export const publishReducer = handleActions(
       }
 
       // -- releaseTimeError
+      // Note: `releaseTime === undefined` means "use original"
       const currentTs = Date.now() / 1000;
       const visibility = getValue('visibility');
       const releaseTime = getValue('releaseTime');
@@ -168,10 +169,11 @@ export const publishReducer = handleActions(
           } else {
             if (isEditing) {
               assert(state.claimToEdit?.value?.release_time, 'scheduled claim without release_time');
-              const originalTs = state.claimToEdit?.value?.release_time || 0;
-              if (originalTs < currentTs) {
-                auto.releaseTimeError = 'Please set to a future date.';
-              }
+              // -- No need to enforce elapsed date when editing --
+              // const originalTs = state.claimToEdit?.value?.release_time || 0;
+              // if (originalTs < currentTs) {
+              //   auto.releaseTimeError = 'Please set to a future date.';
+              // }
             } else {
               auto.releaseTimeError = 'Set a scheduled release date.';
             }


### PR DESCRIPTION
## Issue
> https://odysee-workspace.slack.com/archives/C02G20Z2AEL/p1686002852804409 
When lapsed and trying to edit, the form will enforce setting a future date.

The ideas was to be explicit and make the form mean what it says, so when editing:
1. If no longer want it to be scheduled, set to Public to clear the error.
2. If want to schedule again (not sure if makes sense, but possible), correct the date.

## Change
Stop enforcing as suggested.
