### PR TITLE
Fix non-exclusive-content perks appearing in form

### DIFF
--- a/ui/component/publishProtectedContent/index.js
+++ b/ui/component/publishProtectedContent/index.js
@@ -4,8 +4,6 @@ import { selectActiveChannelClaim, selectIncognito } from 'redux/selectors/app';
 import {
   selectProtectedContentMembershipsForClaimId,
   selectMembershipTiersForCreatorId,
-  selectMyMembershipTiersWithExclusiveContentPerk,
-  selectMyMembershipTiersWithExclusiveLivestreamPerk,
 } from 'redux/selectors/memberships';
 import { selectIsStillEditing, selectPublishFormValue } from 'redux/selectors/publish';
 import { doMembershipContentforStreamClaimId, doMembershipList } from 'redux/actions/memberships';
@@ -24,14 +22,6 @@ const select = (state, props) => {
     incognito,
     protectedMembershipIds: selectProtectedContentMembershipsForClaimId(state, channelClaimId, claimId),
     myMembershipTiers: selectMembershipTiersForCreatorId(state, activeChannel?.claim_id),
-    myMembershipTiersWithExclusiveContentPerk: selectMyMembershipTiersWithExclusiveContentPerk(
-      state,
-      activeChannel?.claim_id
-    ),
-    myMembershipTiersWithExclusiveLivestreamPerk: selectMyMembershipTiersWithExclusiveLivestreamPerk(
-      state,
-      activeChannel?.claim_id
-    ),
     isStillEditing: selectIsStillEditing(state),
     paywall: selectPublishFormValue(state, 'paywall'),
     visibility: selectPublishFormValue(state, 'visibility'),

--- a/ui/redux/selectors/memberships.js
+++ b/ui/redux/selectors/memberships.js
@@ -2,7 +2,7 @@
 import { createSelector } from 'reselect';
 import { createCachedSelector } from 're-reselect';
 
-import { getTotalPriceFromSupportersList } from 'util/memberships';
+import { filterMembershipTiersWithPerk, getTotalPriceFromSupportersList } from 'util/memberships';
 
 import {
   selectChannelClaimIdForUri,
@@ -469,44 +469,17 @@ export const selectPriceOfCheapestPlanForClaimId = (state: State, claimId: Claim
 
 export const selectMyMembershipTiersWithExclusiveContentPerk = (state: State, activeChannelClaimId: string) => {
   const membershipTiers: MembershipTiers = selectMembershipTiersForCreatorId(state, activeChannelClaimId);
-
-  if (!membershipTiers) return [];
-
-  const perkName = 'Exclusive content';
-
-  const tiers: MembershipTiers = membershipTiers.filter((membershipTier: MembershipTier) => {
-    return membershipTier.Perks && membershipTier.Perks.some((perk: MembershipOdyseePerk) => perk.name === perkName);
-  });
-
-  return tiers;
+  return membershipTiers ? filterMembershipTiersWithPerk(membershipTiers, 'Exclusive content') : [];
 };
 
 export const selectMyMembershipTiersWithExclusiveLivestreamPerk = (state: State, activeChannelClaimId: string) => {
   const membershipTiers: MembershipTiers = selectMembershipTiersForCreatorId(state, activeChannelClaimId);
-
-  if (!membershipTiers) return [];
-
-  const perkName = 'Exclusive livestreams';
-
-  const tiers: MembershipTiers = membershipTiers.filter((membershipTier: MembershipTier) => {
-    return membershipTier.Perks && membershipTier.Perks.some((perk: MembershipOdyseePerk) => perk.name === perkName);
-  });
-
-  return tiers;
+  return membershipTiers ? filterMembershipTiersWithPerk(membershipTiers, 'Exclusive livestreams') : [];
 };
 
 export const selectMyMembershipTiersWithMembersOnlyChatPerk = (state: State, channelId: string) => {
   const membershipTiers: MembershipTiers = selectMembershipTiersForCreatorId(state, channelId);
-
-  if (!membershipTiers) return [];
-
-  const perkName = 'Members-only chat';
-
-  const tiers: MembershipTiers = membershipTiers.filter((membershipTier: MembershipTier) => {
-    return membershipTier.Perks && membershipTier.Perks.some((perk: MembershipOdyseePerk) => perk.name === perkName);
-  });
-
-  return tiers;
+  return membershipTiers ? filterMembershipTiersWithPerk(membershipTiers, 'Members-only chat') : [];
 };
 
 export const selectMembersOnlyChatMembershipIdsForCreatorId = createSelector(

--- a/ui/util/memberships.js
+++ b/ui/util/memberships.js
@@ -2,3 +2,10 @@
 
 export const getTotalPriceFromSupportersList = (supportersList: SupportersList) =>
   supportersList.map((supporter) => supporter.Price).reduce((total, supporterPledge) => total + supporterPledge, 0);
+
+export function filterMembershipTiersWithPerk(membershipTiers: Array<MembershipTier>, perkName: string) {
+  const filtered: MembershipTiers = membershipTiers.filter((t: MembershipTier) => {
+    return t.Perks && t.Perks.some((perk: MembershipOdyseePerk) => perk.name === perkName);
+  });
+  return filtered;
+}


### PR DESCRIPTION
## Issue
#2835
> Changing channel in form while restricted settings is expanded, allows selecting tiers with no "exclusive content" perk

## Root
Using vanilla JS in React leads to update issues like this.

But I understand why it was done that way -- the color of the tiers is tied to the css, which restricts how the elements need to be structured (i.e. `.checkbox` needs to be mounted but hidden, and next to each other). We also don't want to tweak FormField for something so specific, so it's an ok tradeoff.

## Change
Ideally, the color should be part of the membership object, not by how the HTML is structured.

But since the filtered array needs to be memo'd anyway, use that as a driver for the effect. Hopefully it's good enough to cover all cases.
