### PR TITLE
Publish: fix stagnant restriction tier list

### DIFF
--- a/ui/component/publish/livestream/livestreamForm/view.jsx
+++ b/ui/component/publish/livestream/livestreamForm/view.jsx
@@ -411,9 +411,6 @@ function LivestreamForm(props: Props) {
     (requiresFile && !filePath) ||
     previewing;
 
-  // replays use 'exclusive content' perk, livestreams use 'exclusive livestreams'
-  const channelRestrictionToUse = liveCreateType === 'choose_replay' ? 'upload' : 'livestream';
-
   // Editing claim uri
   return (
     <div className={balance < 0.01 ? 'disabled' : ''}>
@@ -506,7 +503,7 @@ function LivestreamForm(props: Props) {
               livestreamData={livestreamData}
             />
 
-            <PublishProtectedContent claim={myClaimForUri} location={channelRestrictionToUse} />
+            <PublishProtectedContent claim={myClaimForUri} />
 
             {liveCreateType === 'choose_replay' && <PublishPrice disabled={disabled} />}
 

--- a/ui/component/publish/post/postForm/view.jsx
+++ b/ui/component/publish/post/postForm/view.jsx
@@ -423,7 +423,7 @@ function PostForm(props: Props) {
 
           <PublishVisibility />
 
-          <PublishProtectedContent claim={myClaimForUri} location={'post'} />
+          <PublishProtectedContent claim={myClaimForUri} />
 
           <PublishPrice disabled={formDisabled} />
 

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -451,7 +451,7 @@ function UploadForm(props: Props) {
 
           <PublishVisibility />
 
-          <PublishProtectedContent claim={myClaimForUri} location={'upload'} />
+          <PublishProtectedContent claim={myClaimForUri} />
 
           <PublishPrice disabled={formDisabled} />
 

--- a/ui/component/publishProtectedContent/index.js
+++ b/ui/component/publishProtectedContent/index.js
@@ -23,6 +23,9 @@ const select = (state, props) => {
     protectedMembershipIds: selectProtectedContentMembershipsForClaimId(state, channelClaimId, claimId),
     myMembershipTiers: selectMembershipTiersForCreatorId(state, activeChannel?.claim_id),
     isStillEditing: selectIsStillEditing(state),
+    type: selectPublishFormValue(state, 'type'),
+    liveCreateType: selectPublishFormValue(state, 'liveCreateType'),
+    liveEditType: selectPublishFormValue(state, 'liveEditType'),
     paywall: selectPublishFormValue(state, 'paywall'),
     visibility: selectPublishFormValue(state, 'visibility'),
   };


### PR DESCRIPTION
@keikari, give it a shot in `salt` (8 minutes later) in case I misunderstood?

----

## Issue
#2835
> _Livestream replay publishing/edit shows "access to livestream" tiers instead of "access to video" tiers_

## Changes
- PublishProtectedContent can now derive the correct value after states are moved back in Redux (instead of relying on parent). Single source of truth.
- The switch-case is a bit more verbose than usual -- wanted to ensure every permutation is covered.
- Needed to invalidate the `tier-list` div with a key because it's being updated through vanilla JS. Hope to fix this the React way someday.
