### PR TITLE
Restriction-related fixes

### DIFF
--- a/flow-typed/publish.js
+++ b/flow-typed/publish.js
@@ -114,6 +114,20 @@ declare type DoUpdatePublishForm = {
   data: UpdatePublishState,
 };
 
+declare type MemberRestrictionStatus = {|
+  // -- Main --
+  isApplicable: boolean, // Whether members-only is applicable to the current state of the Publish form
+  isSelectionValid: boolean, // Whether the current settings should flag a user-error.
+  isRestricting: boolean, // Whether restrictions is going to be applied when the form is sent.
+  // -- Supporting details --
+  details: {|
+    isUnlisted: boolean,
+    isAnonymous: boolean,
+    hasTiers: boolean,
+    hasTiersWithRestrictions: boolean,
+  |},
+|};
+
 declare type TusUploader = any;
 
 declare type FileUploadSdkParams = {

--- a/flow-typed/publish.js
+++ b/flow-typed/publish.js
@@ -87,7 +87,6 @@ declare type PublishState = {|
   nsfw: boolean,
   channel: string,
   channelId: ?string,
-  channelClaimId: ?ChannelId, // TODO: figure out why channelId isn't used instead
   name: string,
   nameError: ?string,
   bid: number,

--- a/flow-typed/publish.js
+++ b/flow-typed/publish.js
@@ -67,6 +67,8 @@ declare type PublishState = {|
   fiatRentalFee: Price,
   fiatRentalExpiration: Duration,
   fiatRentalEnabled: boolean,
+  memberRestrictionOn: boolean,
+  memberRestrictionTierIds: Array<number>,
   title: string,
   thumbnail: string, // Manually-entered thumbnail url.
   thumbnail_url: string, // URL for successful thumbnail upload.

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2627,6 +2627,7 @@
   "You're not able to signup for your own memberships": "You're not able to signup for your own memberships",
   "Please %activate_your_memberships% first to to use this functionality.": "Please %activate_your_memberships% first to to use this functionality.",
   "activate your memberships": "activate your memberships",
+  "The selected channel has no membership tiers with exclusive-content perks for the current setup.": "The selected channel has no membership tiers with exclusive-content perks for the current setup.",
   "Restrict Content": "Restrict Content",
   "Restrict content to only allow subscribers to certain memberships to view it": "Restrict content to only allow subscribers to certain memberships to view it",
   "You selected to restrict this content but didn't choose any memberships, please choose a membership tier to restrict, or uncheck the restriction box": "You selected to restrict this content but didn't choose any memberships, please choose a membership tier to restrict, or uncheck the restriction box",

--- a/ui/component/publish/livestream/livestreamForm/index.js
+++ b/ui/component/publish/livestream/livestreamForm/index.js
@@ -4,6 +4,7 @@ import { doResolveUri, doCheckPublishNameAvailability } from 'redux/actions/clai
 import {
   selectPublishFormValues,
   selectIsStillEditing,
+  selectIsMemberRestrictionValid,
   selectPublishFormValue,
   selectMyClaimForUri,
 } from 'redux/selectors/publish';
@@ -50,7 +51,7 @@ const select = (state) => {
     incognito: selectIncognito(state),
     isClaimingInitialRewards: selectIsClaimingInitialRewards(state),
     hasClaimedInitialRewards: selectHasClaimedInitialRewards(state),
-    restrictedToMemberships: selectPublishFormValue(state, 'restrictedToMemberships'),
+    isMemberRestrictionValid: selectIsMemberRestrictionValid(state),
     balance: selectBalance(state),
   };
 };

--- a/ui/component/publish/livestream/livestreamForm/index.js
+++ b/ui/component/publish/livestream/livestreamForm/index.js
@@ -4,7 +4,7 @@ import { doResolveUri, doCheckPublishNameAvailability } from 'redux/actions/clai
 import {
   selectPublishFormValues,
   selectIsStillEditing,
-  selectIsMemberRestrictionValid,
+  selectMemberRestrictionStatus,
   selectPublishFormValue,
   selectMyClaimForUri,
 } from 'redux/selectors/publish';
@@ -51,7 +51,7 @@ const select = (state) => {
     incognito: selectIncognito(state),
     isClaimingInitialRewards: selectIsClaimingInitialRewards(state),
     hasClaimedInitialRewards: selectHasClaimedInitialRewards(state),
-    isMemberRestrictionValid: selectIsMemberRestrictionValid(state),
+    memberRestrictionStatus: selectMemberRestrictionStatus(state),
     balance: selectBalance(state),
   };
 };

--- a/ui/component/publish/livestream/livestreamForm/view.jsx
+++ b/ui/component/publish/livestream/livestreamForm/view.jsx
@@ -97,8 +97,7 @@ type Props = {
   setClearStatus: (boolean) => void,
   // disabled?: boolean,
   remoteFileUrl?: string,
-  restrictedToMemberships: ?string,
-  visibility: Visibility,
+  isMemberRestrictionValid: boolean,
 };
 
 function LivestreamForm(props: Props) {
@@ -141,8 +140,7 @@ function LivestreamForm(props: Props) {
     hasClaimedInitialRewards,
     setClearStatus,
     remoteFileUrl,
-    restrictedToMemberships,
-    visibility,
+    isMemberRestrictionValid,
   } = props;
 
   const {
@@ -179,7 +177,7 @@ function LivestreamForm(props: Props) {
   const waitingForFile = waitForFile && !remoteFileUrl && !filePath;
   // If they are editing, they don't need a new file chosen
   const formValidLessFile =
-    (restrictedToMemberships !== null || visibility === 'unlisted') &&
+    isMemberRestrictionValid &&
     name &&
     isNameValid(name) &&
     title &&

--- a/ui/component/publish/livestream/livestreamForm/view.jsx
+++ b/ui/component/publish/livestream/livestreamForm/view.jsx
@@ -97,7 +97,7 @@ type Props = {
   setClearStatus: (boolean) => void,
   // disabled?: boolean,
   remoteFileUrl?: string,
-  isMemberRestrictionValid: boolean,
+  memberRestrictionStatus: MemberRestrictionStatus,
 };
 
 function LivestreamForm(props: Props) {
@@ -140,7 +140,7 @@ function LivestreamForm(props: Props) {
     hasClaimedInitialRewards,
     setClearStatus,
     remoteFileUrl,
-    isMemberRestrictionValid,
+    memberRestrictionStatus,
   } = props;
 
   const {
@@ -177,7 +177,7 @@ function LivestreamForm(props: Props) {
   const waitingForFile = waitForFile && !remoteFileUrl && !filePath;
   // If they are editing, they don't need a new file chosen
   const formValidLessFile =
-    isMemberRestrictionValid &&
+    (!memberRestrictionStatus.isApplicable || memberRestrictionStatus.isSelectionValid) &&
     name &&
     isNameValid(name) &&
     title &&

--- a/ui/component/publish/livestream/livestreamForm/view.jsx
+++ b/ui/component/publish/livestream/livestreamForm/view.jsx
@@ -153,6 +153,7 @@ function LivestreamForm(props: Props) {
 
   const inEditMode = Boolean(editingURI);
   const activeChannelName = activeChannelClaim && activeChannelClaim.name;
+  const activeChannelId = activeChannelClaim && activeChannelClaim.claim_id;
 
   const [isCheckingLivestreams, setCheckingLivestreams] = React.useState(false);
 
@@ -376,9 +377,11 @@ function LivestreamForm(props: Props) {
   }, []);
 
   useEffect(() => {
-    // $FlowFixMe please
-    updatePublishForm({ channel: activeChannelName });
-  }, [activeChannelName, updatePublishForm]);
+    updatePublishForm({
+      channel: activeChannelName || undefined,
+      channelId: activeChannelId || undefined,
+    });
+  }, [activeChannelName, activeChannelId, updatePublishForm]);
 
   async function handlePublish() {
     let outputFile = filePath;

--- a/ui/component/publish/post/postForm/index.js
+++ b/ui/component/publish/post/postForm/index.js
@@ -4,6 +4,7 @@ import { doResolveUri, doCheckPublishNameAvailability } from 'redux/actions/clai
 import {
   selectPublishFormValues,
   selectIsStillEditing,
+  selectIsMemberRestrictionValid,
   selectPublishFormValue,
   selectMyClaimForUri,
 } from 'redux/selectors/publish';
@@ -49,7 +50,7 @@ const select = (state) => {
     incognito: selectIncognito(state),
     isClaimingInitialRewards: selectIsClaimingInitialRewards(state),
     hasClaimedInitialRewards: selectHasClaimedInitialRewards(state),
-    restrictedToMemberships: selectPublishFormValue(state, 'restrictedToMemberships'),
+    isMemberRestrictionValid: selectIsMemberRestrictionValid(state),
   };
 };
 

--- a/ui/component/publish/post/postForm/index.js
+++ b/ui/component/publish/post/postForm/index.js
@@ -4,7 +4,7 @@ import { doResolveUri, doCheckPublishNameAvailability } from 'redux/actions/clai
 import {
   selectPublishFormValues,
   selectIsStillEditing,
-  selectIsMemberRestrictionValid,
+  selectMemberRestrictionStatus,
   selectPublishFormValue,
   selectMyClaimForUri,
 } from 'redux/selectors/publish';
@@ -50,7 +50,7 @@ const select = (state) => {
     incognito: selectIncognito(state),
     isClaimingInitialRewards: selectIsClaimingInitialRewards(state),
     hasClaimedInitialRewards: selectHasClaimedInitialRewards(state),
-    isMemberRestrictionValid: selectIsMemberRestrictionValid(state),
+    memberRestrictionStatus: selectMemberRestrictionStatus(state),
   };
 };
 

--- a/ui/component/publish/post/postForm/view.jsx
+++ b/ui/component/publish/post/postForm/view.jsx
@@ -147,6 +147,7 @@ function PostForm(props: Props) {
   const formDisabled = emptyPostError || publishing;
   const isInProgress = filePath || editingURI || name || title;
   const activeChannelName = activeChannelClaim && activeChannelClaim.name;
+  const activeChannelId = activeChannelClaim && activeChannelClaim.claim_id;
   // Editing content info
   const fileMimeType =
     myClaimForUri && myClaimForUri.value && myClaimForUri.value.source
@@ -296,11 +297,11 @@ function PostForm(props: Props) {
 
   useEffect(() => {
     if (incognito) {
-      updatePublishForm({ channel: undefined });
+      updatePublishForm({ channel: undefined, channelId: undefined });
     } else if (activeChannelName) {
-      updatePublishForm({ channel: activeChannelName });
+      updatePublishForm({ channel: activeChannelName, channelId: activeChannelId });
     }
-  }, [activeChannelName, incognito, updatePublishForm]);
+  }, [activeChannelName, activeChannelId, incognito, updatePublishForm]);
 
   // @if TARGET='web'
   function createWebFile() {

--- a/ui/component/publish/post/postForm/view.jsx
+++ b/ui/component/publish/post/postForm/view.jsx
@@ -86,7 +86,7 @@ type Props = {
   isClaimingInitialRewards: boolean,
   claimInitialRewards: () => void,
   hasClaimedInitialRewards: boolean,
-  isMemberRestrictionValid: boolean,
+  memberRestrictionStatus: MemberRestrictionStatus,
 };
 
 function PostForm(props: Props) {
@@ -126,7 +126,7 @@ function PostForm(props: Props) {
     isClaimingInitialRewards,
     claimInitialRewards,
     hasClaimedInitialRewards,
-    isMemberRestrictionValid,
+    memberRestrictionStatus,
   } = props;
 
   const inEditMode = Boolean(editingURI);
@@ -161,7 +161,7 @@ function PostForm(props: Props) {
 
   // TODO: formValidLessFile should be a selector
   const formValidLessFile =
-    isMemberRestrictionValid &&
+    (!memberRestrictionStatus.isApplicable || memberRestrictionStatus.isSelectionValid) &&
     name &&
     isNameValid(name) &&
     title &&

--- a/ui/component/publish/post/postForm/view.jsx
+++ b/ui/component/publish/post/postForm/view.jsx
@@ -86,8 +86,7 @@ type Props = {
   isClaimingInitialRewards: boolean,
   claimInitialRewards: () => void,
   hasClaimedInitialRewards: boolean,
-  restrictedToMemberships: ?string,
-  visibility: Visibility,
+  isMemberRestrictionValid: boolean,
 };
 
 function PostForm(props: Props) {
@@ -127,8 +126,7 @@ function PostForm(props: Props) {
     isClaimingInitialRewards,
     claimInitialRewards,
     hasClaimedInitialRewards,
-    restrictedToMemberships,
-    visibility,
+    isMemberRestrictionValid,
   } = props;
 
   const inEditMode = Boolean(editingURI);
@@ -163,7 +161,7 @@ function PostForm(props: Props) {
 
   // TODO: formValidLessFile should be a selector
   const formValidLessFile =
-    (restrictedToMemberships !== null || visibility === 'unlisted') &&
+    isMemberRestrictionValid &&
     name &&
     isNameValid(name) &&
     title &&

--- a/ui/component/publish/post/postForm/view.jsx
+++ b/ui/component/publish/post/postForm/view.jsx
@@ -29,6 +29,7 @@ import Spinner from 'component/spinner';
 import * as ICONS from 'constants/icons';
 import Icon from 'component/common/icon';
 import PublishProtectedContent from 'component/publishProtectedContent';
+import { getChannelIdFromClaim } from 'util/claim';
 
 const SelectThumbnail = lazyImport(() => import('component/selectThumbnail' /* webpackChunkName: "selectThumbnail" */));
 const PublishPrice = lazyImport(() =>
@@ -70,6 +71,7 @@ type Props = {
   balance: number,
   releaseTimeError: ?string,
   isStillEditing: boolean,
+  claimToEdit: ?Claim,
   clearPublish: () => void,
   resolveUri: (string) => void,
   resetThumbnailStatus: () => void,
@@ -112,6 +114,7 @@ function PostForm(props: Props) {
     publishError,
     clearPublish,
     isStillEditing,
+    claimToEdit,
     tags,
     publish,
     disabled = false,
@@ -153,9 +156,6 @@ function PostForm(props: Props) {
     myClaimForUri && myClaimForUri.value && myClaimForUri.value.source
       ? myClaimForUri.value.source.media_type
       : undefined;
-  const claimChannelId =
-    (myClaimForUri && myClaimForUri.signing_channel && myClaimForUri.signing_channel.claim_id) ||
-    (activeChannelClaim && activeChannelClaim.claim_id);
 
   const nameEdited = isStillEditing && name !== prevName;
   const thumbnailUploaded = uploadThumbnailStatus === THUMBNAIL_STATUSES.COMPLETE && thumbnail;
@@ -472,7 +472,12 @@ function PostForm(props: Props) {
             label={submitLabel}
             disabled={isFormIncomplete || !formValid}
           />
-          <ChannelSelector disabled={isFormIncomplete} autoSet channelToSet={claimChannelId} isPublishMenu />
+          <ChannelSelector
+            disabled={isFormIncomplete}
+            autoSet={Boolean(claimToEdit)}
+            channelToSet={getChannelIdFromClaim(claimToEdit)}
+            isPublishMenu
+          />
         </div>
         <p className="help">
           {!formDisabled && !formValid ? (

--- a/ui/component/publish/post/postForm/view.jsx
+++ b/ui/component/publish/post/postForm/view.jsx
@@ -402,8 +402,6 @@ function PostForm(props: Props) {
               disabled={disabled || publishing}
               inProgress={isInProgress}
               setPrevFileText={setPrevFileText}
-              channelId={claimChannelId}
-              channelName={activeChannelName}
             />
           </div>
         }

--- a/ui/component/publish/shared/publishFormErrors/index.js
+++ b/ui/component/publish/shared/publishFormErrors/index.js
@@ -10,10 +10,11 @@ const select = (state) => ({
   fileBitrate: selectPublishFormValue(state, 'fileBitrate'),
   editingURI: selectPublishFormValue(state, 'editingURI'),
   uploadThumbnailStatus: selectPublishFormValue(state, 'uploadThumbnailStatus'),
-  restrictedToMemberships: selectPublishFormValue(state, 'restrictedToMemberships'),
   thumbnail: selectPublishFormValue(state, 'thumbnail'),
   thumbnailError: selectPublishFormValue(state, 'thumbnailError'),
   releaseTimeError: selectPublishFormValue(state, 'releaseTimeError'),
+  memberRestrictionOn: selectPublishFormValue(state, 'memberRestrictionOn'),
+  memberRestrictionTierIds: selectPublishFormValue(state, 'memberRestrictionTierIds'),
   visibility: selectPublishFormValue(state, 'visibility'),
   isStillEditing: selectIsStillEditing(state),
 });

--- a/ui/component/publish/shared/publishFormErrors/index.js
+++ b/ui/component/publish/shared/publishFormErrors/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { selectPublishFormValue, selectIsStillEditing } from 'redux/selectors/publish';
+import { selectPublishFormValue, selectIsStillEditing, selectMemberRestrictionStatus } from 'redux/selectors/publish';
 import PublishFormErrors from './view';
 
 const select = (state) => ({
@@ -13,9 +13,7 @@ const select = (state) => ({
   thumbnail: selectPublishFormValue(state, 'thumbnail'),
   thumbnailError: selectPublishFormValue(state, 'thumbnailError'),
   releaseTimeError: selectPublishFormValue(state, 'releaseTimeError'),
-  memberRestrictionOn: selectPublishFormValue(state, 'memberRestrictionOn'),
-  memberRestrictionTierIds: selectPublishFormValue(state, 'memberRestrictionTierIds'),
-  visibility: selectPublishFormValue(state, 'visibility'),
+  memberRestrictionStatus: selectMemberRestrictionStatus(state),
   isStillEditing: selectIsStillEditing(state),
 });
 

--- a/ui/component/publish/shared/publishFormErrors/view.jsx
+++ b/ui/component/publish/shared/publishFormErrors/view.jsx
@@ -20,7 +20,8 @@ type Props = {
   thumbnail: string,
   thumbnailError: boolean,
   releaseTimeError: ?string,
-  restrictedToMemberships: ?string,
+  memberRestrictionOn: boolean,
+  memberRestrictionTierIds: Array<number>,
   visibility: Visibility,
 };
 
@@ -37,9 +38,10 @@ function PublishFormErrors(props: Props) {
     thumbnail,
     thumbnailError,
     releaseTimeError,
+    memberRestrictionOn,
+    memberRestrictionTierIds,
     waitForFile,
     fileBitrate,
-    restrictedToMemberships,
     visibility,
   } = props;
   // These are extra help
@@ -51,7 +53,7 @@ function PublishFormErrors(props: Props) {
   return (
     <div className="error__text">
       {waitForFile && <div>{__('Choose a replay file, or select None')}</div>}
-      {visibility !== 'unlisted' && restrictedToMemberships === null && (
+      {visibility !== 'unlisted' && memberRestrictionOn && memberRestrictionTierIds.length === 0 && (
         <div>
           {__(
             "You selected to restrict this content but didn't choose any memberships, please choose a membership tier to restrict, or uncheck the restriction box"

--- a/ui/component/publish/shared/publishFormErrors/view.jsx
+++ b/ui/component/publish/shared/publishFormErrors/view.jsx
@@ -20,9 +20,7 @@ type Props = {
   thumbnail: string,
   thumbnailError: boolean,
   releaseTimeError: ?string,
-  memberRestrictionOn: boolean,
-  memberRestrictionTierIds: Array<number>,
-  visibility: Visibility,
+  memberRestrictionStatus: MemberRestrictionStatus,
 };
 
 function PublishFormErrors(props: Props) {
@@ -38,28 +36,21 @@ function PublishFormErrors(props: Props) {
     thumbnail,
     thumbnailError,
     releaseTimeError,
-    memberRestrictionOn,
-    memberRestrictionTierIds,
+    memberRestrictionStatus,
     waitForFile,
     fileBitrate,
-    visibility,
   } = props;
   // These are extra help
   // If there is an error it will be presented as an inline error as well
 
   const isUploadingThumbnail = uploadThumbnailStatus === THUMBNAIL_STATUSES.IN_PROGRESS;
   const thumbnailUploaded = uploadThumbnailStatus === THUMBNAIL_STATUSES.COMPLETE && thumbnail;
+  const missingTiers = memberRestrictionStatus.isApplicable && !memberRestrictionStatus.isSelectionValid;
 
   return (
     <div className="error__text">
       {waitForFile && <div>{__('Choose a replay file, or select None')}</div>}
-      {visibility !== 'unlisted' && memberRestrictionOn && memberRestrictionTierIds.length === 0 && (
-        <div>
-          {__(
-            "You selected to restrict this content but didn't choose any memberships, please choose a membership tier to restrict, or uncheck the restriction box"
-          )}
-        </div>
-      )}
+      {missingTiers && <div>{__(HELP.NO_TIERS_SELECTED)}</div>}
       {fileBitrate > BITRATE.MAX && (
         <div>{__('Bitrate is over the max, please transcode or choose another file.')}</div>
       )}
@@ -79,5 +70,10 @@ function PublishFormErrors(props: Props) {
     </div>
   );
 }
+
+// prettier-ignore
+const HELP = {
+  NO_TIERS_SELECTED: "You selected to restrict this content but didn't choose any memberships, please choose a membership tier to restrict, or uncheck the restriction box",
+};
 
 export default PublishFormErrors;

--- a/ui/component/publish/shared/publishPrice/index.js
+++ b/ui/component/publish/shared/publishPrice/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { selectPublishFormValue } from 'redux/selectors/publish';
+import { selectMemberRestrictionStatus, selectPublishFormValue } from 'redux/selectors/publish';
 import { doUpdatePublishForm } from 'redux/actions/publish';
 import { doCustomerPurchaseCost, doTipAccountStatus } from 'redux/actions/stripe';
 import { selectAccountChargesEnabled } from 'redux/selectors/stripe';
@@ -16,7 +16,7 @@ const select = (state) => ({
   fiatRentalExpiration: selectPublishFormValue(state, 'fiatRentalExpiration'),
   fee: selectPublishFormValue(state, 'fee'),
   chargesEnabled: selectAccountChargesEnabled(state),
-  restrictedToMemberships: state.publish.memberRestrictionOn && state.publish.memberRestrictionTierIds.length > 0,
+  memberRestrictionStatus: selectMemberRestrictionStatus(state),
   type: state.publish.type,
   visibility: selectPublishFormValue(state, 'visibility'),
 });

--- a/ui/component/publish/shared/publishPrice/index.js
+++ b/ui/component/publish/shared/publishPrice/index.js
@@ -16,7 +16,7 @@ const select = (state) => ({
   fiatRentalExpiration: selectPublishFormValue(state, 'fiatRentalExpiration'),
   fee: selectPublishFormValue(state, 'fee'),
   chargesEnabled: selectAccountChargesEnabled(state),
-  restrictedToMemberships: selectPublishFormValue(state, 'restrictedToMemberships'),
+  restrictedToMemberships: state.publish.memberRestrictionOn && state.publish.memberRestrictionTierIds.length > 0,
   type: state.publish.type,
   visibility: selectPublishFormValue(state, 'visibility'),
 });

--- a/ui/component/publish/shared/publishPrice/view.jsx
+++ b/ui/component/publish/shared/publishPrice/view.jsx
@@ -29,7 +29,7 @@ type Props = {
   fiatRentalExpiration: Duration,
   paywall: Paywall,
   fee: Fee,
-  restrictedToMemberships: boolean,
+  memberRestrictionStatus: MemberRestrictionStatus,
   chargesEnabled: ?boolean,
   updatePublishForm: (UpdatePublishState) => void,
   doTipAccountStatus: () => Promise<StripeAccountStatus>,
@@ -52,7 +52,7 @@ function PublishPrice(props: Props) {
     // SDK-LBC
     paywall = PAYWALL.FREE,
     fee,
-    restrictedToMemberships,
+    memberRestrictionStatus,
     chargesEnabled,
     updatePublishForm,
     doTipAccountStatus,
@@ -69,7 +69,7 @@ function PublishPrice(props: Props) {
   const noBankAccount = !chargesEnabled && !bankAccountNotFetched;
 
   // If it's only restricted, the price can be added externally, and they won't be able to change it
-  const restrictedWithoutPrice = paywall === PAYWALL.FREE && restrictedToMemberships;
+  const restrictedWithoutPrice = paywall === PAYWALL.FREE && memberRestrictionStatus.isRestricting;
 
   function clamp(value, min, max) {
     return Math.min(Math.max(Number(value), min), max);

--- a/ui/component/publish/shared/publishPrice/view.jsx
+++ b/ui/component/publish/shared/publishPrice/view.jsx
@@ -29,7 +29,7 @@ type Props = {
   fiatRentalExpiration: Duration,
   paywall: Paywall,
   fee: Fee,
-  restrictedToMemberships: ?string,
+  restrictedToMemberships: boolean,
   chargesEnabled: ?boolean,
   updatePublishForm: (UpdatePublishState) => void,
   doTipAccountStatus: () => Promise<StripeAccountStatus>,

--- a/ui/component/publish/upload/uploadForm/index.js
+++ b/ui/component/publish/upload/uploadForm/index.js
@@ -4,6 +4,7 @@ import { doResolveUri, doCheckPublishNameAvailability } from 'redux/actions/clai
 import {
   selectPublishFormValues,
   selectIsStillEditing,
+  selectIsMemberRestrictionValid,
   selectPublishFormValue,
   selectMyClaimForUri,
 } from 'redux/selectors/publish';
@@ -40,7 +41,7 @@ const select = (state) => {
     filePath: selectPublishFormValue(state, 'filePath'),
     remoteUrl: selectPublishFormValue(state, 'remoteFileUrl'),
     publishSuccess: selectPublishFormValue(state, 'publishSuccess'),
-    restrictedToMemberships: selectPublishFormValue(state, 'restrictedToMemberships'),
+    isMemberRestrictionValid: selectIsMemberRestrictionValid(state),
     totalRewardValue: selectUnclaimedRewardValue(state),
     modal: selectModal(state),
     enablePublishPreview: selectClientSetting(state, SETTINGS.ENABLE_PUBLISH_PREVIEW),

--- a/ui/component/publish/upload/uploadForm/index.js
+++ b/ui/component/publish/upload/uploadForm/index.js
@@ -4,7 +4,7 @@ import { doResolveUri, doCheckPublishNameAvailability } from 'redux/actions/clai
 import {
   selectPublishFormValues,
   selectIsStillEditing,
-  selectIsMemberRestrictionValid,
+  selectMemberRestrictionStatus,
   selectPublishFormValue,
   selectMyClaimForUri,
 } from 'redux/selectors/publish';
@@ -41,7 +41,7 @@ const select = (state) => {
     filePath: selectPublishFormValue(state, 'filePath'),
     remoteUrl: selectPublishFormValue(state, 'remoteFileUrl'),
     publishSuccess: selectPublishFormValue(state, 'publishSuccess'),
-    isMemberRestrictionValid: selectIsMemberRestrictionValid(state),
+    memberRestrictionStatus: selectMemberRestrictionStatus(state),
     totalRewardValue: selectUnclaimedRewardValue(state),
     modal: selectModal(state),
     enablePublishPreview: selectClientSetting(state, SETTINGS.ENABLE_PUBLISH_PREVIEW),

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -91,8 +91,7 @@ type Props = {
   isClaimingInitialRewards: boolean,
   claimInitialRewards: () => void,
   hasClaimedInitialRewards: boolean,
-  restrictedToMemberships: ?string,
-  visibility: Visibility,
+  isMemberRestrictionValid: boolean,
 };
 
 function UploadForm(props: Props) {
@@ -133,8 +132,7 @@ function UploadForm(props: Props) {
     title,
     updatePublishForm,
     uploadThumbnailStatus,
-    restrictedToMemberships,
-    visibility,
+    isMemberRestrictionValid,
   } = props;
 
   const inEditMode = Boolean(editingURI);
@@ -188,7 +186,7 @@ function UploadForm(props: Props) {
   const isOverwritingExistingClaim = !editingURI && myClaimForUri;
 
   const formValid =
-    (restrictedToMemberships !== null || visibility === 'unlisted') &&
+    isMemberRestrictionValid &&
     (isOverwritingExistingClaim
       ? false
       : editingURI && !filePath // if we're editing we don't need a file

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -416,8 +416,6 @@ function UploadForm(props: Props) {
               inProgress={isInProgress}
               setPrevFileText={setPrevFileText}
               setWaitForFile={setWaitForFile}
-              channelId={claimChannelId}
-              channelName={activeChannelName}
             />
           </div>
         }

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -156,6 +156,7 @@ function UploadForm(props: Props) {
   const formDisabled = (fileFormDisabled && !editingURI) || emptyPostError || publishing;
   const isInProgress = filePath || editingURI || name || title;
   const activeChannelName = activeChannelClaim && activeChannelClaim.name;
+  const activeChannelId = activeChannelClaim && activeChannelClaim.claim_id;
   // Editing content info
   const fileMimeType =
     myClaimForUri && myClaimForUri.value && myClaimForUri.value.source
@@ -306,11 +307,11 @@ function UploadForm(props: Props) {
 
   useEffect(() => {
     if (incognito) {
-      updatePublishForm({ channel: undefined });
+      updatePublishForm({ channel: undefined, channelId: undefined });
     } else if (activeChannelName) {
-      updatePublishForm({ channel: activeChannelName });
+      updatePublishForm({ channel: activeChannelName, channelId: activeChannelId });
     }
-  }, [activeChannelName, incognito, updatePublishForm]);
+  }, [activeChannelName, activeChannelId, incognito, updatePublishForm]);
 
   // @if TARGET='web'
   function createWebFile() {

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -35,6 +35,7 @@ import { SOURCE_NONE } from 'constants/publish_sources';
 
 import * as ICONS from 'constants/icons';
 import Icon from 'component/common/icon';
+import { getChannelIdFromClaim } from 'util/claim';
 
 const SelectThumbnail = lazyImport(() => import('component/selectThumbnail' /* webpackChunkName: "selectThumbnail" */));
 const PublishPrice = lazyImport(() =>
@@ -77,6 +78,7 @@ type Props = {
   publishError?: boolean,
   balance: number,
   isStillEditing: boolean,
+  claimToEdit: ?Claim,
   clearPublish: () => void,
   resolveUri: (string) => void,
   resetThumbnailStatus: () => void,
@@ -114,6 +116,7 @@ function UploadForm(props: Props) {
     incognito,
     isClaimingInitialRewards,
     isStillEditing,
+    claimToEdit,
     modal,
     myClaimForUri,
     name,
@@ -162,9 +165,6 @@ function UploadForm(props: Props) {
     myClaimForUri && myClaimForUri.value && myClaimForUri.value.source
       ? myClaimForUri.value.source.media_type
       : undefined;
-  const claimChannelId =
-    (myClaimForUri && myClaimForUri.signing_channel && myClaimForUri.signing_channel.claim_id) ||
-    (activeChannelClaim && activeChannelClaim.claim_id);
 
   const nameEdited = isStillEditing && name !== prevName;
   const thumbnailUploaded = uploadThumbnailStatus === THUMBNAIL_STATUSES.COMPLETE && thumbnail;
@@ -496,7 +496,12 @@ function UploadForm(props: Props) {
       <section>
         <div className="section__actions publish__actions">
           <Button button="primary" onClick={handlePublish} label={submitLabel} disabled={isFormIncomplete} />
-          <ChannelSelector disabled={isFormIncomplete} autoSet channelToSet={claimChannelId} isPublishMenu />
+          <ChannelSelector
+            disabled={isFormIncomplete}
+            autoSet={Boolean(claimToEdit)}
+            channelToSet={getChannelIdFromClaim(claimToEdit)}
+            isPublishMenu
+          />
         </div>
         <span className="help">
           {!formDisabled && !formValid ? (

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -91,7 +91,7 @@ type Props = {
   isClaimingInitialRewards: boolean,
   claimInitialRewards: () => void,
   hasClaimedInitialRewards: boolean,
-  isMemberRestrictionValid: boolean,
+  memberRestrictionStatus: MemberRestrictionStatus,
 };
 
 function UploadForm(props: Props) {
@@ -132,7 +132,7 @@ function UploadForm(props: Props) {
     title,
     updatePublishForm,
     uploadThumbnailStatus,
-    isMemberRestrictionValid,
+    memberRestrictionStatus,
   } = props;
 
   const inEditMode = Boolean(editingURI);
@@ -186,7 +186,7 @@ function UploadForm(props: Props) {
   const isOverwritingExistingClaim = !editingURI && myClaimForUri;
 
   const formValid =
-    isMemberRestrictionValid &&
+    (!memberRestrictionStatus.isApplicable || memberRestrictionStatus.isSelectionValid) &&
     (isOverwritingExistingClaim
       ? false
       : editingURI && !filePath // if we're editing we don't need a file

--- a/ui/component/publishProtectedContent/index.js
+++ b/ui/component/publishProtectedContent/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { doUpdatePublishForm } from 'redux/actions/publish';
 import { selectActiveChannelClaim, selectIncognito } from 'redux/selectors/app';
 import { selectMembershipTiersForCreatorId } from 'redux/selectors/memberships';
-import { selectPublishFormValue } from 'redux/selectors/publish';
+import { selectPublishFormValue, selectValidTierIdsForCurrentForm } from 'redux/selectors/publish';
 import { doMembershipContentforStreamClaimId, doMembershipList } from 'redux/actions/memberships';
 import PublishProtectedContent from './view';
 
@@ -14,11 +14,9 @@ const select = (state, props) => {
     activeChannel,
     incognito,
     myMembershipTiers: selectMembershipTiersForCreatorId(state, activeChannel?.claim_id),
-    type: selectPublishFormValue(state, 'type'),
-    liveCreateType: selectPublishFormValue(state, 'liveCreateType'),
-    liveEditType: selectPublishFormValue(state, 'liveEditType'),
     memberRestrictionOn: selectPublishFormValue(state, 'memberRestrictionOn'),
     memberRestrictionTierIds: selectPublishFormValue(state, 'memberRestrictionTierIds'),
+    validTierIds: selectValidTierIdsForCurrentForm(state),
     paywall: selectPublishFormValue(state, 'paywall'),
     visibility: selectPublishFormValue(state, 'visibility'),
   };

--- a/ui/component/publishProtectedContent/index.js
+++ b/ui/component/publishProtectedContent/index.js
@@ -1,31 +1,24 @@
 import { connect } from 'react-redux';
 import { doUpdatePublishForm } from 'redux/actions/publish';
 import { selectActiveChannelClaim, selectIncognito } from 'redux/selectors/app';
-import {
-  selectProtectedContentMembershipsForClaimId,
-  selectMembershipTiersForCreatorId,
-} from 'redux/selectors/memberships';
-import { selectIsStillEditing, selectPublishFormValue } from 'redux/selectors/publish';
+import { selectMembershipTiersForCreatorId } from 'redux/selectors/memberships';
+import { selectPublishFormValue } from 'redux/selectors/publish';
 import { doMembershipContentforStreamClaimId, doMembershipList } from 'redux/actions/memberships';
 import PublishProtectedContent from './view';
 
 const select = (state, props) => {
-  const claim = props.claim;
-  const { claim_id: claimId, signing_channel: channelClaim } = claim || {};
-  const { claim_id: channelClaimId } = channelClaim || {};
-
   const incognito = selectIncognito(state);
   const activeChannel = !incognito && selectActiveChannelClaim(state);
 
   return {
     activeChannel,
     incognito,
-    protectedMembershipIds: selectProtectedContentMembershipsForClaimId(state, channelClaimId, claimId),
     myMembershipTiers: selectMembershipTiersForCreatorId(state, activeChannel?.claim_id),
-    isStillEditing: selectIsStillEditing(state),
     type: selectPublishFormValue(state, 'type'),
     liveCreateType: selectPublishFormValue(state, 'liveCreateType'),
     liveEditType: selectPublishFormValue(state, 'liveEditType'),
+    memberRestrictionOn: selectPublishFormValue(state, 'memberRestrictionOn'),
+    memberRestrictionTierIds: selectPublishFormValue(state, 'memberRestrictionTierIds'),
     paywall: selectPublishFormValue(state, 'paywall'),
     visibility: selectPublishFormValue(state, 'visibility'),
   };

--- a/ui/component/publishProtectedContent/view.jsx
+++ b/ui/component/publishProtectedContent/view.jsx
@@ -140,6 +140,23 @@ function PublishProtectedContent(props: Props) {
     );
   }
 
+  if (validTierIdsForPerk.length === 0) {
+    return (
+      <Card
+        background
+        isBodyList
+        title={__('Restrict Content')}
+        body={
+          <div className="publish-row publish-row-tiers">
+            <div className="publish-row__reason">
+              {__('The selected channel has no membership tiers with exclusive-content perks for the current setup.')}
+            </div>
+          </div>
+        }
+      />
+    );
+  }
+
   if (validTierIdsForPerk.length > 0) {
     if (visibility === 'unlisted') {
       return (

--- a/ui/component/publishProtectedContent/view.jsx
+++ b/ui/component/publishProtectedContent/view.jsx
@@ -1,6 +1,5 @@
 // @flow
 import React, { useEffect } from 'react';
-import classnames from 'classnames';
 
 import './style.scss';
 import { FormField } from 'component/common/form';
@@ -92,19 +91,6 @@ function PublishProtectedContent(props: Props) {
     }
   }
 
-  React.useEffect(() => {
-    if (memberRestrictionOn) {
-      const elementsToHide = document.getElementsByClassName('hide-tier');
-
-      if (elementsToHide) {
-        for (const element of elementsToHide) {
-          // $FlowFixMe
-          element.parentElement.style.display = 'none';
-        }
-      }
-    }
-  }, [memberRestrictionOn, membershipsToUse]);
-
   useEffect(() => {
     if (activeChannel) {
       getExistingTiers({
@@ -183,21 +169,23 @@ function PublishProtectedContent(props: Props) {
               />
 
               {memberRestrictionOn && (
-                <div className="tier-list" key={perkName}>
-                  {myMembershipTiers.map((membership) => (
-                    <FormField
-                      disabled={paywall !== PAYWALL.FREE}
-                      key={membership.Membership.id}
-                      type="checkbox"
-                      checked={memberRestrictionTierIds.includes(membership.Membership.id)}
-                      label={membership.Membership.name}
-                      name={membership.Membership.id}
-                      onChange={() => toggleMemberRestrictionTierId(membership.Membership.id)}
-                      className={classnames({
-                        'hide-tier': !membershipsToUseIds.includes(membership.Membership.id),
-                      })}
-                    />
-                  ))}
+                <div className="tier-list">
+                  {myMembershipTiers.map((tier: MembershipTier) => {
+                    const show = membershipsToUseIds.includes(tier.Membership.id);
+                    return show ? (
+                      <FormField
+                        disabled={paywall !== PAYWALL.FREE}
+                        key={tier.Membership.id}
+                        type="checkbox"
+                        checked={memberRestrictionTierIds.includes(tier.Membership.id)}
+                        label={tier.Membership.name}
+                        name={tier.Membership.id}
+                        onChange={() => toggleMemberRestrictionTierId(tier.Membership.id)}
+                      />
+                    ) : (
+                      <div key={tier.Membership.id} className="dummy-tier" />
+                    );
+                  })}
                 </div>
               )}
 

--- a/ui/component/publishProtectedContent/view.jsx
+++ b/ui/component/publishProtectedContent/view.jsx
@@ -51,15 +51,6 @@ function PublishProtectedContent(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- @see TODO_NEED_VERIFICATION
   }, [claimId]);
 
-  // Keep track of active channel using `channelClaimId` (??)
-  React.useEffect(() => {
-    if (!activeChannel) return;
-
-    updatePublishForm({
-      channelClaimId: activeChannel.claim_id,
-    });
-  }, [activeChannel, updatePublishForm]);
-
   // Remove previous selections that are no longer valid.
   React.useEffect(() => {
     if (validTierIds) {

--- a/ui/component/publishProtectedContent/view.jsx
+++ b/ui/component/publishProtectedContent/view.jsx
@@ -9,7 +9,7 @@ import I18nMessage from 'component/i18nMessage';
 import Button from 'component/button';
 import * as PAGES from 'constants/pages';
 import { PAYWALL } from 'constants/publish';
-import { filterMembershipTiersWithPerk } from 'util/memberships';
+import { filterMembershipTiersWithPerk, getRestrictivePerkName } from 'util/memberships';
 
 type Props = {
   updatePublishForm: (UpdatePublishState) => void,
@@ -51,34 +51,7 @@ function PublishProtectedContent(props: Props) {
   const claimId = claim?.claim_id;
 
   const perkName = React.useMemo(() => {
-    const EXCLUSIVE_CONTENT = 'Exclusive content';
-    const EXCLUSIVE_LIVESTREAMS = 'Exclusive livestreams';
-
-    switch (type) {
-      case 'file':
-      case 'post':
-        return EXCLUSIVE_CONTENT;
-      case 'livestream':
-        // -- liveCreateType --
-        switch (liveCreateType) {
-          case 'new_placeholder':
-            return EXCLUSIVE_LIVESTREAMS;
-          case 'choose_replay':
-            return EXCLUSIVE_CONTENT;
-          case 'edit_placeholder':
-            // -- liveEditType --
-            switch (liveEditType) {
-              case 'update_only':
-                return EXCLUSIVE_LIVESTREAMS;
-              case 'use_replay':
-              case 'upload_replay':
-                return EXCLUSIVE_CONTENT;
-            }
-        }
-    }
-
-    assert(false, 'unhandled restriction combo', { type, liveCreateType, liveEditType });
-    return EXCLUSIVE_CONTENT;
+    return getRestrictivePerkName(type, liveCreateType, liveEditType);
   }, [liveCreateType, liveEditType, type]);
 
   const membershipsToUse = React.useMemo(() => {

--- a/ui/modal/modalPublishPreview/index.js
+++ b/ui/modal/modalPublishPreview/index.js
@@ -1,11 +1,7 @@
 import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
 import ModalPublishPreview from './view';
-import {
-  selectMyMembershipTiersWithExclusiveContentPerk,
-  selectMyMembershipTiersWithExclusiveLivestreamPerk,
-  selectMembershipTiersForCreatorId,
-} from 'redux/selectors/memberships';
+import { selectMembershipTiersForCreatorId } from 'redux/selectors/memberships';
 import { selectPublishFormValue, selectPublishFormValues, selectIsStillEditing } from 'redux/selectors/publish';
 import { selectMyChannelClaims, selectIsStreamPlaceholderForUri } from 'redux/selectors/claims';
 import * as SETTINGS from 'constants/settings';
@@ -23,10 +19,7 @@ const select = (state, props) => {
     myChannels: selectMyChannelClaims(state),
     isVid: selectPublishFormValue(state, 'fileVid'),
     publishing: selectPublishFormValue(state, 'publishing'),
-    tiersWithExclusiveContent: selectMyMembershipTiersWithExclusiveContentPerk(state, channelClaimId),
-    tiersWithExclusiveLivestream: selectMyMembershipTiersWithExclusiveLivestreamPerk(state, channelClaimId),
     myMembershipTiers: selectMembershipTiersForCreatorId(state, channelClaimId),
-    restrictingTiers: selectPublishFormValue(state, 'restrictedToMemberships'),
     isStillEditing: selectIsStillEditing(state),
     ffmpegStatus: selectFfmpegStatus(state),
     enablePublishPreview: selectClientSetting(state, SETTINGS.ENABLE_PUBLISH_PREVIEW),

--- a/ui/modal/modalPublishPreview/index.js
+++ b/ui/modal/modalPublishPreview/index.js
@@ -2,7 +2,12 @@ import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
 import ModalPublishPreview from './view';
 import { selectMembershipTiersForCreatorId } from 'redux/selectors/memberships';
-import { selectPublishFormValue, selectPublishFormValues, selectIsStillEditing } from 'redux/selectors/publish';
+import {
+  selectPublishFormValue,
+  selectPublishFormValues,
+  selectIsStillEditing,
+  selectMemberRestrictionStatus,
+} from 'redux/selectors/publish';
 import { selectMyChannelClaims, selectIsStreamPlaceholderForUri } from 'redux/selectors/claims';
 import * as SETTINGS from 'constants/settings';
 import { selectFfmpegStatus, selectClientSetting } from 'redux/selectors/settings';
@@ -20,6 +25,7 @@ const select = (state, props) => {
     isVid: selectPublishFormValue(state, 'fileVid'),
     publishing: selectPublishFormValue(state, 'publishing'),
     myMembershipTiers: selectMembershipTiersForCreatorId(state, channelClaimId),
+    memberRestrictionStatus: selectMemberRestrictionStatus(state),
     isStillEditing: selectIsStillEditing(state),
     ffmpegStatus: selectFfmpegStatus(state),
     enablePublishPreview: selectClientSetting(state, SETTINGS.ENABLE_PUBLISH_PREVIEW),

--- a/ui/modal/modalPublishPreview/view.jsx
+++ b/ui/modal/modalPublishPreview/view.jsx
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import moment from 'moment';
-import classnames from 'classnames';
 import type { DoPublishDesktop } from 'redux/actions/publish';
 
 import './style.scss';
@@ -61,10 +60,9 @@ type Props = {
   publishing: boolean,
   isLivestreamClaim: boolean,
   remoteFile: ?string,
-  tiersWithExclusiveContent: MembershipTiers,
-  tiersWithExclusiveLivestream: MembershipTiers,
   myMembershipTiers: MembershipTiers,
-  restrictingTiers: string,
+  memberRestrictionOn: boolean,
+  memberRestrictionTierIds: Array<number>,
   visibility: Visibility,
   scheduledShow: boolean,
 };
@@ -108,10 +106,9 @@ const ModalPublishPreview = (props: Props) => {
     publish,
     closeModal,
     isLivestreamClaim,
-    tiersWithExclusiveContent,
-    tiersWithExclusiveLivestream,
     myMembershipTiers,
-    restrictingTiers,
+    memberRestrictionOn,
+    memberRestrictionTierIds,
     visibility,
     scheduledShow,
   } = props;
@@ -138,9 +135,6 @@ const ModalPublishPreview = (props: Props) => {
   const isOptimizeAvail = filePath && filePath !== '' && isVid && ffmpegStatus.available;
   const modalTitle = getModalTitle();
   const confirmBtnText = getConfirmButtonText();
-  const tiers = livestream ? tiersWithExclusiveLivestream : tiersWithExclusiveContent; // See #2285
-
-  const membershipsToUseIds = tiers && tiers.map((membershipTier) => membershipTier?.Membership?.id);
 
   // **************************************************************************
   // **************************************************************************
@@ -323,38 +317,36 @@ const ModalPublishPreview = (props: Props) => {
   }
 
   function getTierRestrictionValue() {
-    if (myMembershipTiers && restrictingTiers) {
-      const rt = restrictingTiers.split(',');
-
-      return (
-        <div className="publish-preview__tier-restrictions">
-          {myMembershipTiers.map((tier: MembershipTier) => {
-            const tierId = tier?.Membership?.id || '0';
-            const tierRestrictionOn = rt.includes(tierId.toString());
-
-            return tierRestrictionOn ? (
-              <FormField
-                key={tierId}
-                name={tierId}
-                type="checkbox"
-                defaultChecked
-                label={tier?.Membership?.name || tierId}
-                className={classnames({
-                  'hide-tier': !membershipsToUseIds.includes(tier.Membership.id),
-                })}
-              />
-            ) : (
-              <div key={tierId} className="dummy-tier" />
-            );
-          })}
-        </div>
-      );
+    if (hideTierRestrictions()) {
+      return null;
     }
-    return null;
+
+    return (
+      <div className="publish-preview__tier-restrictions">
+        {myMembershipTiers.map((tier: MembershipTier) => {
+          const tierId = tier?.Membership?.id || '0';
+          const tierSelected = memberRestrictionTierIds.includes(tierId);
+
+          return tierSelected ? (
+            <FormField
+              key={tierId}
+              name={tierId}
+              type="checkbox"
+              defaultChecked
+              label={tier?.Membership?.name || tierId}
+            />
+          ) : (
+            <div key={tierId} className="dummy-tier" />
+          );
+        })}
+      </div>
+    );
   }
 
   function hideTierRestrictions() {
-    return !tiers || !restrictingTiers || visibility === 'unlisted';
+    return (
+      !myMembershipTiers || !memberRestrictionOn || memberRestrictionTierIds.length === 0 || visibility === 'unlisted'
+    );
   }
 
   function getVisibilityValue() {
@@ -403,19 +395,6 @@ const ModalPublishPreview = (props: Props) => {
     }
   }, [publishSuccess, publishing, livestream, closeModal]);
   // @endif
-
-  React.useEffect(() => {
-    if (myMembershipTiers) {
-      const elementsToHide = document.getElementsByClassName('hide-tier');
-
-      if (elementsToHide) {
-        for (const element of elementsToHide) {
-          // $FlowFixMe
-          element.parentElement.style.display = 'none';
-        }
-      }
-    }
-  }, [myMembershipTiers]);
 
   // **************************************************************************
   // **************************************************************************

--- a/ui/modal/modalPublishPreview/view.jsx
+++ b/ui/modal/modalPublishPreview/view.jsx
@@ -61,8 +61,8 @@ type Props = {
   isLivestreamClaim: boolean,
   remoteFile: ?string,
   myMembershipTiers: MembershipTiers,
-  memberRestrictionOn: boolean,
   memberRestrictionTierIds: Array<number>,
+  memberRestrictionStatus: MemberRestrictionStatus,
   visibility: Visibility,
   scheduledShow: boolean,
 };
@@ -107,8 +107,8 @@ const ModalPublishPreview = (props: Props) => {
     closeModal,
     isLivestreamClaim,
     myMembershipTiers,
-    memberRestrictionOn,
     memberRestrictionTierIds,
+    memberRestrictionStatus,
     visibility,
     scheduledShow,
   } = props;
@@ -135,6 +135,12 @@ const ModalPublishPreview = (props: Props) => {
   const isOptimizeAvail = filePath && filePath !== '' && isVid && ffmpegStatus.available;
   const modalTitle = getModalTitle();
   const confirmBtnText = getConfirmButtonText();
+
+  assert(
+    !memberRestrictionStatus.isApplicable || memberRestrictionStatus.isSelectionValid,
+    'Something wrong:',
+    memberRestrictionStatus
+  );
 
   // **************************************************************************
   // **************************************************************************
@@ -344,9 +350,7 @@ const ModalPublishPreview = (props: Props) => {
   }
 
   function hideTierRestrictions() {
-    return (
-      !myMembershipTiers || !memberRestrictionOn || memberRestrictionTierIds.length === 0 || visibility === 'unlisted'
-    );
+    return !memberRestrictionStatus.isApplicable || !memberRestrictionStatus.isSelectionValid;
   }
 
   function getVisibilityValue() {

--- a/ui/redux/actions/memberships.js
+++ b/ui/redux/actions/memberships.js
@@ -356,14 +356,14 @@ export const doSaveMembershipRestrictionsForContent =
     channelClaimId: string,
     contentClaimId: string,
     contentClaimName: string,
-    commaSeperatedMembershipIds: string,
+    memberRestrictionTierIds: Array<number>,
     pendingClaim: ?boolean
   ) =>
   async (dispatch: Dispatch) => {
     dispatch({
       type: ACTIONS.SET_MEMBERSHIP_TIERS_FOR_CONTENT_STARTED,
       data: {
-        commaSeperatedMembershipIds,
+        memberRestrictionTierIds,
         contentClaimId,
       },
     });
@@ -374,7 +374,10 @@ export const doSaveMembershipRestrictionsForContent =
       {
         environment: stripeEnvironment,
         claim_id: contentClaimId,
-        membership_ids: commaSeperatedMembershipIds,
+        membership_ids: memberRestrictionTierIds
+          .slice()
+          .sort((a, b) => a - b)
+          .join(','),
         channel_id: channelClaimId,
         claim_name: contentClaimName,
         pending_claim: pendingClaim,

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -37,7 +37,7 @@ import { getVideoBitrate, resolvePublishPayload } from 'util/publish';
 import { parsePurchaseTag, parseRentalTag, TO_SECONDS } from 'util/stripe';
 import Lbry from 'lbry';
 // import LbryFirst from 'extras/lbry-first/lbry-first';
-import { isClaimNsfw, getChannelIdFromClaim, isStreamPlaceholderClaim } from 'util/claim';
+import { isClaimNsfw, getChannelIdFromClaim, isStreamPlaceholderClaim, claimContainsTag } from 'util/claim';
 import { MEMBERS_ONLY_CONTENT_TAG, SCHEDULED_TAGS, VISIBILITY_TAGS } from 'constants/tags';
 
 const PUBLISH_PATH_MAP = Object.freeze({
@@ -75,31 +75,36 @@ export const doPublishDesktop = (filePath: ?string | ?File, preview?: boolean) =
     };
 
     const noFileParam = !filePath || filePath === NO_FILE;
-    const state = getState();
+    const state: State = getState();
     const editingUri = selectPublishFormValue(state, 'editingURI') || '';
     const remoteUrl = selectPublishFormValue(state, 'remoteFileUrl');
-    const restrictedToMemberships = selectPublishFormValue(state, 'restrictedToMemberships');
+    const claimToEdit = selectPublishFormValue(state, 'claimToEdit');
+    const memberRestrictionOn = selectPublishFormValue(state, 'memberRestrictionOn');
+    const memberRestrictionTierIds = selectPublishFormValue(state, 'memberRestrictionTierIds');
 
     const claim = makeSelectClaimForUri(editingUri)(state) || {};
     const hasSourceFile = claim.value && claim.value.source;
     const redirectToLivestream = noFileParam && !hasSourceFile && !remoteUrl;
 
     const publishSuccess = (successResponse, lbryFirstError) => {
-      const state = getState();
+      const state: State = getState();
       const myClaims = selectMyClaims(state);
       const pendingClaim = successResponse.outputs[0];
       const publishData = selectPublishFormValues(state);
 
-      const { restrictedToMemberships, name } = publishData;
+      const { memberRestrictionOn, memberRestrictionTierIds, name } = publishData;
 
       const apiLogSuccessCb = (claimResult: ChannelClaim | StreamClaim) => {
         const channelClaimId = getChannelIdFromClaim(claimResult);
 
         // hit backend to save restricted memberships
-        if (channelClaimId && (restrictedToMemberships || restrictedToMemberships === '')) {
-          dispatch(
-            doSaveMembershipRestrictionsForContent(channelClaimId, claimResult.claim_id, name, restrictedToMemberships)
-          );
+        if (channelClaimId) {
+          // The previous code sends this request even for irrelevant scenarios
+          // (e.g. no tiers; have tiers but restriction not selected; etc.),
+          // presumably to cover the "edit + remove restriction" or other
+          // corner-cases. Err on the side of safety, I guess.
+          const tierIds = memberRestrictionOn ? memberRestrictionTierIds : [];
+          dispatch(doSaveMembershipRestrictionsForContent(channelClaimId, claimResult.claim_id, name, tierIds));
         }
       };
 
@@ -168,10 +173,13 @@ export const doPublishDesktop = (filePath: ?string | ?File, preview?: boolean) =
 
       if (message.endsWith(ERRORS.SDK_FETCH_TIMEOUT)) {
         message = ERRORS.PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL;
-      }
 
-      if (restrictedToMemberships && message === ERRORS.PUBLISH_TIMEOUT_BUT_LIKELY_SUCCESSFUL) {
-        message = ERRORS.RESTRICTED_CONTENT_PUBLISHING_FAILED;
+        if (
+          (Boolean(claimToEdit) && claimContainsTag(claimToEdit, MEMBERS_ONLY_CONTENT_TAG)) ||
+          (memberRestrictionOn && memberRestrictionTierIds.length > 0)
+        ) {
+          message = ERRORS.RESTRICTED_CONTENT_PUBLISHING_FAILED;
+        }
       }
 
       actions.push(doError({ message, cause: error.cause }));
@@ -205,16 +213,19 @@ export const doPublishResume = (publishPayload: FileUploadSdkParams) => (dispatc
     const { permanent_url: url } = pendingClaim;
     const publishData = selectPublishFormValues(state);
 
-    const { restrictedToMemberships, name } = publishData;
+    const { memberRestrictionOn, memberRestrictionTierIds, name } = publishData;
 
     const apiLogSuccessCb = (claimResult: ChannelClaim | StreamClaim) => {
       const channelClaimId = getChannelIdFromClaim(claimResult);
 
       // hit backend to save restricted memberships
-      if (channelClaimId && (restrictedToMemberships || restrictedToMemberships === '')) {
-        dispatch(
-          doSaveMembershipRestrictionsForContent(channelClaimId, claimResult.claim_id, name, restrictedToMemberships)
-        );
+      if (channelClaimId) {
+        // The previous code sends this request even for irrelevant scenarios
+        // (e.g. no tiers; have tiers but restriction not selected; etc.),
+        // presumably to cover the "edit + remove restriction" or other
+        // corner-cases. Err on the side of safety, I guess.
+        const tierIds = memberRestrictionOn ? memberRestrictionTierIds : [];
+        dispatch(doSaveMembershipRestrictionsForContent(channelClaimId, claimResult.claim_id, name, tierIds));
       }
     };
 
@@ -680,11 +691,18 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
       };
     }
 
-    // Membership restrictions
+    // == Tag derivations ==
     const publishDataTags = new Set(publishData.tags && publishData.tags.map((tag) => tag.name));
+
+    // -- Membership restrictions
     if (publishDataTags.has(MEMBERS_ONLY_CONTENT_TAG)) {
       if (channelId) {
-        let protectedMembershipIds = selectProtectedContentMembershipsForClaimId(state, channelId, claim.claim_id);
+        // Repopulate membership restriction IDs
+        let protectedMembershipIds: Array<number> = selectProtectedContentMembershipsForClaimId(
+          state,
+          channelId,
+          claim.claim_id
+        );
 
         if (protectedMembershipIds === undefined) {
           await dispatch(doMembershipContentforStreamClaimId(claim.claim_id));
@@ -692,8 +710,15 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
           protectedMembershipIds = selectProtectedContentMembershipsForClaimId(state, channelId, claim.claim_id);
         }
 
-        publishData['restrictedToMemberships'] = protectedMembershipIds && protectedMembershipIds.join(',');
+        if (protectedMembershipIds && protectedMembershipIds.length > 0) {
+          publishData.memberRestrictionOn = true;
+          publishData.memberRestrictionTierIds = protectedMembershipIds;
+        } else {
+          publishData.memberRestrictionOn = false;
+          publishData.memberRestrictionTierIds = [];
+        }
       } else {
+        // ??
         if (publishData.tags) {
           publishData.tags = publishData.tags.filter((tag) => tag.name === MEMBERS_ONLY_CONTENT_TAG);
         } else {
@@ -742,7 +767,7 @@ export const doPublish =
 
     const publishPayload = payload || resolvePublishPayload(publishData, myClaimForUri, myChannels, Boolean(previewFn));
 
-    const { restrictedToMemberships, name } = publishData;
+    const { memberRestrictionOn, memberRestrictionTierIds, name } = publishData;
 
     const { channel_id: channelClaimId } = publishPayload;
 
@@ -750,13 +775,13 @@ export const doPublish =
 
     // hit backend to save restricted memberships
     // hit the backend immediately to save the data, we will overwrite it if publish succeeds
-    if (channelClaimId && (restrictedToMemberships || restrictedToMemberships === '') && !previewFn) {
+    if (channelClaimId && !previewFn) {
       dispatch(
         doSaveMembershipRestrictionsForContent(
           channelClaimId,
           existingClaimId,
           name,
-          restrictedToMemberships,
+          memberRestrictionOn ? memberRestrictionTierIds : [],
           existingClaimId ? undefined : true
         )
       );

--- a/ui/redux/reducers/publish.js
+++ b/ui/redux/reducers/publish.js
@@ -47,6 +47,8 @@ const defaultState: PublishState = {
   fiatRentalFee: { amount: 1, currency: 'USD' },
   fiatRentalExpiration: { value: 1, unit: 'weeks' },
   fiatRentalEnabled: false,
+  memberRestrictionOn: false,
+  memberRestrictionTierIds: [],
   title: '',
   thumbnail: '',
   thumbnail_url: '',

--- a/ui/redux/reducers/publish.js
+++ b/ui/redux/reducers/publish.js
@@ -63,7 +63,6 @@ const defaultState: PublishState = {
   nsfw: false,
   channel: CHANNEL_ANONYMOUS,
   channelId: '',
-  channelClaimId: '',
   name: '',
   nameError: undefined,
   bid: 0.001,
@@ -189,9 +188,9 @@ export const publishReducer = handleActions(
       // -- remoteFileUrl
       if (!data.hasOwnProperty('remoteFileUrl')) {
         const nonReplayChosen = data.hasOwnProperty('liveEditType') && data.liveEditType !== 'use_replay';
-        const activeChanChanged = data.hasOwnProperty('channelClaimId') && data.channelClaimId !== state.channelClaimId;
+        const channelChanged = data.hasOwnProperty('channelId') && data.channelId !== state.channelId;
 
-        if (nonReplayChosen || activeChanChanged) {
+        if (nonReplayChosen || channelChanged) {
           // Purge remoteFileUrl selection on these cases.
           auto.remoteFileUrl = undefined;
         }
@@ -205,6 +204,7 @@ export const publishReducer = handleActions(
       type: state.type,
       uri: undefined,
       channel: state.channel,
+      channelId: state.channelId,
       bid: state.bid,
       optimize: state.optimize,
       language: state.language,

--- a/ui/redux/selectors/publish.js
+++ b/ui/redux/selectors/publish.js
@@ -154,6 +154,18 @@ export const selectTakeOverAmount = createSelector(
   }
 );
 
+export const selectIsMemberRestrictionValid = (state: State) => {
+  const { memberRestrictionOn, memberRestrictionTierIds, visibility } = state.publish;
+
+  if (visibility === 'unlisted') {
+    // Member-restrictions are currently disabled for Unlisted.
+    return true;
+  } else {
+    // If on, tiers must be selected
+    return !memberRestrictionOn || memberRestrictionTierIds.length > 0;
+  }
+};
+
 export const selectCurrentUploads = (state: State) => selectState(state).currentUploads;
 
 export const selectUploadCount = createSelector(

--- a/ui/redux/selectors/publish.js
+++ b/ui/redux/selectors/publish.js
@@ -171,7 +171,7 @@ export const selectValidTierIdsForCurrentForm = createSelector(
   (state: State) => state.publish.type,
   (state: State) => state.publish.liveCreateType,
   (state: State) => state.publish.liveEditType,
-  (state: State) => state.publish.channelClaimId,
+  (state: State) => state.publish.channelId,
   selectIncognito,
   selectMembershipsListByCreatorId,
   (type, liveCreateType, liveEditType, channelId, incognito, tiersByCreatorId) => {
@@ -194,21 +194,13 @@ export const selectMemberRestrictionStatus = createSelector(
   (state: State) => state.publish.memberRestrictionOn,
   (state: State) => state.publish.memberRestrictionTierIds,
   (state: State) => state.publish.visibility,
-  (state: State) => state.publish.channelClaimId,
+  (state: State) => state.publish.channelId,
   selectIncognito,
   selectMembershipsListByCreatorId,
   selectValidTierIdsForCurrentForm,
-  (
-    memberRestrictionOn,
-    memberRestrictionTierIds,
-    visibility,
-    channelClaimId,
-    incognito,
-    tiersByCreatorId,
-    validTierIds
-  ) => {
+  (memberRestrictionOn, memberRestrictionTierIds, visibility, channelId, incognito, tiersByCreatorId, validTierIds) => {
     const isUnlisted = visibility === 'unlisted';
-    const hasTiers = Boolean(tiersByCreatorId[channelClaimId]);
+    const hasTiers = Boolean(tiersByCreatorId[channelId]);
     const hasTiersWithRestrictions = validTierIds ? validTierIds.length > 0 : false;
     const isApplicable = !isUnlisted && !incognito && hasTiers && hasTiersWithRestrictions;
     const enabled = memberRestrictionOn;

--- a/ui/redux/selectors/publish.js
+++ b/ui/redux/selectors/publish.js
@@ -18,7 +18,9 @@ import {
   selectCollectionHasEditsForId,
   selectCollectionTitleForId,
 } from 'redux/selectors/collections';
-import { selectActiveChannelClaimId } from 'redux/selectors/app';
+import { selectActiveChannelClaimId, selectIncognito } from 'redux/selectors/app';
+import { selectMembershipsListByCreatorId } from 'redux/selectors/memberships';
+import { filterMembershipTiersWithPerk, getRestrictivePerkName } from 'util/memberships';
 
 const selectState = (state) => state.publish || {};
 
@@ -154,17 +156,84 @@ export const selectTakeOverAmount = createSelector(
   }
 );
 
-export const selectIsMemberRestrictionValid = (state: State) => {
-  const { memberRestrictionOn, memberRestrictionTierIds, visibility } = state.publish;
+// ****************************************************************************
+// selectValidTierIdsForCurrentForm
+// ****************************************************************************
 
-  if (visibility === 'unlisted') {
-    // Member-restrictions are currently disabled for Unlisted.
-    return true;
-  } else {
-    // If on, tiers must be selected
-    return !memberRestrictionOn || memberRestrictionTierIds.length > 0;
+/**
+ * Based on the current publish form state, return the list of relevant
+ * restrictive Tier IDs that the creator can enable for the claim being
+ * published.
+ *
+ * @return ?Array<number>
+ */
+export const selectValidTierIdsForCurrentForm = createSelector(
+  (state: State) => state.publish.type,
+  (state: State) => state.publish.liveCreateType,
+  (state: State) => state.publish.liveEditType,
+  (state: State) => state.publish.channelClaimId,
+  selectIncognito,
+  selectMembershipsListByCreatorId,
+  (type, liveCreateType, liveEditType, channelId, incognito, tiersByCreatorId) => {
+    if (incognito || !channelId) {
+      return undefined;
+    }
+
+    const perkName = getRestrictivePerkName(type, liveCreateType, liveEditType);
+    const tiers: Array<MembershipTier> = tiersByCreatorId[channelId] || [];
+    const validTiers = filterMembershipTiersWithPerk(tiers, perkName);
+    return validTiers.map((tier) => tier?.Membership?.id);
   }
-};
+);
+
+// ****************************************************************************
+// selectMemberRestrictionStatus
+// ****************************************************************************
+
+export const selectMemberRestrictionStatus = createSelector(
+  (state: State) => state.publish.memberRestrictionOn,
+  (state: State) => state.publish.memberRestrictionTierIds,
+  (state: State) => state.publish.visibility,
+  (state: State) => state.publish.channelClaimId,
+  selectIncognito,
+  selectMembershipsListByCreatorId,
+  selectValidTierIdsForCurrentForm,
+  (
+    memberRestrictionOn,
+    memberRestrictionTierIds,
+    visibility,
+    channelClaimId,
+    incognito,
+    tiersByCreatorId,
+    validTierIds
+  ) => {
+    const isUnlisted = visibility === 'unlisted';
+    const hasTiers = Boolean(tiersByCreatorId[channelClaimId]);
+    const hasTiersWithRestrictions = validTierIds ? validTierIds.length > 0 : false;
+    const isApplicable = !isUnlisted && !incognito && hasTiers && hasTiersWithRestrictions;
+    const enabled = memberRestrictionOn;
+    const hasSelectedTiers = memberRestrictionTierIds.length > 0;
+    const isSelectionValid = !enabled || (enabled && hasSelectedTiers);
+
+    const status: MemberRestrictionStatus = {
+      isApplicable: isApplicable,
+      isSelectionValid: isSelectionValid,
+      isRestricting: isApplicable && enabled && hasSelectedTiers,
+      details: {
+        isUnlisted: isUnlisted,
+        isAnonymous: incognito,
+        hasTiers: hasTiers,
+        hasTiersWithRestrictions: hasTiersWithRestrictions,
+      },
+    };
+
+    return status;
+  }
+);
+
+// ****************************************************************************
+// TUS/Upload
+// ****************************************************************************
 
 export const selectCurrentUploads = (state: State) => selectState(state).currentUploads;
 
@@ -172,6 +241,9 @@ export const selectUploadCount = createSelector(
   selectCurrentUploads,
   (currentUploads) => currentUploads && Object.keys(currentUploads).length
 );
+
+// ****************************************************************************
+// ****************************************************************************
 
 export const selectIsScheduled = (state: State) =>
   selectState(state).tags.some((t) => t.name === SCHEDULED_LIVESTREAM_TAG);

--- a/ui/scss/component/_card.scss
+++ b/ui/scss/component/_card.scss
@@ -998,5 +998,10 @@
     input {
       display: none;
     }
+
+    .dummy-tier {
+      // Dummy element to maintain color index
+      display: inline-block;
+    }
   }
 }

--- a/ui/util/memberships.js
+++ b/ui/util/memberships.js
@@ -3,6 +3,46 @@
 export const getTotalPriceFromSupportersList = (supportersList: SupportersList) =>
   supportersList.map((supporter) => supporter.Price).reduce((total, supporterPledge) => total + supporterPledge, 0);
 
+/**
+ * Given the current form type combination, what is the applicable perk name
+ * that provides members-only restriction.
+ *
+ * @param type
+ * @param liveCreateType
+ * @param liveEditType
+ * @returns {string}
+ */
+export function getRestrictivePerkName(type: PublishType, liveCreateType: LiveCreateType, liveEditType: LiveEditType) {
+  const EXCLUSIVE_CONTENT = 'Exclusive content';
+  const EXCLUSIVE_LIVESTREAMS = 'Exclusive livestreams';
+
+  switch (type) {
+    case 'file':
+    case 'post':
+      return EXCLUSIVE_CONTENT;
+    case 'livestream':
+      // -- liveCreateType --
+      switch (liveCreateType) {
+        case 'new_placeholder':
+          return EXCLUSIVE_LIVESTREAMS;
+        case 'choose_replay':
+          return EXCLUSIVE_CONTENT;
+        case 'edit_placeholder':
+          // -- liveEditType --
+          switch (liveEditType) {
+            case 'update_only':
+              return EXCLUSIVE_LIVESTREAMS;
+            case 'use_replay':
+            case 'upload_replay':
+              return EXCLUSIVE_CONTENT;
+          }
+      }
+  }
+
+  assert(false, 'unhandled restriction combo', { type, liveCreateType, liveEditType });
+  return EXCLUSIVE_CONTENT;
+}
+
 export function filterMembershipTiersWithPerk(membershipTiers: Array<MembershipTier>, perkName: string) {
   const filtered: MembershipTiers = membershipTiers.filter((t: MembershipTier) => {
     return t.Perks && t.Perks.some((perk: MembershipOdyseePerk) => perk.name === perkName);

--- a/ui/util/publish.js
+++ b/ui/util/publish.js
@@ -357,8 +357,8 @@ const PAYLOAD = {
       tagSet.delete(MEMBERS_ONLY_CONTENT_TAG);
 
       if (publishData.visibility !== 'unlisted') {
-        // $FlowFixMe - handle restrictedToMemberships
-        if (publishData.restrictedToMemberships && channel_id) {
+        const membersOnly = publishData.memberRestrictionOn && publishData.memberRestrictionTierIds.length > 0;
+        if (membersOnly && channel_id) {
           tagSet.add(MEMBERS_ONLY_CONTENT_TAG);
         }
       }

--- a/ui/util/publish.js
+++ b/ui/util/publish.js
@@ -96,6 +96,7 @@ export function resolvePublishPayload(
   publishData: UpdatePublishState,
   myClaimForUri: ?StreamClaim,
   myChannels: ?Array<ChannelClaim>,
+  memberRestrictionStatus: MemberRestrictionStatus,
   preview: boolean
 ) {
   const {
@@ -165,7 +166,7 @@ export function resolvePublishPayload(
   PAYLOAD.tags.useLbryUploader(tagSet, publishData);
   PAYLOAD.tags.scheduledLivestream(tagSet, publishData, publishPayload.release_time, nowTimeStamp);
   PAYLOAD.tags.fiatPaywall(tagSet, publishData);
-  PAYLOAD.tags.membershipRestrictions(tagSet, publishData, publishPayload.channel_id);
+  PAYLOAD.tags.membershipRestrictions(tagSet, publishPayload.channel_id, memberRestrictionStatus);
   PAYLOAD.tags.visibility(tagSet, publishData);
 
   publishPayload.tags = Array.from(tagSet);
@@ -353,15 +354,20 @@ const PAYLOAD = {
       }
     },
 
-    membershipRestrictions: (tagSet: Set<string>, publishData: UpdatePublishState, channel_id: ?string) => {
+    membershipRestrictions: (
+      tagSet: Set<string>,
+      channel_id: ?string,
+      memberRestrictionStatus: MemberRestrictionStatus
+    ) => {
       tagSet.delete(MEMBERS_ONLY_CONTENT_TAG);
-
-      if (publishData.visibility !== 'unlisted') {
-        const membersOnly = publishData.memberRestrictionOn && publishData.memberRestrictionTierIds.length > 0;
-        if (membersOnly && channel_id) {
-          tagSet.add(MEMBERS_ONLY_CONTENT_TAG);
-        }
+      if (channel_id && memberRestrictionStatus.isRestricting) {
+        tagSet.add(MEMBERS_ONLY_CONTENT_TAG);
       }
+
+      assert(
+        !memberRestrictionStatus.isApplicable || memberRestrictionStatus.isSelectionValid,
+        'Trying to publish an invalid Tier Restriction selection'
+      );
     },
 
     visibility: (tagSet: Set<string>, publishData: UpdatePublishState) => {


### PR DESCRIPTION
## Test
- `kp`
- `inf` = master reference w/ stripe test key (but note that transcoded videos won't play here)

## Issues
- Closes #2835
    - Incorrect error-gating when restrictions are toggled
    - Ensure restriction is still valid when scenario changes (+ don't carry over invalid ones)
- Revert #2801 
    - Default to `update_only` when editing Livestreams again (personal pref)
- Closes #2834 
- Closes #2421
- Fix restrictions not actually cleared when switched to Unlisted (although the backend still serves it as long as Unlisted key is present)
- Closes #2489