### PR TITLE
Publish: improve pending claim information

### DIFF
--- a/flow-typed/Claims.js
+++ b/flow-typed/Claims.js
@@ -65,3 +65,18 @@ declare type ClaimSearchResultsInfo = {|
   totalItems?: number,
   totalPages?: number,
 |};
+
+// ****************************************************************************
+// Action Creators
+// ****************************************************************************
+
+declare type UpdatePendingClaimsAction = {|
+  type: 'UPDATE_PENDING_CLAIMS',
+  data: {
+    claims: Array<Claim>,
+    options?: {|
+      overrideTags?: boolean,
+      overrideSigningChannel?: boolean,
+    |},
+  },
+|};

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -125,12 +125,19 @@ export const doPublishDesktop = (filePath: ?string | ?File, preview?: boolean) =
       const isMatch = (claim) => claim.claim_id === pendingClaim.claim_id;
       const isEdit = myClaims.some(isMatch);
 
-      actions.push({
-        type: ACTIONS.UPDATE_PENDING_CLAIMS,
-        data: {
-          claims: [pendingClaim],
-        },
-      });
+      actions.push(
+        ({
+          type: ACTIONS.UPDATE_PENDING_CLAIMS,
+          data: {
+            claims: [pendingClaim],
+            options: {
+              overrideTags: true,
+              overrideSigningChannel: true,
+            },
+          },
+        }: UpdatePendingClaimsAction)
+      );
+
       // @if TARGET='app'
       actions.push({
         type: ACTIONS.ADD_FILES_REFLECTING,

--- a/ui/redux/reducers/claims.js
+++ b/ui/redux/reducers/claims.js
@@ -583,8 +583,8 @@ reducers[ACTIONS.ABANDON_CLAIM_STARTED] = (state: ClaimsState, action: any): Cla
   });
 };
 
-reducers[ACTIONS.UPDATE_PENDING_CLAIMS] = (state: ClaimsState, action: any): ClaimsState => {
-  const { claims: pendingClaims }: { claims: Array<Claim> } = action.data;
+reducers[ACTIONS.UPDATE_PENDING_CLAIMS] = (state: ClaimsState, action: UpdatePendingClaimsAction): ClaimsState => {
+  const { claims: pendingClaims, options } = action.data;
   const byIdDelta = {};
   const pendingById = Object.assign({}, state.pendingById);
   const byUriDelta = {};
@@ -600,6 +600,15 @@ reducers[ACTIONS.UPDATE_PENDING_CLAIMS] = (state: ClaimsState, action: any): Cla
     const oldClaim = state.byId[claimId];
     if (oldClaim && oldClaim.canonical_url) {
       newClaim = mergeClaim(oldClaim, claim);
+
+      if (options) {
+        if (options.overrideTags) {
+          newClaim.value = { ...newClaim.value, tags: claim.value?.tags };
+        }
+        if (options.overrideSigningChannel) {
+          newClaim.signing_channel = claim.signing_channel;
+        }
+      }
     } else {
       newClaim = claim;
     }


### PR DESCRIPTION
## Issue
2873 - After a claim is edited, the "confirming" tile displays wrong (old) information like previous channel or previous tags.

## Possible fixes
1. Tweak `mergeClaim` to be more elaborate.
2. For the publish case, just override the cached claim with the Publish SDK response entirely.

## Approach
Chose a confined solution to reduce testing: let the caller decide what to override. All other `UPDATE_PENDING_CLAIMS` calls remain the same (no need to test)
