### PR TITLE
Publish: clear livestream form on success

### DIFF
--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -153,6 +153,7 @@ export const doPublishDesktop = (filePath: ?string | ?File, preview?: boolean) =
       // @endif
       // @if TARGET='web'
       if (redirectToLivestream) {
+        dispatch(doClearPublish());
         dispatch(push(`/$/${PAGES.LIVESTREAM}`));
       }
       // @endif


### PR DESCRIPTION
## Issue
In Livestream Edit (create too), the return page is in a funky state with prior form values.

## Change
Since the 'success' path forces a navigation to the livestream page immediately (instead of letting the Success modal decide), the form needs to be cleared immediately.

The form is already sent, so there's nothing to retain (should be safe).
