### PR TITLE
Comments: fix missing "show more" for >10 replies

### DIFF
--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -181,7 +181,7 @@ function CommentView(props: Props & StateProps & DispatchProps) {
     linkedCommentId &&
     linkedCommentAncestors[linkedCommentId] &&
     linkedCommentAncestors[linkedCommentId].includes(commentId);
-  const showRepliesOnMount = isThreadComment || isInLinkedCommentChain;
+  const showRepliesOnMount = isThreadComment || isInLinkedCommentChain || (threadLevel === 0 && !!comment.replies);
 
   const [isReplying, setReplying] = React.useState(false);
   const [isEditing, setEditing] = useState(false);
@@ -199,14 +199,6 @@ function CommentView(props: Props & StateProps & DispatchProps) {
   const slimedToDeath =
     !commentByOwnerOfContent && totalLikesAndDislikes >= 5 && dislikesCount / totalLikesAndDislikes > 0.8;
   const stickerFromMessage = parseSticker(message);
-
-  React.useEffect(() => {
-    if (threadLevel === 0 && comment.replies && uri) {
-      fetchReplies(uri, commentId, page, COMMENT_PAGE_SIZE_REPLIES, SORT_BY.OLDEST);
-      setShowReplies(true);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only?
-  }, []);
 
   const isSprout = channelAge && Math.round((new Date() - channelAge) / (1000 * 60 * 60 * 24)) < 7;
 
@@ -556,7 +548,7 @@ function CommentView(props: Props & StateProps & DispatchProps) {
               threadCommentId={threadCommentId}
               numDirectReplies={numDirectReplies}
               onShowMore={handleShowMore}
-              hasMore={page < totalReplyPages && threadLevel > 0}
+              hasMore={page < totalReplyPages}
               threadDepthLevel={threadDepthLevel}
             />
           ))}

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -49,7 +49,6 @@ import MembershipBadge from 'component/membershipBadge';
 import Spinner from 'component/spinner';
 import { lazyImport } from 'util/lazyImport';
 
-const AUTO_EXPAND_ALL_REPLIES = false;
 const CommentCreate = lazyImport(() => import('component/commentCreate' /* webpackChunkName: "comments" */));
 
 // ****************************************************************************
@@ -182,7 +181,7 @@ function CommentView(props: Props & StateProps & DispatchProps) {
     linkedCommentId &&
     linkedCommentAncestors[linkedCommentId] &&
     linkedCommentAncestors[linkedCommentId].includes(commentId);
-  const showRepliesOnMount = isThreadComment || isInLinkedCommentChain || AUTO_EXPAND_ALL_REPLIES;
+  const showRepliesOnMount = isThreadComment || isInLinkedCommentChain;
 
   const [isReplying, setReplying] = React.useState(false);
   const [isEditing, setEditing] = useState(false);


### PR DESCRIPTION
## Ticket
Closes #2799

## Won't fix
If "Show more" (vertical) is expanded and then the local refresh button is hit (not F5), all replies are shown yet "Show more" is displayed.  Clicking on it just does nothing, which I think is minor.  Not fixing because currently logic is spread between parent and child, each knowing half the story.  Refactoring would incur more testing.

## Noticed
Seems like threading (horizontal) doesn't work well in mobile beyond certain level?
