### PR TITLE
AdSticky: don't show empty container when blocked

### DIFF
--- a/web/component/ad/adSticky/view.jsx
+++ b/web/component/ad/adSticky/view.jsx
@@ -110,9 +110,9 @@ export default function AdSticky(props: Props) {
         if (!stickyWidgetCheck) {
           scriptSticky = document.createElement('script');
           scriptSticky.src = 'https://x.revcontent.com/rc_sticky_all.js';
+          scriptSticky.onload = () => setIsActive(true);
           // $FlowIgnore
           document.body.appendChild(scriptSticky);
-          setIsActive(true);
         }
 
         return () => {


### PR DESCRIPTION
## Issue
The empty container is shown during page navigation when uBlock Origin is active. The ad-blocker detection method no longer works for a while now.

## Fix
Set as active only when the script actually succeeds.
