### PR TITLE
Band-aid: debounce Post Editor

### DIFF
--- a/ui/component/postEditor/index.js
+++ b/ui/component/postEditor/index.js
@@ -12,9 +12,9 @@ const select = (state, props) => ({
   isStillEditing: selectIsStillEditing(state),
 });
 
-const perform = (dispatch) => ({
-  updatePublishForm: (value) => dispatch(doUpdatePublishForm(value)),
-  fetchStreamingUrl: (uri) => dispatch(doPlayUri(uri)),
-});
+const perform = {
+  updatePublishForm: doUpdatePublishForm,
+  fetchStreamingUrl: doPlayUri,
+};
 
 export default connect(select, perform)(PostEditor);

--- a/ui/component/postEditor/view.jsx
+++ b/ui/component/postEditor/view.jsx
@@ -1,6 +1,7 @@
 // @flow
 import React, { useEffect } from 'react';
 import { FormField } from 'component/common/form';
+import debounce from 'util/debounce';
 
 type Props = {
   uri: ?string,
@@ -37,6 +38,13 @@ function PostEditor(props: Props) {
 
   const [ready, setReady] = React.useState(!editing);
   const [loading, setLoading] = React.useState(false);
+
+  const updateFileText = React.useCallback(
+    debounce((value) => {
+      updatePublishForm({ fileText: value });
+    }, 750),
+    []
+  );
 
   useEffect(() => {
     if (editing && uri) {
@@ -106,7 +114,7 @@ function PostEditor(props: Props) {
       placeholder={__('My content for this post...')}
       value={ready ? fileText : __('Loading...')}
       disabled={!ready || disabled}
-      onChange={(value) => updatePublishForm({ fileText: value })}
+      onChange={updateFileText}
     />
   );
 }


### PR DESCRIPTION
## Ticket
#2907 - Post Editor laggy with huge articles

## Root
The classic problem with "controlled input" -- each character-change causes the component to render itself.

## Change
Work in "uncontrolled input" mode (which simpleMDE already does) + debounce the redux write.

This is just a band-aid, as there will still be stutter every now and then when the debounced function finally executes during idle (and user coincidently types again).

But at least the user can type now for 99% of the time.

## Notes for full fix
The crux of the problem is the dependence on the `fileText` state. Try this:

1. There are 4 effects that fetches the post's data (if in Editing mode). Move this into a single redux action and store the outcome into `publish.postOriginalText`, and copy that into `publish.fileText` in `doPrepareEdit`.
2. In the component, use `publish.postOriginalText` instead of `publish.fileText` as the starting point.
3. Continue to use the debounced function that updates `publish.fileText`.

That way, the component won't be re-rendering on every character typed.
