### PR TITLE
Retry tus on 404

### DIFF
--- a/web/setup/publish-v4-tasks.js
+++ b/web/setup/publish-v4-tasks.js
@@ -48,6 +48,7 @@ export function requestUploadToken(authToken: string): Promise<TokenRequestRespo
 // Step: Perform TUS upload/resume
 // ****************************************************************************
 
+const STATUS_NOT_FOUND = 404;
 const STATUS_CONFLICT = 409;
 const STATUS_LOCKED = 423;
 
@@ -92,7 +93,11 @@ export function startTus(
       },
       onShouldRetry: (err, retryAttempt, options) => {
         const status = err.originalResponse ? err.originalResponse.getStatus() : 0;
-        const shouldRetry = !inStatusCategory(status, 400) || status === STATUS_CONFLICT || status === STATUS_LOCKED;
+        const shouldRetry =
+          !inStatusCategory(status, 400) ||
+          status === STATUS_CONFLICT ||
+          status === STATUS_LOCKED ||
+          status === STATUS_NOT_FOUND;
         if (shouldRetry) {
           cb.onRetry();
         }


### PR DESCRIPTION
## Issue
There are a lot of these in the log.

- If there were successive logs of this from the same user, that could mean the app messed up (didn't clear successful ones or something).
- But it is all just 1 per user and I can see the file successfully uploaded later -- hints of temp backend glitch. Maybe it wasn't ready yet.

## Change
Include 404 in the auto-retry list to confirm the guess. Wouldn't affect the user much other than having to wait longer if the error was real.
