### PR TITLE
Fix broken pagination in Community Tab

### DIFF
--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -241,7 +241,7 @@ export default function CommentList(props: Props & StateProps & DispatchProps) {
 
   // Force comments reset
   useEffect(() => {
-    if (page >= 0) {
+    if (page === 0) {
       handleReset();
     }
   }, [handleReset, page]);

--- a/ui/page/ownComments/view.jsx
+++ b/ui/page/ownComments/view.jsx
@@ -146,6 +146,11 @@ export default function OwnComments(props: Props) {
     }
   }, [page, spinnerRef, isFetchingComments, moreBelow, totalPages]);
 
+  // Clear redux when leaving page (because OwnComment is sharing key with CommunityTab)
+  React.useEffect(() => {
+    return () => doCommentReset(activeChannelId);
+  }, [activeChannelId, doCommentReset]);
+
   // **************************************************************************
   // **************************************************************************
 


### PR DESCRIPTION
The previous PR will cause the page to reset when scrolled.

The root of the issue is that OwnComments lazily shared the same cache key as Community. A quick fix is to just clear the cache when leaving the OwnComments page.

#2906