### PR TITLE
Fix: Added an alert when the user tries to leave a page with a comment written but not submitted

### DIFF
--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -48,6 +48,7 @@ import { useIsMobile } from 'effects/use-screensize';
 import MembershipBadge from 'component/membershipBadge';
 import Spinner from 'component/spinner';
 import { lazyImport } from 'util/lazyImport';
+import { Prompt } from 'react-router-dom';
 
 const CommentCreate = lazyImport(() => import('component/commentCreate' /* webpackChunkName: "comments" */));
 
@@ -317,6 +318,7 @@ function CommentView(props: Props & StateProps & DispatchProps) {
       })}
       id={commentId}
     >
+      <Prompt when={isEditing} message={'Your comment edits are not saved. Are you sure you want to leave?'} />
       <div className="comment__thumbnail-wrapper">
         {authorUri ? (
           <ChannelThumbnail uri={authorUri} xsmall className="comment__author-thumbnail" checkMembership={false} />

--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -26,6 +26,7 @@ import { AppContext } from 'component/app/view';
 import withCreditCard from 'hocs/withCreditCard';
 import { getStripeEnvironment } from 'util/stripe';
 import './style.lazy.scss';
+import { Prompt } from 'react-router-dom';
 
 const stripeEnvironment = getStripeEnvironment();
 
@@ -696,7 +697,7 @@ export function CommentCreate(props: Props) {
           action={<Button button="primary" label={__('Join')} onClick={handleJoinMembersOnlyChat} />}
         />
       )}
-
+      <Prompt when={charCount > 0} message={'Your comment has not been submitted. Are you sure you want to leave?'} />
       <Form
         onSubmit={() => {}}
         className={classnames('comment-create', {


### PR DESCRIPTION
On this PR, an alert popup has been implemented using `Prompt` from `react-router-dom` to be triggered when a user starts creating a comment or editing a previous comment and tries to navigate away without submitting the comments

## Fixes
- Notify users if they have unsaved comments and try to change the current view

Issue Number:
#1672 

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
If a users starts editing or creating a comment and change their current view, their comments are deleted without notifying them that the comment has not been submitted

## What is the new behavior?
The user triggers an alert notifying that they have an unsaved comment

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [X] Bugfix

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change

</details>
