### PR TITLE
Fix missing resolve for purchase receipt

### DIFF
--- a/ui/hocs/withResolvedClaimRender/view.jsx
+++ b/ui/hocs/withResolvedClaimRender/view.jsx
@@ -73,6 +73,9 @@ const withResolvedClaimRender = (ClaimRenderComponent: FunctionalComponentParam)
     const claimIsRestricted =
       !claimIsMine && (geoRestriction !== null || isClaimBlackListed || (isClaimFiltered && !preferEmbed));
 
+    const resolveRequired =
+      claim === undefined || (claim && claim.value?.fee && claim.purchase_receipt === undefined && isAuthenticated);
+
     const isVisibilityRestricted = useIsVisibilityRestricted(
       claim,
       claimIsMine,
@@ -106,10 +109,10 @@ const withResolvedClaimRender = (ClaimRenderComponent: FunctionalComponentParam)
     );
 
     React.useEffect(() => {
-      if (hasClaim === undefined) {
+      if (resolveRequired) {
         resolveClaim();
       }
-    }, [hasClaim, resolveClaim]);
+    }, [resolveRequired, resolveClaim]);
 
     if (!hasClaim) {
       if (hasClaim === undefined) {


### PR DESCRIPTION
## Reproduce
1. F5 to clear resolve cache.
2. Navigate to a channel that you have purchased something from.
3. Click on the claim that you know you have purchased. The app still asks you to purchase it.

## Root
We used to always call `resolve + include_purchase_receipt` when entering a File Page. The embed/hoc refactoring skips that if the claim is already in cache, but that claim was resolved without `include_purchase_receipt` from step 2's search.

## Change
Retain existing optimization, but also double-check if the claim requires a fee. If yes, then re-fetch if we don't have the purchase receipt info.
