### PR TITLE
Hide comments from deleted channels

### DIFF
--- a/ui/component/comment/index.js
+++ b/ui/component/comment/index.js
@@ -46,7 +46,6 @@ const select = (state, props) => {
     claim,
     commentingEnabled: Boolean(selectUserVerifiedEmail(state)),
     othersReacts: selectOthersReactsForComment(state, reactionKey),
-    activeChannelClaim,
     hasChannels: selectHasChannels(state),
     playingUri: selectPlayingUri(state),
     stakedLevel: selectStakedLevelForChannelUri(state, channel_url),

--- a/ui/component/comment/index.js
+++ b/ui/component/comment/index.js
@@ -49,6 +49,7 @@ const select = (state, props) => {
     hasChannels: selectHasChannels(state),
     playingUri: selectPlayingUri(state),
     stakedLevel: selectStakedLevelForChannelUri(state, channel_url),
+    isCommenterChannelDeleted: selectClaimForUri(state, channel_url) === null,
     linkedCommentAncestors: selectFetchedCommentAncestors(state),
     totalReplyPages: makeSelectTotalReplyPagesForParentId(comment_id)(state),
     odyseeMembership: selectOdyseeMembershipForChannelId(state, channel_id) || '',

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -77,7 +77,6 @@ type StateProps = {|
   linkedCommentAncestors: { [string]: Array<string> },
   totalReplyPages: number,
   repliesFetching: boolean,
-  activeChannelClaim: ?ChannelClaim,
   claim: StreamClaim,
   authorTitle: ?string,
   channelAge?: any,

--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -87,6 +87,7 @@ type StateProps = {|
   commentingEnabled: boolean,
   playingUri: PlayingUri,
   stakedLevel: number,
+  isCommenterChannelDeleted: boolean,
 |};
 
 type DispatchProps = {|
@@ -124,6 +125,7 @@ function CommentView(props: Props & StateProps & DispatchProps) {
     othersReacts,
     playingUri,
     stakedLevel,
+    isCommenterChannelDeleted,
     supportDisabled,
     setQuickReply,
     quickReply,
@@ -307,6 +309,10 @@ function CommentView(props: Props & StateProps & DispatchProps) {
     },
     [ROUGH_HEADER_HEIGHT, isMobile]
   );
+
+  if (isCommenterChannelDeleted) {
+    return null;
+  }
 
   return (
     <li


### PR DESCRIPTION
## Ticket
Closes #2934 

## Old behavior
- `UriIndicator` will display the deleted channel name as "[Removed]".
- Comment text remains displayed.

## Root cause
#2554 (1f60d017) removed `UriIndicator` and tries to display the best channel name format based on `comment` object data, which is populated even if the channel was deleted.

## Change
I think there was a reason why we decided to show the comment instead of hiding it, but I can't recall. Maybe it's so that the Total shown tallies, or some pagination issue.

Anyway, just hide it for now as suggested in the ticket. If an issue is found, we can try to restore the old behavior.
****