### PR TITLE
Version nag improvements

### DIFF
--- a/ui/util/storage.js
+++ b/ui/util/storage.js
@@ -7,6 +7,7 @@ export const LS = Object.freeze({
   AUTH_IN_PROGRESS: 'authInProgress',
   CHANNEL_LIVE_STATUS: 'channel-live-status',
   GDPR_REQUIRED: 'gdprRequired', // <-- should be using 'locale/get', right?
+  MINIMUM_VERSION_LAST_NAGGED_MS: 'minimumVersionLastNaggedMs',
   SHARE_INTERNAL: 'shareInternal',
   TUS_LOCKED_UPLOADS: 'tusLockedUploads',
   TUS_REFRESH_LOCK: 'tusRefreshLock',


### PR DESCRIPTION
1. Avoid nag infinite-loop when the server fails to produce the right content. 
    - Known reasons: CDN cache stuck in certain regions. 
    - Known symptoms: Users had to do a hard reload.
2. Add internal diagnostics to see if the server can actually serve the right version that it was nagging the user with. 
    - `fetch` has a `no-store` option that bypasses the browser cache, so we can use that as an independent verifier. 
    - I just wanted to narrow down the root-causes.

> [!NOTE]
> Couldn't test the `fetch` for sure due to CORS, so I'm assuming the server can query itself.  
> Even if it fails, the error will be caught and won't affect the user.

## Flaws
If the html is changed in the future, the regex here will fail (out of sync). But since this is just for diagnostics, it doesn't matter.
