### PR TITLE
UserReport: also route to Sentry

### DIFF
--- a/ui/page/report/view.jsx
+++ b/ui/page/report/view.jsx
@@ -1,3 +1,4 @@
+import analytics from 'analytics';
 import { doToast } from 'redux/actions/notifications';
 import { FormField } from 'component/common/form';
 import { Lbryio } from 'lbryinc';
@@ -31,6 +32,12 @@ class ReportPage extends React.Component {
       // Display global notice
       const action = doToast({ message: __('Message received! Thanks for helping.') });
       window.app.store.dispatch(action);
+    });
+
+    analytics.log(message.length > 80 ? `${message.slice(0, 80)}…` : message, {
+      level: 'info',
+      tags: { origin: '/$/report' },
+      extra: { message: message },
     });
 
     this.setState({ message: '' });


### PR DESCRIPTION
## Why
Better search, viewing, alert.

## How
- Search: `_origin:/$/report`
- Full message will be located in the "extras" section of each entry.

## Flaws
The sentry version should not be considered the primary one since:
- ad-blockers block the packet
- sentry's own throttling will sometimes drop successive entries, even if they are distinct.

## Aside
Sentry has a formal crash report widget and different dashboard. But that takes a bit of effort and testing to set up, so just use the existing mechanism for now.

https://docs.sentry.io/platforms/javascript/enriching-events/user-feedback/?original_referrer=https%3A%2F%2Fdocs.sentry.io%2Fproduct%2Fuser-feedback%2F#embeddable-javascript-widget
