### PR TITLE
Clear file cache through a separate `fetch::no-cache` call

### DIFF
--- a/ui/util/lazyImport.js
+++ b/ui/util/lazyImport.js
@@ -1,23 +1,52 @@
 import React from 'react';
 import * as ACTIONS from 'constants/action_types';
+import { URL as SITE_URL } from 'config';
 
-const RETRY_DELAY_MS = 3000;
-const RETRY_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 5000;
+const RETRY_ATTEMPTS = 3;
+
+/**
+ * While there is no way to programmatically clear a user's cache, doing a
+ * separate `fetch` with `no-cache` indirectly replaces the cache with a fresh
+ * download.
+ *
+ * This is an opportunistic attempt which fails silently, as some browsers may
+ * not return the URL in the error.
+ *
+ * @param error ChunkLoadError which contains the URL of the failed webpack import.
+ * @returns {Promise<void>}
+ */
+async function bustFileCache(error) {
+  try {
+    const match = error?.message?.match(new RegExp(`${SITE_URL}(.+?\\.js)`, 'gi'));
+    const url = match[0];
+    await fetch(url, { cache: 'no-store' });
+  } catch (err) {
+    console.error('bustFileCache:', err.message); // eslint-disable-line no-console
+  }
+}
 
 function componentLoader(lazyComponent, attemptsLeft) {
   return new Promise((resolve, reject) => {
     lazyComponent()
       .then(resolve)
       .catch((error) => {
-        setTimeout(() => {
-          if (attemptsLeft === 1) {
-            window.store.dispatch({
-              type: ACTIONS.RELOAD_REQUIRED,
-              data: { reason: 'lazyImportFailed', extra: error },
-            });
-            console.error(error.message); // eslint-disable-line no-console
-          } else {
-            componentLoader(lazyComponent, attemptsLeft - 1).then(resolve, reject);
+        setTimeout(async () => {
+          switch (attemptsLeft) {
+            case 0:
+              window.store.dispatch({
+                type: ACTIONS.RELOAD_REQUIRED,
+                data: { reason: 'lazyImportFailed', extra: error },
+              });
+              console.error(error.message); // eslint-disable-line no-console
+              break;
+
+            default:
+              if (attemptsLeft === 1) {
+                await bustFileCache(error);
+              }
+              componentLoader(lazyComponent, attemptsLeft - 1).then(resolve, reject);
+              break;
           }
         }, RETRY_DELAY_MS);
       });


### PR DESCRIPTION
## Issue
ChunkLoadError.

There is anecdote[^1] saying that Chromium will cache failed responses (e.g. timeout), so users could end up perpetually in a bad state until the cache is manually cleared, or the site moved on to a different chunk.

[^1]: `https://github.com/whatwg/html/issues/6768` -- confirmed to be true; can be replicated

## Approach
While there is no way to programmatically clear a user's cache, doing a separate `fetch` with `no-cache` indirectly replaces the cache with a fresh download.

Here an experiment to prove the concept:
1. In the first 2 reloads, we see the browser consistently/correctly using the one cached at 6.47pm.  
2. Assume the cache was bad, so we send a separate `fetch :: no-cache` to clear it.
3. Reload.  We see that the browser still used the cached version (correct behavior since filename didn't change or cache didn't expire), but it's a new one from 6:50pm.

https://github.com/OdyseeTeam/odysee-frontend/assets/64950861/060fd444-f485-4cc7-9874-be91c37895bd