### PR TITLE
Serve missing internal files as 404 instead of soft-404 page

### DIFF
--- a/web/src/routes.js
+++ b/web/src/routes.js
@@ -70,6 +70,18 @@ router.get(`/$/rss/:claimName::claimId`, rssMiddleware);
 router.get(`/$/oembed`, oEmbedMiddleware);
 
 router.get('*', async (ctx) => {
+  const requestedUrl = ctx.url;
+
+  if (requestedUrl.startsWith('/public/') && requestedUrl.endsWith('.js')) {
+    // If the file exists, `app.use(serve(DIST_ROOT))` would have handled it.
+    // Handle the non-existent file here, otherwise it'll get resolved to a
+    // claim with the name 'public'.
+    ctx.status = 404;
+    ctx.body = 'Resource not found';
+    ctx.set('Cache-Control', 'no-store');
+    return;
+  }
+
   const html = await getHtml(ctx);
   ctx.body = html;
 });


### PR DESCRIPTION
This addresses the deeper root-cause for the ChunkLoadError.

## Issue
Requesting for an missing/invalid js file like `https://odysee.com/public/some-non-existent-file.js` yields HTML, which is usually incorrectly redirected to an actual claim, or the React soft-404 page.

Besides incorrect, it is also being cached.  Users are stuck until cache is manually cleared.

## Approach
- In the final catch-all stage, try to detect if it's a file request and return a 404 instead.
- Do not cache 404s.  (Same reasons as https://community.cloudflare.com/t/404s-and-caching/337151. The file could eventually be corrected).
- The body is now "Resource not found".  I think we can add plain HTML (no redirect to claims) to beautify it, as long as the status is 404.  But not sure if it's worth it.

> [!WARNING]
> Is the detection too loose? Any better ideas to not over-catch?

