### PR TITLE
Defer React script until DOM is ready

### DIFF
--- a/web/src/html.js
+++ b/web/src/html.js
@@ -42,7 +42,7 @@ function insertToHead(fullHtml, htmlToInsert, buildRev = '') {
   const finalIndex = fullHtml.indexOf(FINAL_STR);
 
   if (beginIndex > -1 && finalIndex > -1 && finalIndex > beginIndex) {
-    const uiScript = buildRev ? `<script src="/public/ui-${buildRev}.js" async></script>` : '';
+    const uiScript = buildRev ? `<script src="/public/ui-${buildRev}.js" defer></script>` : '';
 
     return (
       `${fullHtml.slice(0, beginIndex)}` +


### PR DESCRIPTION
## Issue
[LBRY-DESKTOP-WEB-PRD Target container is not a DOM element](https://sentry.lbry.tech/organizations/odysee/issues/28517/) aka "white screen"
Reproduce:  make a bookmark of the site, and keep clicking it with variations in delay

## Root/Change
- React looks for a div with a specific ID, so the div must exist first.
- There are various suggestions, from putting the script tag at the bottom-most of `<body>`, to listening to `DOMContentLoaded`.
- The easiest seems to be the `defer` tag -- it's the same as `async` (start fetch in parallel), but only executes after the DOM is ready.

## Caveat
On Chrome, clicking on a bookmark will utilize the cached version of `index.html` (maybe this was what some users were doing when they say they are "reloading").

The fix will only take effect on regular F5 (or clicking the button, or clicking our Reload nag).
