### PR TITLE
PopoutChat: fix empty page on 'members-only livestreams'

### DIFF
--- a/ui/page/popoutChatWrapper/index.js
+++ b/ui/page/popoutChatWrapper/index.js
@@ -1,3 +1,4 @@
+import { doMembershipList } from 'redux/actions/memberships';
 import { buildURI } from 'util/lbryURI';
 import { connect } from 'react-redux';
 import { doCommentSocketConnectAsCommenter, doCommentSocketDisconnectAsCommenter } from 'redux/actions/websocket';
@@ -32,6 +33,7 @@ const perform = {
   doCommentSocketConnectAsCommenter,
   doCommentSocketDisconnectAsCommenter,
   doResolveUri,
+  doMembershipList,
 };
 
 export default connect(select, perform)(PopoutChatPage);

--- a/ui/page/popoutChatWrapper/view.jsx
+++ b/ui/page/popoutChatWrapper/view.jsx
@@ -1,4 +1,5 @@
 // @flow
+import { getChannelIdFromClaim, getChannelNameFromClaim } from 'util/claim';
 import { formatLbryChannelName } from 'util/url';
 import { lazyImport } from 'util/lazyImport';
 import Page from 'component/page';
@@ -13,6 +14,7 @@ type Props = {
   doCommentSocketConnectAsCommenter: (string, string, string, ?boolean) => void,
   doCommentSocketDisconnectAsCommenter: (string, string) => void,
   doResolveUri: (string, boolean) => void,
+  doMembershipList: ({ channel_name: string, channel_id: string }) => Promise<CreatorMemberships>,
   isProtectedContent: boolean,
   contentUnlocked: boolean,
   contentRestrictedFromUser: boolean,
@@ -25,6 +27,7 @@ export default function PopoutChatPage(props: Props) {
     doCommentSocketConnectAsCommenter,
     doCommentSocketDisconnectAsCommenter,
     doResolveUri,
+    doMembershipList,
     isProtectedContent,
     contentUnlocked,
     contentRestrictedFromUser,
@@ -58,6 +61,14 @@ export default function PopoutChatPage(props: Props) {
     isProtectedContent,
     uri,
   ]);
+
+  React.useEffect(() => {
+    if (claim) {
+      const channelName = getChannelNameFromClaim(claim) || 'invalid';
+      const channelId = getChannelIdFromClaim(claim) || 'invalid';
+      doMembershipList({ channel_name: channelName, channel_id: channelId });
+    }
+  }, [claim, doMembershipList]);
 
   if (contentRestrictedFromUser) {
     return (


### PR DESCRIPTION
## Ticket
Closes #2909

The popout is a separate instance (same as separate tabs), and the popout components aren't within any of the resolve HOCs, so the membership data had to be re-fetched.
