### PR TITLE
Account deletion: Only run useEffect at first render

### DIFF
--- a/ui/modal/modalRemoveAccount/view.jsx
+++ b/ui/modal/modalRemoveAccount/view.jsx
@@ -69,6 +69,7 @@ export default function ModalRemoveAccount(props: Props) {
       doFetchClaimListMine(page, pageSize, resolve);
       doFetchChannelListMine();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount
   }, []);
 
   async function handleOnClick() {

--- a/ui/modal/modalRemoveAccount/view.jsx
+++ b/ui/modal/modalRemoveAccount/view.jsx
@@ -69,7 +69,7 @@ export default function ModalRemoveAccount(props: Props) {
       doFetchClaimListMine(page, pageSize, resolve);
       doFetchChannelListMine();
     }
-  }, [isPendingDeletion, isWalletEmpty, doFetchAccountList, doFetchClaimListMine, doFetchChannelListMine]);
+  }, []);
 
   async function handleOnClick() {
     setButtonClicked(true);


### PR DESCRIPTION
Don't re-fetch account info, after deleting the account.

lint gave error about this, but noticed now that with non-empty dependency list, it will re-fetch the account info after the account is deleted.
(Not needed, and made "Loading account info..." spinner flash there looking odd.)