### PR TITLE
Fix jumpy progress nub in Safari

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-time-marker/ProgressNub.scss
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-time-marker/ProgressNub.scss
@@ -11,7 +11,6 @@
   z-index: 1;
   &::before {
     margin-bottom: -10px !important;
-    margin-left: -100% !important;
     color: #f77937;
   }
 }
@@ -19,11 +18,11 @@
 .vjs-progress-control.vjs-control {
   &:hover {
     .vjs-progress-nub {
-      transform: scale(1);
+      transform: scale(1) translateX(-50%);
     }
   }
 
   .vjs-progress-holder.vjs-slider.vjs-slider-horizontal.vjs-sliding ~ .vjs-progress-nub {
-    transform: scale(1);
+    transform: scale(1) translateX(-50%);
   }
 }


### PR DESCRIPTION
Patches 448d0b66

## Symptom
The `left: npx` was incrementing correctly, but visually the nub goes backwards on every pixel step.

Might be due to a recent change in Safari -- somewhat sure the previous commit was tested on Safari back then.

