### PR TITLE
Minor fix to account deletion message logic

### DIFF
--- a/ui/modal/modalRemoveAccount/view.jsx
+++ b/ui/modal/modalRemoveAccount/view.jsx
@@ -92,7 +92,7 @@ export default function ModalRemoveAccount(props: Props) {
           <>
             {isBusy
               ? ''
-              : !isLoadingAccountInfo && !isLoadingAccountInfoSuccess
+              : !isLoadingAccountInfo && !isLoadingAccountInfoSuccess && (!isPendingDeletion || !isWalletEmpty)
               ? __(
                   'Failed to load account info. If the issue persists, please reach out to help@odysee.com for support.'
                 )


### PR DESCRIPTION
Fixes:
The modal shows the `"Failed to load account info. If the issue persists, please reach out to help@odysee.com for support.'`-message instead of `'Account has already been queued for deletion.'`, for accounts that are already pending for deletion after a page refresh. 