### PR TITLE
feat: bypass CF for txo list

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -16,6 +16,7 @@ WEB_SERVER_PORT=1337
 
 # -- APIs ---
 LBRY_WEB_API=https://api.na-backend.odysee.com
+LBRY_WEB_API_NO_CF=https://naked-api.na-backend.odysee.com
 LBRY_WEB_PUBLISH_API=https://publish.na-backend.odysee.com/v1
 LBRY_WEB_PUBLISH_API_V2=https://publish.na-backend.odysee.com/api/v2/publish/
 LBRY_WEB_PUBLISH_API_V3=https://publish.na-backend.odysee.com/api/v3/publish/

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ const config = {
   WEBPACK_ELECTRON_PORT: process.env.WEBPACK_ELECTRON_PORT,
   WEB_SERVER_PORT: process.env.WEB_SERVER_PORT,
   LBRY_WEB_API: process.env.LBRY_WEB_API, // api.na-backend.odysee.com',
+  LBRY_WEB_API_NO_CF: process.env.LBRY_WEB_API_NO_CF, // naked-api.na-backend.odysee.com', bypasses CF timeout (90 seconds) for longer running calls
   LBRY_WEB_PUBLISH_API: process.env.LBRY_WEB_PUBLISH_API,
   LBRY_WEB_PUBLISH_API_V2: process.env.LBRY_WEB_PUBLISH_API_V2,
   LBRY_WEB_PUBLISH_API_V3: process.env.LBRY_WEB_PUBLISH_API_V3,
@@ -105,6 +106,7 @@ const config = {
 
 config.SDK_API_PATH = `${config.LBRY_WEB_API}/api/v1`;
 config.PROXY_URL = `${config.SDK_API_PATH}/proxy`;
+config.PROXY_URL_NO_CF = `${config.LBRY_WEB_API_NO_CF}/api/v1/proxy`;
 
 config.URL_DEV = `http://localhost:${config.WEBPACK_WEB_PORT}`;
 config.URL_LOCAL = `http://localhost:${config.WEB_SERVER_PORT}`;

--- a/ui/lbry.js
+++ b/ui/lbry.js
@@ -3,6 +3,7 @@ import analytics from 'analytics';
 import { FETCH_TIMEOUT, SDK_FETCH_TIMEOUT } from 'constants/errors';
 import { NO_AUTH, X_LBRY_AUTH_TOKEN } from 'constants/token';
 import fetchWithTimeout from 'util/fetch';
+import { PROXY_URL_NO_CF } from 'config';
 
 require('proxy-polyfill');
 
@@ -15,8 +16,8 @@ const Lbry: LbryTypes = {
   isConnected: false,
   connectPromise: null,
   daemonConnectionString: 'http://localhost:5279',
-  alternateConnectionString: '',
-  methodsUsingAlternateConnectionString: [],
+  alternateConnectionString: PROXY_URL_NO_CF,
+  methodsUsingAlternateConnectionString: ['txo_list'],
   apiRequestHeaders: { 'Content-Type': 'application/json-rpc' },
 
   // Allow overriding daemon connection string (e.g. to `/api/proxy` for lbryweb)


### PR DESCRIPTION
Supports long running queries to bypass CF timeout of 90 seconds.

todo: fix https://github.com/OdyseeTeam/odysee-frontend/issues/3004
