### PR TITLE
Fix for triple txoList call

### DIFF
--- a/ui/page/wallet/view.jsx
+++ b/ui/page/wallet/view.jsx
@@ -112,9 +112,7 @@ const WalletPage = (props: Props) => {
                   {!loading && (
                     <>
                       {showIntro && <YrblWalletEmpty includeWalletLink />}
-                      <div className="card-stack">
-                        <TxoList search={search} />
-                      </div>
+                      <div className="card-stack">{tabIndex === 1 && <TxoList search={search} />}</div>
                     </>
                   )}
                 </div>
@@ -131,9 +129,7 @@ const WalletPage = (props: Props) => {
                   )}
                   {!loading && (
                     <>
-                      <div className="card-stack">
-                        <TxoList search={search} />
-                      </div>
+                      <div className="card-stack">{tabIndex === 2 && <TxoList search={search} />}</div>
                     </>
                   )}
                 </div>
@@ -150,9 +146,7 @@ const WalletPage = (props: Props) => {
                   )}
                   {!loading && (
                     <>
-                      <div className="card-stack">
-                        <TxoList search={search} />
-                      </div>
+                      <div className="card-stack">{tabIndex === 3 && <TxoList search={search} />}</div>
                     </>
                   )}
                 </div>


### PR DESCRIPTION
Closes #3004

## Root
3 instances of the TxoList component is present.

## Change
Mount per active tab.

Somewhat a quick-fix -- continued with the hardcoded tabIndex since that takes longer to refactor.
