### PR TITLE
Add ability for methods to skip the artificial timeout

### DIFF
--- a/flow-typed/Lbry.js
+++ b/flow-typed/Lbry.js
@@ -370,6 +370,7 @@ declare type LbryTypes = {
   daemonConnectionString: string,
   alternateConnectionString: string,
   methodsUsingAlternateConnectionString: Array<string>,
+  methodsWithNoArtificialTimeout: Array<string>,
   apiRequestHeaders: { [key: string]: string },
   setDaemonConnectionString: (string) => void,
   setApiHeader: (string, string) => void,


### PR DESCRIPTION
In 9b44b7eb, we added an artificial fetch timeout that's shorter than the browser's default so that (1) user don't have to wait too long (2) we get to differentiate the error as being a timeout (fetch errors all use the same string).

This commit provides the ability to specify list of methods that will bypass that mechanism (i.e. use browser's default timeout length. I think Firefox was like 90s), with `txo_list` being the first (known to be long, should just wait for it)

Test: `kp`