### PR TITLE
Skip auth-sync reload if already authenticating

### DIFF
--- a/ui/redux/middleware/auth-token.js
+++ b/ui/redux/middleware/auth-token.js
@@ -11,7 +11,7 @@ type Store = { dispatch: Dispatch, getState: GetState };
 export const populateAuthTokenHeader = (store: Store) => {
   return (next: any) => (action: any) => {
     // @if TARGET='web'
-    const { dispatch } = store;
+    const { dispatch, getState } = store;
 
     switch (action.type) {
       case ACTIONS.USER_FETCH_SUCCESS:
@@ -28,8 +28,9 @@ export const populateAuthTokenHeader = (store: Store) => {
         const isVerifyPage = location.href.includes(PAGES.AUTH_VERIFY) && !location.href.includes(PAGES.REWARDS_VERIFY);
         const isNewAccount = LocalStorage.getItem(LS.IS_NEW_ACCOUNT) === 'true';
         const xAuth = (Lbry.getApiRequestHeaders() || {})[X_LBRY_AUTH_TOKEN] || '';
+        const state = getState();
 
-        if (!xAuth) {
+        if (!xAuth && !state.user.authenticationIsPending) {
           if (isVerifyPage) {
             if (isNewAccount) {
               LocalStorage.removeItem(LS.IS_NEW_ACCOUNT);


### PR DESCRIPTION
Closes [#3009 Tabs reloading itself when multiple are opened simultaneously ](https://github.com/OdyseeTeam/odysee-frontend/issues/3009)

@keikari, can you take a look to see if it fixes the issue on your side + review the code?  I think the `isNewAccount` part can be skipped too in this scenario, but if not, we can move the `state.user.authenticationIsPending` part down to the reloading part instead.