### PR TITLE
GH Actions: update setup-node action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,9 +14,22 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: Borales/actions-yarn@v3.0.0
-      - run: yarn lint
+      - uses: actions/checkout@v3
+
+      - name: Set Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Run "yarn install"
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: install
+
+      - name: Run "yarn lint"
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: lint
 
   build:
     needs: ['lint']


### PR DESCRIPTION
## Issue
GH Actions failing with node version error.

## Root
??

## Change
Had to update the v4 and use `cmd` format for things to work.
