### PR TITLE
Remember scheduled time in the edit-form time picker - attempt

### DIFF
--- a/ui/component/publish/shared/publishStreamReleaseDate/view.jsx
+++ b/ui/component/publish/shared/publishStreamReleaseDate/view.jsx
@@ -22,7 +22,8 @@ type Props = {
 const PublishStreamReleaseDate = (props: Props) => {
   const { isScheduled, releaseTime, clock24h, appLanguage, updatePublishForm } = props;
 
-  const [publishLater, setPublishLater] = React.useState(isScheduled);
+  const minScheduledTimePassed = releaseTime ? releaseTime < dateToLinuxTimestamp(moment().toDate()) : undefined;
+  const [publishLater, setPublishLater] = React.useState(isScheduled && !minScheduledTimePassed);
 
   const getPlus30MinutesDate = () => {
     return moment().add('1', 'hour').add('30', 'minutes').startOf('hour').toDate();
@@ -49,14 +50,6 @@ const PublishStreamReleaseDate = (props: Props) => {
     : __(
         'Your scheduled streams will appear on your channel page and for your followers. Chat will not be active until 5 minutes before the start time.'
       );
-
-  React.useEffect(() => {
-    if (isScheduled) {
-      // TODO: this is doPrepareEdit's responsibility, not the component's.
-      updatePublishForm({ releaseTime: dateToLinuxTimestamp(getPlus30MinutesDate()) });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- on mount only
-  }, []);
 
   return (
     <>

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -590,6 +590,7 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
       title,
       tags,
       stream_type,
+      release_time,
     } = value;
 
     let state = getState();
@@ -748,6 +749,8 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
     } else {
       dispatch(doSetIncognito(true));
     }
+
+    publishData.releaseTime = Number(release_time);
 
     dispatch({ type: ACTIONS.DO_PREPARE_EDIT, data: publishData });
     dispatch(push(`/$/${PUBLISH_PATH_MAP[type]}`));


### PR DESCRIPTION
Changes:
- Remember the schduled livestream date in the edit form DateTimePicker
- Remember the scheduled video release date in the edit form DateTimePicker
- If livestream's scheduled time has passed, default to "Anytime" in edit


Not sure if I'm missing something, as I just followed what the TODO comment in old code said. But I didn't found this causing any issues. 