### PR TITLE
Fix attempt - save public list order changes on publish

### DIFF
--- a/ui/redux/selectors/collections.js
+++ b/ui/redux/selectors/collections.js
@@ -357,7 +357,7 @@ export const selectHasPrivateCollectionForId = (state: State, id: string) => {
 
   if (COLLECTIONS_CONSTS.BUILTIN_PLAYLISTS.includes(id)) return true;
 
-  if (selectCollectionHasEditsForId(state, id)) {
+  if (selectCollectionHasEditsForId(state, id) || selectCollectionHasUnsavedEditsForId(state, id)) {
     const urlParams = new URLSearchParams(window.location.search);
     const isOnPublicView = urlParams.get(COLLECTION_PAGE.QUERIES.VIEW) === COLLECTION_PAGE.VIEWS.PUBLIC;
     if (!isOnPublicView) return true;
@@ -368,7 +368,11 @@ export const selectHasPrivateCollectionForId = (state: State, id: string) => {
 
 // Is private === only private (doesn't include public with private edits)
 export const selectIsCollectionPrivateForId = (state: State, id: string) =>
-  Boolean(selectHasPrivateCollectionForId(state, id) && !selectCollectionHasEditsForId(state, id));
+  Boolean(
+    selectHasPrivateCollectionForId(state, id) &&
+      !selectCollectionHasEditsForId(state, id) &&
+      !selectCollectionHasUnsavedEditsForId(state, id)
+  );
 
 export const selectClaimIdsForCollectionId = createSelector(
   selectHasPrivateCollectionForId,

--- a/ui/redux/selectors/publish.js
+++ b/ui/redux/selectors/publish.js
@@ -16,6 +16,7 @@ import {
   selectClaimIdsForCollectionId,
   selectIsCollectionPrivateForId,
   selectCollectionHasEditsForId,
+  selectCollectionHasUnsavedEditsForId,
   selectCollectionTitleForId,
 } from 'redux/selectors/collections';
 import { selectActiveChannelClaimId, selectIncognito } from 'redux/selectors/app';
@@ -276,8 +277,9 @@ export const selectCollectionClaimUploadParamsForId = (state: State, collectionI
   };
 
   const hasEdits = selectCollectionHasEditsForId(state, collectionId);
+  const hasUnSavedEdits = selectCollectionHasUnsavedEditsForId(state, collectionId);
 
-  if (hasEdits) {
+  if (hasEdits || hasUnSavedEdits) {
     // $FlowFixMe please
     Object.assign(collectionClaimUploadParams, privateCollectionParams);
   }


### PR DESCRIPTION
## Fixes
Editing item order of public(not edited) list, in the publish form, doesn't save on publish.

## Reason
`unSavedEdits` weren't checked for in collection params creation.