### PR TITLE
Fix attempt - Removal of deleted content from private list

### DIFF
--- a/ui/component/claimMenuList/index.js
+++ b/ui/component/claimMenuList/index.js
@@ -40,7 +40,13 @@ import ClaimPreview from './view';
 
 const select = (state, props) => {
   const { uri } = props;
-  const claim = selectClaimForUri(state, uri, false);
+  // This is used to handle deleted content in lists
+  const placeholderForDeletedClaim = {
+    canonical_url: uri,
+    permanent_url: uri,
+    value_type: 'deleted',
+  };
+  const claim = selectClaimForUri(state, uri, false) || placeholderForDeletedClaim;
   const collectionId = props.collectionId;
   const repostedClaim = claim && claim.reposted_claim;
   const contentClaim = repostedClaim || claim;

--- a/ui/component/claimMenuList/view.jsx
+++ b/ui/component/claimMenuList/view.jsx
@@ -30,7 +30,7 @@ type SubscriptionArgs = {
 
 type Props = {
   uri: string,
-  claim: ?Claim,
+  claim: Claim,
   repostedClaim: ?Claim,
   contentClaim: ?Claim,
   contentSigningChannel: ?Claim,
@@ -141,7 +141,7 @@ function ClaimMenuList(props: Props) {
     ? __('Unfollow')
     : __('Follow');
 
-  if (!claim) {
+  if (claim.value_type === 'deleted' && !collectionId) {
     return null;
   }
 
@@ -406,211 +406,231 @@ function ClaimMenuList(props: Props) {
         <Icon size={20} icon={ICONS.MORE_VERTICAL} />
       </MenuButton>
       <MenuList className="menu__list">
-        {/* FYP */}
-        {fypId && (
-          <>
-            <MenuItem className="comment__menu-option" onSelect={() => doRemovePersonalRecommendation(uri)}>
-              <div className="menu__link">
-                <Icon aria-hidden icon={ICONS.REMOVE} />
-                {__('Not interested')}
-              </div>
-            </MenuItem>
-            <hr className="menu__separator" />
-          </>
-        )}
-
-        <>
-          {/* COLLECTION OPERATIONS */}
-          {collectionId && isCollectionClaim ? (
+        {claim.value_type === 'deleted' && collectionId ? (
+          <AddToCollectionContext />
+        ) : (
+          claim.value_type !== 'deleted' && (
             <>
-              <MenuItem className="comment__menu-option" onSelect={() => push(`/$/${PAGES.PLAYLIST}/${collectionId}`)}>
-                <a className="menu__link" href={`/$/${PAGES.PLAYLIST}/${collectionId}`}>
-                  <Icon aria-hidden icon={ICONS.VIEW} />
-                  {__('View Playlist')}
-                </a>
-              </MenuItem>
-              {!collectionEmpty && (
-                <MenuItem className="comment__menu-option" onSelect={() => doEnableCollectionShuffle({ collectionId })}>
-                  <div className="menu__link">
-                    <Icon aria-hidden icon={ICONS.SHUFFLE} />
-                    {__('Shuffle Play')}
-                  </div>
-                </MenuItem>
-              )}
-              {isMyCollection && (
+              {/* FYP */}
+              {fypId && (
                 <>
-                  {!collectionEmpty && (
-                    <MenuItem
-                      className="comment__menu-option"
-                      onSelect={() =>
-                        push(`/$/${PAGES.PLAYLIST}/${collectionId}?${CP.QUERIES.VIEW}=${CP.VIEWS.PUBLISH}`)
-                      }
-                    >
-                      <div className="menu__link">
-                        <Icon aria-hidden iconColor={'red'} icon={ICONS.PUBLISH} />
-                        {hasEdits ? __('Publish') : __('Update')}
-                      </div>
-                    </MenuItem>
-                  )}
-                  <MenuItem
-                    className="comment__menu-option"
-                    onSelect={() => push(`/$/${PAGES.PLAYLIST}/${collectionId}?${CP.QUERIES.VIEW}=${CP.VIEWS.EDIT}`)}
-                  >
+                  <MenuItem className="comment__menu-option" onSelect={() => doRemovePersonalRecommendation(uri)}>
                     <div className="menu__link">
-                      <Icon aria-hidden icon={ICONS.EDIT} />
-                      {__('Edit')}
+                      <Icon aria-hidden icon={ICONS.REMOVE} />
+                      {__('Not interested')}
                     </div>
                   </MenuItem>
-                  <MenuItem
-                    className="comment__menu-option"
-                    onSelect={() => openModal(MODALS.COLLECTION_DELETE, { collectionId })}
-                  >
-                    <div className="menu__link">
-                      <Icon aria-hidden icon={ICONS.DELETE} />
-                      {__('Delete Playlist')}
-                    </div>
-                  </MenuItem>
+                  <hr className="menu__separator" />
                 </>
               )}
-            </>
-          ) : (
-            <AddToCollectionContext />
-          )}
-        </>
 
-        {contentClaim && isContentProtectedAndLocked && !claimIsMine && (
-          <MenuItem
-            className="comment__menu-option"
-            onSelect={() =>
-              openModal(MODALS.JOIN_MEMBERSHIP, { uri, fileUri: contentClaim.permanent_url, shouldNavigate: true })
-            }
-          >
-            <div className="menu__link">
-              <Icon aria-hidden icon={ICONS.MEMBERSHIP} />
-              {__('Join')}
-            </div>
-          </MenuItem>
-        )}
-
-        {isAuthenticated && (
-          <>
-            {!isChannelPage && (
               <>
-                <MenuItem className="comment__menu-option" onSelect={handleSupport}>
-                  <div className="menu__link">
-                    <Icon aria-hidden icon={ICONS.LBC} />
-                    {__('Support --[button to support a claim]--')}
-                  </div>
-                </MenuItem>
-              </>
-            )}
-
-            {!incognitoClaim && !claimIsMine && !isChannelPage && (
-              <>
-                <hr className="menu__separator" />
-                <MenuItem className="comment__menu-option" onSelect={handleFollow}>
-                  <div className="menu__link">
-                    <Icon aria-hidden icon={ICONS.SUBSCRIBE} />
-                    {subscriptionLabel}
-                  </div>
-                </MenuItem>
-              </>
-            )}
-
-            {!isMyCollection && (
-              <>
-                {(!claimIsMine || channelIsBlocked) && contentChannelUri ? (
-                  !incognitoClaim && (
-                    <>
-                      <MenuItem className="comment__menu-option" onSelect={handleToggleBlock}>
-                        <div className="menu__link">
-                          <Icon aria-hidden icon={ICONS.BLOCK} />
-                          {channelIsBlocked ? __('Unblock Channel') : __('Block Channel')}
-                        </div>
-                      </MenuItem>
-
-                      {isAdmin && (
-                        <MenuItem className="comment__menu-option" onSelect={handleToggleAdminBlock}>
-                          <div className="menu__link">
-                            <Icon aria-hidden icon={ICONS.GLOBE} />
-                            {channelIsAdminBlocked ? __('Global Unblock Channel') : __('Global Block Channel')}
-                          </div>
-                        </MenuItem>
-                      )}
-
-                      <MenuItem className="comment__menu-option" onSelect={handleToggleMute}>
-                        <div className="menu__link">
-                          <Icon aria-hidden icon={ICONS.MUTE} />
-                          {channelIsMuted ? __('Unmute Channel') : __('Mute Channel')}
-                        </div>
-                      </MenuItem>
-                    </>
-                  )
-                ) : (
+                {/* COLLECTION OPERATIONS */}
+                {collectionId && isCollectionClaim ? (
                   <>
-                    {/* claimIsMine && (
-                      <MenuItem className="comment__menu-option" onSelect={handleFeature}>
+                    <MenuItem
+                      className="comment__menu-option"
+                      onSelect={() => push(`/$/${PAGES.PLAYLIST}/${collectionId}`)}
+                    >
+                      <a className="menu__link" href={`/$/${PAGES.PLAYLIST}/${collectionId}`}>
+                        <Icon aria-hidden icon={ICONS.VIEW} />
+                        {__('View Playlist')}
+                      </a>
+                    </MenuItem>
+                    {!collectionEmpty && (
+                      <MenuItem
+                        className="comment__menu-option"
+                        onSelect={() => doEnableCollectionShuffle({ collectionId })}
+                      >
                         <div className="menu__link">
-                          <Icon aria-hidden icon={ICONS.HOME} />
-                          {__('Feature')}
-                        </div>
-                      </MenuItem>
-                    ) */}
-                    {!repostedClaim && (
-                      <MenuItem className="comment__menu-option" onSelect={handleEdit}>
-                        <div className="menu__link">
-                          <Icon aria-hidden icon={ICONS.EDIT} />
-                          {__('Edit')}
+                          <Icon aria-hidden icon={ICONS.SHUFFLE} />
+                          {__('Shuffle Play')}
                         </div>
                       </MenuItem>
                     )}
+                    {isMyCollection && (
+                      <>
+                        {!collectionEmpty && (
+                          <MenuItem
+                            className="comment__menu-option"
+                            onSelect={() =>
+                              push(`/$/${PAGES.PLAYLIST}/${collectionId}?${CP.QUERIES.VIEW}=${CP.VIEWS.PUBLISH}`)
+                            }
+                          >
+                            <div className="menu__link">
+                              <Icon aria-hidden iconColor={'red'} icon={ICONS.PUBLISH} />
+                              {hasEdits ? __('Publish') : __('Update')}
+                            </div>
+                          </MenuItem>
+                        )}
+                        <MenuItem
+                          className="comment__menu-option"
+                          onSelect={() =>
+                            push(`/$/${PAGES.PLAYLIST}/${collectionId}?${CP.QUERIES.VIEW}=${CP.VIEWS.EDIT}`)
+                          }
+                        >
+                          <div className="menu__link">
+                            <Icon aria-hidden icon={ICONS.EDIT} />
+                            {__('Edit')}
+                          </div>
+                        </MenuItem>
+                        <MenuItem
+                          className="comment__menu-option"
+                          onSelect={() => openModal(MODALS.COLLECTION_DELETE, { collectionId })}
+                        >
+                          <div className="menu__link">
+                            <Icon aria-hidden icon={ICONS.DELETE} />
+                            {__('Delete Playlist')}
+                          </div>
+                        </MenuItem>
+                      </>
+                    )}
                   </>
-                )}
-
-                {showDelete && (
-                  <MenuItem className="comment__menu-option" onSelect={handleDelete}>
-                    <div className="menu__link">
-                      <Icon aria-hidden icon={ICONS.DELETE} />
-                      {__('Delete')}
-                    </div>
-                  </MenuItem>
+                ) : (
+                  <AddToCollectionContext />
                 )}
               </>
-            )}
-            <hr className="menu__separator" />
-          </>
-        )}
 
-        <MenuItem className="comment__menu-option" onSelect={handleCopyLink}>
-          <div className="menu__link">
-            <Icon aria-hidden icon={ICONS.COPY_LINK} />
-            {__('Copy Link')}
-          </div>
-        </MenuItem>
+              {contentClaim && isContentProtectedAndLocked && !claimIsMine && (
+                <MenuItem
+                  className="comment__menu-option"
+                  onSelect={() =>
+                    openModal(MODALS.JOIN_MEMBERSHIP, {
+                      uri,
+                      fileUri: contentClaim.permanent_url,
+                      shouldNavigate: true,
+                    })
+                  }
+                >
+                  <div className="menu__link">
+                    <Icon aria-hidden icon={ICONS.MEMBERSHIP} />
+                    {__('Join')}
+                  </div>
+                </MenuItem>
+              )}
 
-        {isChannelPage && IS_WEB && rssUrl && (
-          <MenuItem className="comment__menu-option" onSelect={handleCopyRssLink}>
-            <div className="menu__link">
-              <Icon aria-hidden icon={ICONS.RSS} />
-              {__('Copy RSS URL')}
-            </div>
-          </MenuItem>
-        )}
+              {isAuthenticated && (
+                <>
+                  {!isChannelPage && (
+                    <>
+                      <MenuItem className="comment__menu-option" onSelect={handleSupport}>
+                        <div className="menu__link">
+                          <Icon aria-hidden icon={ICONS.LBC} />
+                          {__('Support --[button to support a claim]--')}
+                        </div>
+                      </MenuItem>
+                    </>
+                  )}
 
-        {!claimIsMine && !isMyCollection && (
-          <MenuItem
-            className="comment__menu-option"
-            onSelect={isEmbed ? (e) => e.preventDefault() : handleReportContent}
-          >
-            <NavLink
-              className="menu__link"
-              to={{ pathname: contentClaim ? `/$/${PAGES.REPORT_CONTENT}?claimId=${contentClaim.claim_id}` : '' }}
-              target={isEmbed && '_blank'}
-            >
-              <Icon aria-hidden icon={ICONS.REPORT} />
-              {__('Report Content')}
-            </NavLink>
-          </MenuItem>
+                  {!incognitoClaim && !claimIsMine && !isChannelPage && (
+                    <>
+                      <hr className="menu__separator" />
+                      <MenuItem className="comment__menu-option" onSelect={handleFollow}>
+                        <div className="menu__link">
+                          <Icon aria-hidden icon={ICONS.SUBSCRIBE} />
+                          {subscriptionLabel}
+                        </div>
+                      </MenuItem>
+                    </>
+                  )}
+
+                  {!isMyCollection && (
+                    <>
+                      {(!claimIsMine || channelIsBlocked) && contentChannelUri ? (
+                        !incognitoClaim && (
+                          <>
+                            <MenuItem className="comment__menu-option" onSelect={handleToggleBlock}>
+                              <div className="menu__link">
+                                <Icon aria-hidden icon={ICONS.BLOCK} />
+                                {channelIsBlocked ? __('Unblock Channel') : __('Block Channel')}
+                              </div>
+                            </MenuItem>
+
+                            {isAdmin && (
+                              <MenuItem className="comment__menu-option" onSelect={handleToggleAdminBlock}>
+                                <div className="menu__link">
+                                  <Icon aria-hidden icon={ICONS.GLOBE} />
+                                  {channelIsAdminBlocked ? __('Global Unblock Channel') : __('Global Block Channel')}
+                                </div>
+                              </MenuItem>
+                            )}
+
+                            <MenuItem className="comment__menu-option" onSelect={handleToggleMute}>
+                              <div className="menu__link">
+                                <Icon aria-hidden icon={ICONS.MUTE} />
+                                {channelIsMuted ? __('Unmute Channel') : __('Mute Channel')}
+                              </div>
+                            </MenuItem>
+                          </>
+                        )
+                      ) : (
+                        <>
+                          {/* claimIsMine && (
+                        <MenuItem className="comment__menu-option" onSelect={handleFeature}>
+                          <div className="menu__link">
+                            <Icon aria-hidden icon={ICONS.HOME} />
+                            {__('Feature')}
+                          </div>
+                        </MenuItem>
+                      ) */}
+                          {!repostedClaim && (
+                            <MenuItem className="comment__menu-option" onSelect={handleEdit}>
+                              <div className="menu__link">
+                                <Icon aria-hidden icon={ICONS.EDIT} />
+                                {__('Edit')}
+                              </div>
+                            </MenuItem>
+                          )}
+                        </>
+                      )}
+
+                      {showDelete && (
+                        <MenuItem className="comment__menu-option" onSelect={handleDelete}>
+                          <div className="menu__link">
+                            <Icon aria-hidden icon={ICONS.DELETE} />
+                            {__('Delete')}
+                          </div>
+                        </MenuItem>
+                      )}
+                    </>
+                  )}
+                  <hr className="menu__separator" />
+                </>
+              )}
+
+              <MenuItem className="comment__menu-option" onSelect={handleCopyLink}>
+                <div className="menu__link">
+                  <Icon aria-hidden icon={ICONS.COPY_LINK} />
+                  {__('Copy Link')}
+                </div>
+              </MenuItem>
+
+              {isChannelPage && IS_WEB && rssUrl && (
+                <MenuItem className="comment__menu-option" onSelect={handleCopyRssLink}>
+                  <div className="menu__link">
+                    <Icon aria-hidden icon={ICONS.RSS} />
+                    {__('Copy RSS URL')}
+                  </div>
+                </MenuItem>
+              )}
+
+              {!claimIsMine && !isMyCollection && (
+                <MenuItem
+                  className="comment__menu-option"
+                  onSelect={isEmbed ? (e) => e.preventDefault() : handleReportContent}
+                >
+                  <NavLink
+                    className="menu__link"
+                    to={{ pathname: contentClaim ? `/$/${PAGES.REPORT_CONTENT}?claimId=${contentClaim.claim_id}` : '' }}
+                    target={isEmbed && '_blank'}
+                  >
+                    <Icon aria-hidden icon={ICONS.REPORT} />
+                    {__('Report Content')}
+                  </NavLink>
+                </MenuItem>
+              )}
+            </>
+          )
         )}
       </MenuList>
     </Menu>

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -401,13 +401,25 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
 
   if ((claim && showNullPlaceholder && shouldHide) || (!claim && playlistPreviewItem)) {
     return (
-      <ClaimPreviewHidden
-        message={!claim && playlistPreviewItem ? __('Deleted content') : __('This content is hidden')}
-        isChannel={isChannelUri}
-        type={type}
-        uri={uri}
-        collectionId={!claim && playlistPreviewItem && collectionId ? collectionId : undefined}
-      />
+      <WrapperElement
+        ref={ref}
+        className={classnames('claim-preview__wrapper', {
+          'claim-preview__wrapper--row': !type,
+          'claim-preview__wrapper--inline': type === 'inline',
+          'claim-preview__wrapper--playlist-row': type === 'small' && collectionId,
+          'claim-preview__wrapper--active': active,
+          'non-clickable': nonClickable,
+        })}
+      >
+        <ClaimPreviewHidden
+          message={!claim && playlistPreviewItem ? __('Deleted content') : __('This content is hidden')}
+          isChannel={isChannelUri}
+          type={type}
+          uri={uri}
+          collectionId={!claim && playlistPreviewItem && collectionId ? collectionId : undefined}
+        />
+        {!hideMenu && <ClaimMenuList uri={uri} collectionId={collectionId} />}
+      </WrapperElement>
     );
   }
 

--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -408,7 +408,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
           'claim-preview__wrapper--inline': type === 'inline',
           'claim-preview__wrapper--playlist-row': type === 'small' && collectionId,
           'claim-preview__wrapper--active': active,
-          'non-clickable': nonClickable,
+          'non-clickable': !playlistPreviewItem || nonClickable,
         })}
       >
         <ClaimPreviewHidden
@@ -418,7 +418,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
           uri={uri}
           collectionId={!claim && playlistPreviewItem && collectionId ? collectionId : undefined}
         />
-        {!hideMenu && <ClaimMenuList uri={uri} collectionId={collectionId} />}
+        {playlistPreviewItem && !hideMenu && <ClaimMenuList uri={uri} collectionId={collectionId} />}
       </WrapperElement>
     );
   }


### PR DESCRIPTION
**Issue:**
Removing deleted items from private list is bit unclear on desktop, and not possible on mobile.
Also deleted content doesn't look that nice in the list.

**Changes:**
-Make deleted content look similar to existing content
-Show 3-dot menu for deleted content for clearer deletion option

<details>
<summary>OLD vs NEW mobile:</summary>

![2023-12-16_13-43_1](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/87990f18-03dd-4f99-94ec-c6adefb8bc71)
![2023-12-16_13-43](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/c2cc41a9-49b7-4341-8591-6a67146da6a2)
</details>

<details>
<summary>OLD vs NEW desktop:</summary>

![2023-12-16_13-42_1](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/a36cca22-78d5-47b4-9afe-eaec1751e756)
![2023-12-16_13-42](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/575baa00-4d39-4e3d-9989-e5c56005900d)
</details>

