### PR TITLE
Fix comment fetch when pinned count == page count

### DIFF
--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -334,8 +334,6 @@ export default function CommentList(props: Props & StateProps & DispatchProps) {
 
   // Infinite scroll
   useEffect(() => {
-    if (topLevelComments.length === 0) return;
-
     function shouldFetchNextPage(page, topLevelTotalPages, yPrefetchPx = 1000) {
       if (!spinnerRef || !spinnerRef.current) return false;
 
@@ -379,7 +377,6 @@ export default function CommentList(props: Props & StateProps & DispatchProps) {
       }
     }
   }, [
-    topLevelComments,
     hasDefaultExpansion,
     didInitialPageFetch,
     isFetchingComments,


### PR DESCRIPTION
## Ticket
Closes #3032

## Remarks

The line doesn't belong in that effect because comment-fetching has always been a function of scroll position and 'current vs total page count'.

But I'm sure it's there for a reason. Couldn't figure out from history either, so we'll have to try out random cases (e.g. pop out? livestream?).  Help @ `inf` to see what breaks?
