### PR TITLE
Improve notification deletion

### DIFF
--- a/flow-typed/notification.js
+++ b/flow-typed/notification.js
@@ -103,6 +103,7 @@ declare type DoDismissError = {
 declare type NotificationState = {
   notifications: Array<Notification>,
   notificationsFiltered: Array<Notification>,
+  deletedNotificationIds: Array<number>,
   notificationCategories: any,
   fetchingNotifications: boolean,
   errors: Array<ErrorNotification>,

--- a/ui/page/notifications/view.jsx
+++ b/ui/page/notifications/view.jsx
@@ -105,7 +105,7 @@ export default function NotificationsPage(props: Props) {
         }
       }
     }
-  }, [name, notifications, stringifiedNotificationCategories, doNotificationList]);
+  }, [name, stringifiedNotificationCategories, doNotificationList]);
 
   React.useEffect(() => {
     if (!notificationCategories) {

--- a/ui/redux/reducers/notifications.js
+++ b/ui/redux/reducers/notifications.js
@@ -5,6 +5,7 @@ import { handleActions } from 'util/redux-utils';
 const defaultState: NotificationState = {
   notifications: [],
   notificationsFiltered: [],
+  deletedNotificationIds: [],
   notificationCategories: undefined,
   fetchingNotifications: false,
   toasts: [],
@@ -56,17 +57,23 @@ export default handleActions(
       };
     },
     [ACTIONS.NOTIFICATION_LIST_COMPLETED]: (state, action) => {
+      const { deletedNotificationIds } = state;
       const { filterRule, newNotifications } = action.data;
+
+      const deleteIds = (list, ids) => {
+        return list.filter((n) => !ids.includes(n.id));
+      };
+
       if (filterRule) {
         return {
           ...state,
-          notificationsFiltered: newNotifications,
+          notificationsFiltered: deleteIds(newNotifications, deletedNotificationIds),
           fetchingNotifications: false,
         };
       } else {
         return {
           ...state,
-          notifications: newNotifications,
+          notifications: deleteIds(newNotifications, deletedNotificationIds),
           fetchingNotifications: false,
         };
       }
@@ -133,7 +140,7 @@ export default handleActions(
       };
     },
     [ACTIONS.NOTIFICATION_DELETE_COMPLETED]: (state, action) => {
-      const { notifications, notificationsFiltered } = state;
+      const { notifications, notificationsFiltered, deletedNotificationIds } = state;
       const { notificationId } = action.data;
 
       const deleteId = (list, id) => {
@@ -144,6 +151,7 @@ export default handleActions(
         ...state,
         notifications: deleteId(notifications, notificationId),
         notificationsFiltered: deleteId(notificationsFiltered, notificationId),
+        deletedNotificationIds: deletedNotificationIds.concat(notificationId),
       };
     },
 


### PR DESCRIPTION
Fixes:
Deleting notification in some other category than "All" didn't delete the item on the UI. (Needed to wait a min and then trigger re-fetching of notifications for it to disappear.)