### PR TITLE
Show a message if loading own comments is taking >10s

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2957,6 +2957,7 @@
   "Credits: %credits%": "Credits: %credits%",
   "Publications: %claims%": "Publications: %claims%",
   "Channels:": "Channels",
+  "Larger comment histories may take time to load": "Larger comment histories may take time to load",
 
   "--end--": "--end--"
 }


### PR DESCRIPTION
# Fixes:
User complained about loading own comments "hanging".  It took ~30s on their account.

Now loading long would look like this:  

https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/c076a2bc-baba-4322-be61-f6007fef42e3


