### PR TITLE
Fix attempt - Issue #2895 

### DIFF
--- a/ui/component/viewers/videoViewer/view.jsx
+++ b/ui/component/viewers/videoViewer/view.jsx
@@ -322,6 +322,7 @@ function VideoViewer(props: Props) {
 
   React.useEffect(() => {
     if (playerElem) {
+      playerElem.off('ended');
       playerElem.on('ended', onVideoEnded);
     }
   }, [onVideoEnded, playerElem]);


### PR DESCRIPTION
## Fixes

Issue Number: #2895 

New behavior:
-queue pauses playing on end of the last video
-the second item from the queue doesn't start playing in middle of other playlists

Seems that a second `onVideoEnded` function gets attached to the player, when a second queue item is added. (Doesn't happen with following video adds)  
And one of those sticked around, and got called when not wanted. (I didn't quite understood how this exactly worked.)

Clearing `onEnded`s before adding a new one, seems to fix the behavior.
Also clearing them didn't seem to break anything. Looping and shuffle also kept working the same than before.

