### PR TITLE
Improve sync deletion warnings

### DIFF
--- a/ui/modal/modalRemoveAccount/index.js
+++ b/ui/modal/modalRemoveAccount/index.js
@@ -15,13 +15,14 @@ import {
   selectIsFetchingAccountsSuccess,
 } from 'redux/selectors/wallet';
 import { doFetchAccountList } from 'redux/actions/wallet';
-import { selectUser } from 'redux/selectors/user';
+import { selectUser, selectHasYoutubeChannels } from 'redux/selectors/user';
 import { doFetchChannelListMine, doFetchClaimListMine } from 'redux/actions/claims';
 import { doRemoveAccountSequence } from './thunk';
 import ModalRemoveAccount from './view';
 
 const select = (state) => ({
   isPendingDeletion: selectUser(state)?.pending_deletion,
+  hasYouTubeChannels: selectHasYoutubeChannels(state),
   totalBalance: selectTotalBalance(state),
   totalClaimsCount: selectMyClaimsPageItemCount(state),
   channelUrls: selectMyChannelClaimUrls(state),

--- a/ui/modal/modalRemoveAccount/view.jsx
+++ b/ui/modal/modalRemoveAccount/view.jsx
@@ -9,6 +9,7 @@ import { FormField } from 'component/common/form';
 
 type Props = {
   isPendingDeletion: ?boolean,
+  hasYouTubeChannels: boolean,
   totalBalance: number,
   totalClaimsCount: number,
   isFetchingChannels: boolean,
@@ -29,6 +30,7 @@ type Props = {
 export default function ModalRemoveAccount(props: Props) {
   const {
     isPendingDeletion,
+    hasYouTubeChannels,
     totalBalance,
     totalClaimsCount,
     isFetchingChannels,
@@ -55,10 +57,7 @@ export default function ModalRemoveAccount(props: Props) {
   const isLoadingAccountInfo = isFetchingChannels || isFetchingAccounts || isFetchingClaims;
   const isLoadingAccountInfoSuccess = isFetchingChannelsSuccess && isFetchingAccountsSuccess && isFetchingClaimsSuccess;
   const showButton =
-    !buttonClicked &&
-    (!isPendingDeletion || !isWalletEmpty) &&
-    isLoadingAccountInfoSuccess &&
-    !isLoadingAccountInfo;
+    !buttonClicked && (!isPendingDeletion || !isWalletEmpty) && isLoadingAccountInfoSuccess && !isLoadingAccountInfo;
 
   React.useEffect(() => {
     if (!isPendingDeletion || !isWalletEmpty) {
@@ -151,6 +150,16 @@ export default function ModalRemoveAccount(props: Props) {
                 <p>
                   {__(
                     "We detected multiple wallets on this account. Please make sure this account doesn't have any credits, publications or channels that you don't want to lose. If you aren't sure, please reach out to help@odysee.com for support."
+                  )}
+                </p>
+              </div>
+            )}
+            {showButton && hasYouTubeChannels && (
+              <div className="help--warning">
+                <p>{__('YOUTUBE SYNCED CHANNELS!')}</p>
+                <p>
+                  {__(
+                    "If something went wrong with the sync, please don't try to fix it by deleting the channel. Instead reach out to us at help@odysee.com to get it fixed. Once deleted we may not be able to sync it again or fix it."
                   )}
                 </p>
               </div>

--- a/ui/modal/modalRevokeClaim/index.js
+++ b/ui/modal/modalRevokeClaim/index.js
@@ -2,11 +2,13 @@ import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
 import { doAbandonTxo, doAbandonClaim, doResolveUri } from 'redux/actions/claims';
 import { doToast } from 'redux/actions/notifications';
+import { selectHasYoutubeChannels } from 'redux/selectors/user';
 import ModalRevokeClaim from './view';
 import { selectTransactionItems } from 'redux/selectors/wallet';
 
 const select = (state) => ({
   transactionItems: selectTransactionItems(state),
+  hasYouTubeChannels: selectHasYoutubeChannels(state),
 });
 
 const perform = (dispatch) => ({

--- a/ui/modal/modalRevokeClaim/view.jsx
+++ b/ui/modal/modalRevokeClaim/view.jsx
@@ -13,13 +13,14 @@ type Props = {
   abandonTxo: (Txo, () => void) => void,
   abandonClaim: (Claim, ?() => void) => void,
   tx: Txo,
+  hasYouTubeChannels: boolean,
   claim: Claim,
   cb: () => void,
   doResolveUri: (string) => void,
 };
 
 export default function ModalRevokeClaim(props: Props) {
-  const { tx, claim, closeModal, abandonTxo, abandonClaim, cb, doResolveUri } = props;
+  const { tx, hasYouTubeChannels, claim, closeModal, abandonTxo, abandonClaim, cb, doResolveUri } = props;
   const { value_type: valueType, type, normalized_name: name, is_my_input: isSupport } = tx || claim;
   const [channelName, setChannelName] = useState('');
 
@@ -70,15 +71,16 @@ export default function ModalRevokeClaim(props: Props) {
     } else if (shouldConfirmChannel) {
       return (
         <React.Fragment>
-          <p>
-            {__('This will permanently remove your channel. Content published under this channel will be orphaned.')}
-          </p>
-          <p>{__('YOUTUBE SYNCED CHANNELS!')}</p>
-          <p>
-            {__(
-              "If something went wrong with the sync, please don't try to fix it by deleting the channel. Instead reach out to us at help@odysee.com to get it fixed. Once deleted we may not be able to sync it again or fix it."
-            )}
-          </p>
+          {hasYouTubeChannels && (
+            <div className="help--warning">
+              <p>{__('YOUTUBE SYNCED CHANNELS!')}</p>
+              <p>
+                {__(
+                  "If something went wrong with the sync, please don't try to fix it by deleting the channel. Instead reach out to us at help@odysee.com to get it fixed. Once deleted we may not be able to sync it again or fix it."
+                )}
+              </p>
+            </div>
+          )}
           <p>{__('Are you sure? Type %name% to confirm that you wish to remove the channel.', { name })}</p>
           <FormField type={'text'} onChange={(e) => setChannelName(e.target.value)} />
         </React.Fragment>

--- a/ui/modal/modalRevokeClaim/view.jsx
+++ b/ui/modal/modalRevokeClaim/view.jsx
@@ -71,6 +71,9 @@ export default function ModalRevokeClaim(props: Props) {
     } else if (shouldConfirmChannel) {
       return (
         <React.Fragment>
+          <p>
+            {__('This will permanently remove your channel. Content published under this channel will be orphaned.')}
+          </p>
           {hasYouTubeChannels && (
             <div className="help--warning">
               <p>{__('YOUTUBE SYNCED CHANNELS!')}</p>

--- a/ui/redux/selectors/user.js
+++ b/ui/redux/selectors/user.js
@@ -34,7 +34,7 @@ export const selectPhoneToVerify = createSelector(
 );
 
 export const selectYoutubeChannels = createSelector(selectUser, (user) => (user ? user.youtube_channels : null));
-export const selectHasYoutubeChannels = (state) => Number.isInteger(selectYoutubeChannels(state)?.length);
+export const selectHasYoutubeChannels = (state) => selectYoutubeChannels(state)?.length > 0;
 
 export const selectUserIsRewardApproved = createSelector(selectUser, (user) => user && user.is_reward_approved);
 


### PR DESCRIPTION
-Show warning about synced channels on account deletion, if user has any synced channels
-On channel deletion, don't show the warning about synced channels, if user doesn't have any synced channels
-`selectHasYoutubeChannels`  used to always return `true` due to it working previously like this: `Number.isInteger(youtubeChannels?.length)` (returned `true` for an array with length of 0)


<details>
<summary>Channel deletion warning images:</summary>

<img width="700px" src="https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/cb7487c9-29c6-4308-a137-c8d9734f1572">

<img width="700px" src="https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/3c8ea782-cfba-44ca-87f9-76f6d59f2990">

</details>
  
 ---------
#### *Note:*

Changing the `selectHasYoutubeChannels` to return  `false`, when account doesn't have any connected YouTube channels, changes how the empty channel page looks.

<details>
<summary>Images:</summary>

OLD:
<img width="700px" src="https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/4a104cdf-a370-4002-ab3e-c50a3d9e0cbd">
NEW:
<img width="700px" src="https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/c59087df-08fb-409f-b667-7e3bcb46f4ce">

</details>

