### PR TITLE
Fix - Editing queue/favorites broken

### DIFF
--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -539,7 +539,7 @@ export const doCollectionEdit =
     await dispatch(doFetchItemsInCollection({ collectionId }));
     state = getState();
     const hasItemsResolved = selectCollectionHasItemsResolvedForId(state, collectionId);
-    if (!hasItemsResolved) {
+    if (isPublic && !hasItemsResolved) {
       return dispatch(doToast({ message: __('Failed to resolve collection items. Please try again.'), isError: true }));
     }
 


### PR DESCRIPTION
## Fixes
Can't edit queue and some other private lists

Don't block editing of private list, even if the list items aren't resolved, as the urls are already known.
Possibly temporary quick fix, will look bit more into it, but this should work.