### PR TITLE
Fix attempt - Can't click scroll bar in the player side playlist-card

### DIFF
--- a/ui/component/playlistCard/view.jsx
+++ b/ui/component/playlistCard/view.jsx
@@ -159,9 +159,12 @@ const PlaylistCardComponent = (props: PlaylistCardProps) => {
   const [hasActive, setHasActive] = React.useState();
   const [scrolledPastActive, setScrolledPast] = React.useState();
 
+  /*
+  // Disabled due to it blocking the clicking of the scrollbar
   const backgroundImage = thumbnailFromClaim
     ? 'https://thumbnails.odycdn.com/optimize/s:390:0/quality:85/plain/' + thumbnailFromClaim
     : undefined;
+  */
 
   function closePlaylist() {
     if (collectionEmpty) {
@@ -453,7 +456,8 @@ const PlaylistCardComponent = (props: PlaylistCardProps) => {
             />
           )
         }
-        backgroundImage={backgroundImage}
+        // Disabled due to it blocking the clicking of the scrollbar
+        // backgroundImage={backgroundImage}
       />
     </>
   );


### PR DESCRIPTION
Fixes #3073 
Not sure if a wanted solution.

Div created for background image seems to be blocking the scrollbar.
Not using the background image in the player side playlist and in the floating player list allows to avoid it.


<details>
<summary>Images</summary>

![2024-03-20_10-06](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/3c0b4172-c9ae-4d93-8481-a9415aef2b4f)
--------------------

![2024-03-20_10-07](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/2953ca8c-6063-4b8b-a486-abafb8016358)
</details>
