### PR TITLE
Allow disabling reactions with a tag

### DIFF
--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -479,7 +479,9 @@ function CommentView(props: Props & StateProps & DispatchProps) {
                       icon={ICONS.REPLY}
                       iconSize={isMobile && 12}
                     />
-                    {ENABLE_COMMENT_REACTIONS && <CommentReactions uri={uri} commentId={commentId} />}
+                    {ENABLE_COMMENT_REACTIONS && (
+                      <CommentReactions uri={uri} authorUri={authorUri} commentId={commentId} />
+                    )}
                   </div>
                 )}
 

--- a/ui/component/commentReactions/index.js
+++ b/ui/component/commentReactions/index.js
@@ -6,7 +6,7 @@ import { doToast } from 'redux/actions/notifications';
 import { selectMyReactsForComment, selectOthersReactsForComment } from 'redux/selectors/comments';
 import { doCommentReact } from 'redux/actions/comments';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
-import { DISABLE_REACTIONS_ALL } from 'constants/tags';
+import { DISABLE_REACTIONS_ALL_TAG } from 'constants/tags';
 
 const select = (state, props) => {
   const activeChannelClaim = selectActiveChannelClaim(state);
@@ -16,7 +16,7 @@ const select = (state, props) => {
 
   return {
     claim,
-    disableReactions: makeSelectTagInClaimOrChannelForUri(props.authorUri, DISABLE_REACTIONS_ALL)(state),
+    disableReactions: makeSelectTagInClaimOrChannelForUri(props.authorUri, DISABLE_REACTIONS_ALL_TAG)(state),
     claimIsMine: selectClaimIsMine(state, claim),
     myReacts: selectMyReactsForComment(state, reactionKey),
     othersReacts: selectOthersReactsForComment(state, reactionKey),

--- a/ui/component/commentReactions/index.js
+++ b/ui/component/commentReactions/index.js
@@ -1,11 +1,12 @@
 import { connect } from 'react-redux';
 import CommentReactions from './view';
-import { selectClaimIsMine, selectClaimForUri } from 'redux/selectors/claims';
+import { selectClaimIsMine, selectClaimForUri, makeSelectTagInClaimOrChannelForUri } from 'redux/selectors/claims';
 import { doResolveUri } from 'redux/actions/claims';
 import { doToast } from 'redux/actions/notifications';
 import { selectMyReactsForComment, selectOthersReactsForComment } from 'redux/selectors/comments';
 import { doCommentReact } from 'redux/actions/comments';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
+import { DISABLE_REACTIONS_ALL } from 'constants/tags';
 
 const select = (state, props) => {
   const activeChannelClaim = selectActiveChannelClaim(state);
@@ -15,6 +16,7 @@ const select = (state, props) => {
 
   return {
     claim,
+    disableReactions: makeSelectTagInClaimOrChannelForUri(props.authorUri, DISABLE_REACTIONS_ALL)(state),
     claimIsMine: selectClaimIsMine(state, claim),
     myReacts: selectMyReactsForComment(state, reactionKey),
     othersReacts: selectOthersReactsForComment(state, reactionKey),

--- a/ui/component/commentReactions/view.jsx
+++ b/ui/component/commentReactions/view.jsx
@@ -12,6 +12,7 @@ import { useIsMobile } from 'effects/use-screensize';
 
 type Props = {
   myReacts: Array<string>,
+  disableReactions: boolean,
   othersReacts: any,
   react: (string, string) => void,
   commentId: string,
@@ -28,6 +29,7 @@ type Props = {
 export default function CommentReactions(props: Props) {
   const {
     myReacts,
+    disableReactions,
     othersReacts,
     commentId,
     react,
@@ -109,28 +111,32 @@ export default function CommentReactions(props: Props) {
 
   return (
     <>
-      <Button
-        requiresAuth={IS_WEB}
-        title={__('Upvote')}
-        icon={likeIcon}
-        iconSize={isMobile && 12}
-        className={classnames('comment__action button-like', {
-          'comment__action--active': myReacts && myReacts.includes(REACTION_TYPES.LIKE),
-        })}
-        onClick={handleCommentLike}
-        label={<span className="comment__reaction-count">{getCountForReact(REACTION_TYPES.LIKE)}</span>}
-      />
-      <Button
-        requiresAuth={IS_WEB}
-        title={__('Downvote')}
-        icon={dislikeIcon}
-        iconSize={isMobile && 12}
-        className={classnames('comment__action button-dislike', {
-          'comment__action--active': myReacts && myReacts.includes(REACTION_TYPES.DISLIKE),
-        })}
-        onClick={handleCommentDislike}
-        label={<span className="comment__reaction-count">{getCountForReact(REACTION_TYPES.DISLIKE)}</span>}
-      />
+      {!disableReactions && (
+        <>
+          <Button
+            requiresAuth={IS_WEB}
+            title={__('Upvote')}
+            icon={likeIcon}
+            iconSize={isMobile && 12}
+            className={classnames('comment__action button-like', {
+              'comment__action--active': myReacts && myReacts.includes(REACTION_TYPES.LIKE),
+            })}
+            onClick={handleCommentLike}
+            label={<span className="comment__reaction-count">{getCountForReact(REACTION_TYPES.LIKE)}</span>}
+          />
+          <Button
+            requiresAuth={IS_WEB}
+            title={__('Downvote')}
+            icon={dislikeIcon}
+            iconSize={isMobile && 12}
+            className={classnames('comment__action button-dislike', {
+              'comment__action--active': myReacts && myReacts.includes(REACTION_TYPES.DISLIKE),
+            })}
+            onClick={handleCommentDislike}
+            label={<span className="comment__reaction-count">{getCountForReact(REACTION_TYPES.DISLIKE)}</span>}
+          />
+        </>
+      )}
 
       {!shouldHide && ENABLE_CREATOR_REACTIONS && (canCreatorReact || creatorLiked) && (
         <Button

--- a/ui/component/fileActions/index.js
+++ b/ui/component/fileActions/index.js
@@ -20,7 +20,7 @@ import { doOpenModal } from 'redux/actions/app';
 import FileActions from './view';
 import { makeSelectFileRenderModeForUri, selectContentStates } from 'redux/selectors/content';
 import { selectNoRestrictionOrUserIsMemberForContentClaimId } from 'redux/selectors/memberships';
-import { DISABLE_DOWNLOAD_BUTTON_TAG } from 'constants/tags';
+import { DISABLE_DOWNLOAD_BUTTON_TAG, DISABLE_REACTIONS_ALL } from 'constants/tags';
 import { isStreamPlaceholderClaim } from 'util/claim';
 import * as RENDER_MODES from 'constants/file_render_modes';
 
@@ -33,6 +33,7 @@ const select = (state, props) => {
 
   return {
     claim,
+    disableFileReactions: makeSelectTagInClaimOrChannelForUri(uri, DISABLE_REACTIONS_ALL)(state),
     claimIsMine: selectClaimIsMine(state, claim),
     renderMode: makeSelectFileRenderModeForUri(uri)(state),
     costInfo: selectCostInfoForUri(state, uri),

--- a/ui/component/fileActions/index.js
+++ b/ui/component/fileActions/index.js
@@ -20,7 +20,7 @@ import { doOpenModal } from 'redux/actions/app';
 import FileActions from './view';
 import { makeSelectFileRenderModeForUri, selectContentStates } from 'redux/selectors/content';
 import { selectNoRestrictionOrUserIsMemberForContentClaimId } from 'redux/selectors/memberships';
-import { DISABLE_DOWNLOAD_BUTTON_TAG, DISABLE_REACTIONS_ALL } from 'constants/tags';
+import { DISABLE_DOWNLOAD_BUTTON_TAG, DISABLE_REACTIONS_ALL, DISABLE_REACTIONS_VIDEO } from 'constants/tags';
 import { isStreamPlaceholderClaim } from 'util/claim';
 import * as RENDER_MODES from 'constants/file_render_modes';
 
@@ -33,7 +33,9 @@ const select = (state, props) => {
 
   return {
     claim,
-    disableFileReactions: makeSelectTagInClaimOrChannelForUri(uri, DISABLE_REACTIONS_ALL)(state),
+    disableFileReactions:
+      makeSelectTagInClaimOrChannelForUri(uri, DISABLE_REACTIONS_ALL)(state) ||
+      makeSelectTagInClaimOrChannelForUri(uri, DISABLE_REACTIONS_VIDEO)(state),
     claimIsMine: selectClaimIsMine(state, claim),
     renderMode: makeSelectFileRenderModeForUri(uri)(state),
     costInfo: selectCostInfoForUri(state, uri),

--- a/ui/component/fileActions/index.js
+++ b/ui/component/fileActions/index.js
@@ -20,7 +20,7 @@ import { doOpenModal } from 'redux/actions/app';
 import FileActions from './view';
 import { makeSelectFileRenderModeForUri, selectContentStates } from 'redux/selectors/content';
 import { selectNoRestrictionOrUserIsMemberForContentClaimId } from 'redux/selectors/memberships';
-import { DISABLE_DOWNLOAD_BUTTON_TAG, DISABLE_REACTIONS_ALL, DISABLE_REACTIONS_VIDEO } from 'constants/tags';
+import { DISABLE_DOWNLOAD_BUTTON_TAG, DISABLE_REACTIONS_ALL_TAG, DISABLE_REACTIONS_VIDEO_TAG } from 'constants/tags';
 import { isStreamPlaceholderClaim } from 'util/claim';
 import * as RENDER_MODES from 'constants/file_render_modes';
 
@@ -34,8 +34,8 @@ const select = (state, props) => {
   return {
     claim,
     disableFileReactions:
-      makeSelectTagInClaimOrChannelForUri(uri, DISABLE_REACTIONS_ALL)(state) ||
-      makeSelectTagInClaimOrChannelForUri(uri, DISABLE_REACTIONS_VIDEO)(state),
+      makeSelectTagInClaimOrChannelForUri(uri, DISABLE_REACTIONS_ALL_TAG)(state) ||
+      makeSelectTagInClaimOrChannelForUri(uri, DISABLE_REACTIONS_VIDEO_TAG)(state),
     claimIsMine: selectClaimIsMine(state, claim),
     renderMode: makeSelectFileRenderModeForUri(uri)(state),
     costInfo: selectCostInfoForUri(state, uri),

--- a/ui/component/fileActions/view.jsx
+++ b/ui/component/fileActions/view.jsx
@@ -26,6 +26,7 @@ type Props = {
   hideRepost?: boolean,
   // redux
   claim: StreamClaim,
+  disableFileReactions: boolean,
   claimIsMine: boolean,
   renderMode: string,
   costInfo: ?{ cost: number },
@@ -53,6 +54,7 @@ export default function FileActions(props: Props) {
     uri,
     claimIsMine,
     claim,
+    disableFileReactions,
     costInfo,
     renderMode,
     hasChannels,
@@ -149,7 +151,7 @@ export default function FileActions(props: Props) {
 
   return (
     <div className="media__actions">
-      {ENABLE_FILE_REACTIONS && isAllowedToReact() && <FileReactions uri={uri} />}
+      {ENABLE_FILE_REACTIONS && !disableFileReactions && isAllowedToReact() && <FileReactions uri={uri} />}
 
       {!isAPreorder && !isFiatRequired && <ClaimSupportButton uri={uri} fileAction />}
 

--- a/ui/component/notification/view.jsx
+++ b/ui/component/notification/view.jsx
@@ -218,6 +218,7 @@ export default function Notification(props: Props) {
             />
             <CommentReactions
               uri={notificationTarget}
+              authorUri={channelUrl}
               commentId={notification_parameters.dynamic.hash}
               hideCreatorLike
             />

--- a/ui/constants/tags.js
+++ b/ui/constants/tags.js
@@ -22,6 +22,7 @@ export const SCHEDULED_LIVESTREAM_TAG = 'c:scheduled-livestream'; // Deprecated;
 export const LBRY_FIRST_TAG = 'c:lbry-first';
 export const DISABLE_DOWNLOAD_BUTTON_TAG = 'c:disable-download';
 export const DISABLE_REACTIONS_ALL = 'c:disable-reactions-all';
+export const DISABLE_REACTIONS_VIDEO = 'c:disable-reactions-video';
 
 export const PURCHASE_TAG = 'c:purchase';
 export const RENTAL_TAG = 'c:rental';
@@ -44,7 +45,13 @@ export const SCHEDULED_TAGS = Object.freeze({
 });
 
 // Control tags are special tags that are available to the user in some situations.
-export const CONTROL_TAGS = [DISABLE_SUPPORT_TAG, PREFERENCE_EMBED, DISABLE_DOWNLOAD_BUTTON_TAG, DISABLE_REACTIONS_ALL];
+export const CONTROL_TAGS = [
+  DISABLE_SUPPORT_TAG,
+  PREFERENCE_EMBED,
+  DISABLE_DOWNLOAD_BUTTON_TAG,
+  DISABLE_REACTIONS_ALL,
+  DISABLE_REACTIONS_VIDEO,
+];
 
 // System tags are special tags that are not available to the user.
 export const SYSTEM_TAGS = [LBRY_FIRST_TAG, ...Object.values(VISIBILITY_TAGS), ...Object.values(SCHEDULED_TAGS)];

--- a/ui/constants/tags.js
+++ b/ui/constants/tags.js
@@ -21,6 +21,7 @@ export const PREFERENCE_EMBED = 'c:preference-embed';
 export const SCHEDULED_LIVESTREAM_TAG = 'c:scheduled-livestream'; // Deprecated; use 'SCHEDULED_TAGS.LIVE'
 export const LBRY_FIRST_TAG = 'c:lbry-first';
 export const DISABLE_DOWNLOAD_BUTTON_TAG = 'c:disable-download';
+export const DISABLE_REACTIONS_ALL = 'c:disable-reactions-all';
 
 export const PURCHASE_TAG = 'c:purchase';
 export const RENTAL_TAG = 'c:rental';
@@ -43,7 +44,7 @@ export const SCHEDULED_TAGS = Object.freeze({
 });
 
 // Control tags are special tags that are available to the user in some situations.
-export const CONTROL_TAGS = [DISABLE_SUPPORT_TAG, PREFERENCE_EMBED, DISABLE_DOWNLOAD_BUTTON_TAG];
+export const CONTROL_TAGS = [DISABLE_SUPPORT_TAG, PREFERENCE_EMBED, DISABLE_DOWNLOAD_BUTTON_TAG, DISABLE_REACTIONS_ALL];
 
 // System tags are special tags that are not available to the user.
 export const SYSTEM_TAGS = [LBRY_FIRST_TAG, ...Object.values(VISIBILITY_TAGS), ...Object.values(SCHEDULED_TAGS)];

--- a/ui/constants/tags.js
+++ b/ui/constants/tags.js
@@ -21,8 +21,8 @@ export const PREFERENCE_EMBED = 'c:preference-embed';
 export const SCHEDULED_LIVESTREAM_TAG = 'c:scheduled-livestream'; // Deprecated; use 'SCHEDULED_TAGS.LIVE'
 export const LBRY_FIRST_TAG = 'c:lbry-first';
 export const DISABLE_DOWNLOAD_BUTTON_TAG = 'c:disable-download';
-export const DISABLE_REACTIONS_ALL = 'c:disable-reactions-all';
-export const DISABLE_REACTIONS_VIDEO = 'c:disable-reactions-video';
+export const DISABLE_REACTIONS_ALL_TAG = 'c:disable-reactions-all';
+export const DISABLE_REACTIONS_VIDEO_TAG = 'c:disable-reactions-video';
 
 export const PURCHASE_TAG = 'c:purchase';
 export const RENTAL_TAG = 'c:rental';
@@ -49,8 +49,8 @@ export const CONTROL_TAGS = [
   DISABLE_SUPPORT_TAG,
   PREFERENCE_EMBED,
   DISABLE_DOWNLOAD_BUTTON_TAG,
-  DISABLE_REACTIONS_ALL,
-  DISABLE_REACTIONS_VIDEO,
+  DISABLE_REACTIONS_ALL_TAG,
+  DISABLE_REACTIONS_VIDEO_TAG,
 ];
 
 // System tags are special tags that are not available to the user.


### PR DESCRIPTION
## Fixes
Allows disabling reactions for channel's content/comments with tag `c:disable-reactions-all`, and for content only with `c:disable-reactions-video`

*Note:*
Currently creator likes are still always allowed with this(?)

![2024-04-08_11-35](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/e308cc22-9284-4337-bd70-4ebc195a5cda)


