### PR TITLE
Fix - disable reactions in comments

### DIFF
--- a/ui/component/comment/view.jsx
+++ b/ui/component/comment/view.jsx
@@ -479,9 +479,7 @@ function CommentView(props: Props & StateProps & DispatchProps) {
                       icon={ICONS.REPLY}
                       iconSize={isMobile && 12}
                     />
-                    {ENABLE_COMMENT_REACTIONS && (
-                      <CommentReactions uri={uri} authorUri={authorUri} commentId={commentId} />
-                    )}
+                    {ENABLE_COMMENT_REACTIONS && <CommentReactions uri={uri} commentId={commentId} />}
                   </div>
                 )}
 

--- a/ui/component/commentReactions/index.js
+++ b/ui/component/commentReactions/index.js
@@ -16,8 +16,8 @@ const select = (state, props) => {
 
   return {
     claim,
-    disableReactions: makeSelectTagInClaimOrChannelForUri(props.authorUri, DISABLE_REACTIONS_ALL_TAG)(state),
-    disableSlimes: makeSelectTagInClaimOrChannelForUri(props.authorUri, DISABLE_SLIMES_ALL_TAG)(state),
+    disableReactions: makeSelectTagInClaimOrChannelForUri(props.uri, DISABLE_REACTIONS_ALL_TAG)(state),
+    disableSlimes: makeSelectTagInClaimOrChannelForUri(props.uri, DISABLE_SLIMES_ALL_TAG)(state),
     claimIsMine: selectClaimIsMine(state, claim),
     myReacts: selectMyReactsForComment(state, reactionKey),
     othersReacts: selectOthersReactsForComment(state, reactionKey),

--- a/ui/component/notification/view.jsx
+++ b/ui/component/notification/view.jsx
@@ -218,7 +218,6 @@ export default function Notification(props: Props) {
             />
             <CommentReactions
               uri={notificationTarget}
-              authorUri={channelUrl}
               commentId={notification_parameters.dynamic.hash}
               hideCreatorLike
             />


### PR DESCRIPTION
Allow disabling reactions on all comments on own content, instead of own comments in other's content

