### PR TITLE
Show control tags

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2960,7 +2960,7 @@
   "Larger comment histories may take time to load": "Larger comment histories may take time to load",
   "Disable Slimes Video + Comments": "Disable Slimes Video + Comments",
   "Disable Reactions Video + Comments": "Disable Reactions Video + Comments",
-  "Disable tipping and boosting": "Disable tipping and boosting",
+  "Disable Tipping And Boosting": "Disable Tipping And Boosting",
 
   "--end--": "--end--"
 }

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2960,7 +2960,7 @@
   "Larger comment histories may take time to load": "Larger comment histories may take time to load",
   "Disable Slimes Video + Comments": "Disable Slimes Video + Comments",
   "Disable Reactions Video + Comments": "Disable Reactions Video + Comments",
-  "Disable Tipping And Boosting": "Disable Tipping And Boosting",
+  "Disable Tipping and Boosting": "Disable Tipping and Boosting",
 
   "--end--": "--end--"
 }

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2958,6 +2958,9 @@
   "Publications: %claims%": "Publications: %claims%",
   "Channels:": "Channels",
   "Larger comment histories may take time to load": "Larger comment histories may take time to load",
+  "Disable Slimes Video + Comments": "Disable Slimes Video + Comments",
+  "Disable Reactions Video + Comments": "Disable Reactions Video + Comments",
+  "Disable tipping and boosting": "Disable tipping and boosting",
 
   "--end--": "--end--"
 }

--- a/ui/component/channelEdit/view.jsx
+++ b/ui/component/channelEdit/view.jsx
@@ -480,7 +480,6 @@ function ChannelForm(props: Props) {
                     <TagsSearch
                       suggestMature={!SIMPLE_SITE}
                       disableAutoFocus
-                      disableControlTags
                       limitSelect={MAX_TAG_SELECT}
                       tagsPassedIn={params.tags || []}
                       label={__('Selected Tags')}

--- a/ui/component/tagsSearch/view.jsx
+++ b/ui/component/tagsSearch/view.jsx
@@ -110,7 +110,7 @@ export default function TagsSearch(props: Props) {
   CONTROL_TAGS.map((t) => {
     let label;
     if (t === 'disable-support') {
-      label = __('Disable tipping and boosting');
+      label = __('Disable Tipping And Boosting');
     } else if (t === 'c:disable-reactions-all') {
       label = __('Disable Reactions Video + Comments');
     } else if (t === 'c:disable-slimes-all') {

--- a/ui/component/tagsSearch/view.jsx
+++ b/ui/component/tagsSearch/view.jsx
@@ -106,7 +106,7 @@ export default function TagsSearch(props: Props) {
     });
   }
 
-  const controlTagLables = {};
+  const controlTagLabels = {};
   CONTROL_TAGS.map((t) => {
     let label;
     if (t === 'disable-support') {
@@ -124,7 +124,7 @@ export default function TagsSearch(props: Props) {
           .join(' ')
       );
     }
-    controlTagLables[t] = label;
+    controlTagLabels[t] = label;
   });
 
   // const countWithoutLbryFirst = selectedTagsSet.has('lbry-first') ? selectedTagsSet.size - 1 : selectedTagsSet.size;
@@ -277,7 +277,7 @@ export default function TagsSearch(props: Props) {
                   name={t}
                   type="checkbox"
                   blockWrap={false}
-                  label={controlTagLables[t]}
+                  label={controlTagLabels[t]}
                   checked={tagsPassedIn.some((te) => te.name === t)}
                   onChange={() => handleUtilityTagCheckbox(t)}
                 />

--- a/ui/component/tagsSearch/view.jsx
+++ b/ui/component/tagsSearch/view.jsx
@@ -70,7 +70,6 @@ export default function TagsSearch(props: Props) {
     disabled,
     limitSelect = TAG_FOLLOW_MAX,
     limitShow = 5,
-    user,
     disableControlTags,
     help,
   } = props;
@@ -82,7 +81,6 @@ export default function TagsSearch(props: Props) {
 
   // Make sure there are no duplicates, then trim
   // suggestedTags = (followedTags - tagsPassedIn) + unfollowedTags
-  const experimentalFeature = user && user.experimental_ui;
   const followedTagsSet = new Set(followedTags.map((tag) => tag.name));
   const selectedTagsSet = new Set(tagsPassedIn.map((tag) => tag.name));
   const unfollowedTagsSet = new Set(unfollowedTags.map((tag) => tag.name));
@@ -248,8 +246,7 @@ export default function TagsSearch(props: Props) {
             </section>
           )}
         </fieldset-section>
-        {experimentalFeature &&
-          !disableControlTags &&
+        {!disableControlTags &&
           onSelect && ( // onSelect ensures this does not appear on TagFollow
             <fieldset-section>
               <label>{__('Control Tags')}</label>

--- a/ui/component/tagsSearch/view.jsx
+++ b/ui/component/tagsSearch/view.jsx
@@ -106,6 +106,27 @@ export default function TagsSearch(props: Props) {
     });
   }
 
+  const controlTagLables = {};
+  CONTROL_TAGS.map((t) => {
+    let label;
+    if (t === 'disable-support') {
+      label = __('Disable tipping and boosting');
+    } else if (t === 'c:disable-reactions-all') {
+      label = __('Disable Reactions Video + Comments');
+    } else if (t === 'c:disable-slimes-all') {
+      label = __('Disable Slimes Video + Comments');
+    } else {
+      label = __(
+        t
+          .replace(INTERNAL_TAG_PREFIX, '')
+          .split('-')
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' ')
+      );
+    }
+    controlTagLables[t] = label;
+  });
+
   // const countWithoutLbryFirst = selectedTagsSet.has('lbry-first') ? selectedTagsSet.size - 1 : selectedTagsSet.size;
   const maxed = Boolean(limitSelect && countWithoutSpecialTags >= limitSelect);
   const suggestedTags = Array.from(suggestedTagsSet).filter(doesTagMatch).slice(0, limitShow);
@@ -256,13 +277,7 @@ export default function TagsSearch(props: Props) {
                   name={t}
                   type="checkbox"
                   blockWrap={false}
-                  label={__(
-                    t
-                      .replace(INTERNAL_TAG_PREFIX, '')
-                      .split('-')
-                      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-                      .join(' ')
-                  )}
+                  label={controlTagLables[t]}
                   checked={tagsPassedIn.some((te) => te.name === t)}
                   onChange={() => handleUtilityTagCheckbox(t)}
                 />

--- a/ui/component/tagsSearch/view.jsx
+++ b/ui/component/tagsSearch/view.jsx
@@ -110,7 +110,7 @@ export default function TagsSearch(props: Props) {
   CONTROL_TAGS.map((t) => {
     let label;
     if (t === 'disable-support') {
-      label = __('Disable Tipping And Boosting');
+      label = __('Disable Tipping and Boosting');
     } else if (t === 'c:disable-reactions-all') {
       label = __('Disable Reactions Video + Comments');
     } else if (t === 'c:disable-slimes-all') {

--- a/ui/constants/tags.js
+++ b/ui/constants/tags.js
@@ -49,7 +49,6 @@ export const SCHEDULED_TAGS = Object.freeze({
 // Control tags are special tags that are available to the user in some situations.
 export const CONTROL_TAGS = [
   DISABLE_SUPPORT_TAG,
-  PREFERENCE_EMBED,
   DISABLE_DOWNLOAD_BUTTON_TAG,
   DISABLE_REACTIONS_ALL_TAG,
   DISABLE_REACTIONS_VIDEO_TAG,
@@ -60,7 +59,7 @@ export const CONTROL_TAGS = [
 // System tags are special tags that are not available to the user.
 export const SYSTEM_TAGS = [LBRY_FIRST_TAG, ...Object.values(VISIBILITY_TAGS), ...Object.values(SCHEDULED_TAGS)];
 
-export const INTERNAL_TAGS = [...CONTROL_TAGS, ...SYSTEM_TAGS, ...MEMBERS_ONLY_TAGS];
+export const INTERNAL_TAGS = [...CONTROL_TAGS, ...SYSTEM_TAGS, ...MEMBERS_ONLY_TAGS, PREFERENCE_EMBED];
 
 export const MATURE_TAGS = Object.freeze([
   'porn',


### PR DESCRIPTION
-Show control tags for all
-Show control tags on channel page
-Move `PREFERENCE_EMBED` tag from `CONTROL_TAGS` to `INTERNAL_TAGS` 
-Custom labels for some control tags

![2024-04-10_19-07](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/05f36292-e5cb-4bb8-b69e-4cea8b126ff7)
