### PR TITLE
Fix `selectIsCollectionPrivateForId`

### DIFF
--- a/ui/redux/selectors/collections.js
+++ b/ui/redux/selectors/collections.js
@@ -368,11 +368,7 @@ export const selectHasPrivateCollectionForId = (state: State, id: string) => {
 
 // Is private === only private (doesn't include public with private edits)
 export const selectIsCollectionPrivateForId = (state: State, id: string) =>
-  Boolean(
-    selectHasPrivateCollectionForId(state, id) &&
-      !selectCollectionHasEditsForId(state, id) &&
-      !selectCollectionHasUnsavedEditsForId(state, id)
-  );
+  Boolean(selectUnpublishedCollectionForId(state, id) || COLLECTIONS_CONSTS.BUILTIN_PLAYLISTS.includes(id));
 
 export const selectClaimIdsForCollectionId = createSelector(
   selectHasPrivateCollectionForId,


### PR DESCRIPTION
Private list with unpublished edits wasn't actually considered private. So if editing in publishing form, would cause submit  to try to do `collectionUpdate`.

Fix:
Copied the related stuff from `selectHasPrivateCollectionForId` to `selectIsCollectionPrivateForId`, just left out the checks for private versions of published lists.
![2024-04-17_18-08](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/34c1b571-9403-4b49-b06c-1b0bc8a20390)

Didn't test much, but don't really see how this could cause any surprises. (Unpublished collections only has the actually private lists)