### PR TITLE
Don't wipe list items on edit when claim_search fails

### DIFF
--- a/flow-typed/Claims.js
+++ b/flow-typed/Claims.js
@@ -12,6 +12,8 @@ declare type ClaimsState = {
   pendingById: { [ClaimId]: Claim }, // keep pending claims
   resolvingIds: Array<ClaimId>,
   resolvingUris: Array<string>,
+  failedToResolveUris: Array<string>,
+  failedToResolveIds: Array<ClaimId>,
   reflectingById: { [ClaimId]: ReflectingUpdate },
   myClaims: ?Array<ClaimId>,
   myChannelClaimsById: ?{ [channelClaimId: string]: ChannelClaim },

--- a/ui/redux/reducers/claims.js
+++ b/ui/redux/reducers/claims.js
@@ -23,6 +23,8 @@ const defaultState: ClaimsState = {
   fetchingChannelClaims: {},
   resolvingUris: [],
   resolvingIds: [],
+  failedToResolveUris: [],
+  failedToResolveIds: [],
   myChannelClaimsById: undefined,
   resolvedCollectionsById: {},
   myCollectionClaimIds: undefined,
@@ -197,6 +199,7 @@ function handleClaimAction(state: ClaimsState, action: any): ClaimsState {
   const channelClaimCounts = Object.assign({}, state.channelClaimCounts);
   const pendingById = state.pendingById;
   let newResolvingUrls = new Set(state.resolvingUris);
+  let newFailedToResolveUrls = new Set(state.failedToResolveUris);
   const myClaimIds = new Set(state.myClaims);
   const newResolvedCollectionsById = Object.assign({}, state.resolvedCollectionsById);
   let newMyCollectionClaimIds =
@@ -224,6 +227,8 @@ function handleClaimAction(state: ClaimsState, action: any): ClaimsState {
       updateIfValueChanged(state.claimsByUri, byUriDelta, stream.permanent_url, stream.claim_id);
       newResolvingUrls.delete(stream.canonical_url);
       newResolvingUrls.delete(stream.permanent_url);
+      newFailedToResolveUrls.delete(stream.canonical_url);
+      newFailedToResolveUrls.delete(stream.permanent_url);
 
       if (stream.value_type === 'collection') {
         if (!newResolvedCollectionsById[stream.claim_id]) {
@@ -262,6 +267,8 @@ function handleClaimAction(state: ClaimsState, action: any): ClaimsState {
       updateIfValueChanged(state.claimsByUri, byUriDelta, channel.canonical_url, channel.claim_id);
       newResolvingUrls.delete(channel.canonical_url);
       newResolvingUrls.delete(channel.permanent_url);
+      newFailedToResolveUrls.delete(stream.canonical_url);
+      newFailedToResolveUrls.delete(stream.permanent_url);
     }
 
     if (repostSrcChannel && repostSrcChannel.claim_id) {
@@ -282,6 +289,8 @@ function handleClaimAction(state: ClaimsState, action: any): ClaimsState {
       updateIfValueChanged(state.claimsByUri, byUriDelta, collection.permanent_url, collection.claim_id);
       newResolvingUrls.delete(collection.canonical_url);
       newResolvingUrls.delete(collection.permanent_url);
+      newFailedToResolveUrls.delete(stream.canonical_url);
+      newFailedToResolveUrls.delete(stream.permanent_url);
 
       // $FlowFixMe
       newResolvedCollectionsById[collection.claim_id] = claimToStoredCollection(collection);
@@ -295,6 +304,7 @@ function handleClaimAction(state: ClaimsState, action: any): ClaimsState {
     }
 
     newResolvingUrls.delete(url);
+    newFailedToResolveUrls.delete(url);
     if (!stream && !channel && !collection && !pendingById[state.claimsByUri[url]]) {
       updateIfValueChanged(state.claimsByUri, byUriDelta, url, null);
     }
@@ -313,6 +323,7 @@ function handleClaimAction(state: ClaimsState, action: any): ClaimsState {
     claimsByUri: resolveDelta(state.claimsByUri, byUriDelta),
     channelClaimCounts,
     resolvingUris: Array.from(newResolvingUrls),
+    failedToResolveUris: Array.from(newFailedToResolveUrls),
     resolvedCollectionsById: newResolvedCollectionsById,
     myCollectionClaimIds: newMyCollectionClaimIds && Array.from(newMyCollectionClaimIds),
     ...(!state.myClaims || myClaimIds.size !== state.myClaims.length ? { myClaims: Array.from(myClaimIds) } : {}),
@@ -361,9 +372,14 @@ reducers[ACTIONS.RESOLVE_URIS_FAIL] = (state: ClaimsState, action: any): ClaimsS
   const uris: Array<string> = action.data;
 
   const newResolvingUris = new Set(state.resolvingUris);
+  const newFailedToResolveUrls = new Set(state.failedToResolveUris.concat(uris));
   uris.forEach((uri) => newResolvingUris.delete(uri));
 
-  return { ...state, resolvingUris: Array.from(newResolvingUris) };
+  return {
+    ...state,
+    resolvingUris: Array.from(newResolvingUris),
+    failedToResolveUris: Array.from(newFailedToResolveUrls),
+  };
 };
 
 reducers[ACTIONS.FETCH_CLAIM_LIST_MINE_STARTED] = (state: ClaimsState): ClaimsState =>
@@ -813,6 +829,7 @@ reducers[ACTIONS.CLAIM_SEARCH_COMPLETED] = (state: ClaimsState, action: any): Cl
   const claimSearchByQueryLastPageReached = Object.assign({}, state.claimSearchByQueryLastPageReached);
   const claimSearchByQueryMiscInfo = { ...state.claimSearchByQueryMiscInfo };
   const newResolvingIds = new Set(state.resolvingIds);
+  const newFailedToResolveIds = new Set(state.failedToResolveIds);
   const { append, query, urls, page, pageSize, totalItems, totalPages } = action.data;
 
   if (append) {
@@ -831,7 +848,12 @@ reducers[ACTIONS.CLAIM_SEARCH_COMPLETED] = (state: ClaimsState, action: any): Cl
   claimSearchByQueryMiscInfo[query] = { page, pageSize, totalItems, totalPages };
 
   const { claim_ids: claimIds } = JSON.parse(query);
-  if (claimIds?.length > 0) claimIds.forEach((claimId) => newResolvingIds.delete(claimId));
+  if (claimIds?.length > 0) {
+    claimIds.forEach((claimId) => {
+      newResolvingIds.delete(claimId);
+      newFailedToResolveIds.delete(claimId);
+    });
+  }
 
   return Object.assign({}, state, {
     ...handleClaimAction(state, action),
@@ -840,6 +862,7 @@ reducers[ACTIONS.CLAIM_SEARCH_COMPLETED] = (state: ClaimsState, action: any): Cl
     claimSearchByQueryMiscInfo,
     fetchingClaimSearchByQuery,
     resolvingIds: Array.from(newResolvingIds),
+    failedToResolveIds: Array.from(newFailedToResolveIds),
   });
 };
 
@@ -859,6 +882,8 @@ reducers[ACTIONS.CLAIM_SEARCH_FAILED] = (state: ClaimsState, action: any): Claim
   }
 
   const { claim_ids: claimIds } = JSON.parse(query);
+  const newFailedToResolveIds =
+    claimIds?.length > 0 ? new Set(state.failedToResolveIds.concat(claimIds)) : state.failedToResolveIds;
   if (claimIds?.length > 0) claimIds.forEach((claimId) => newResolvingIds.delete(claimId));
 
   return Object.assign({}, state, {
@@ -866,6 +891,7 @@ reducers[ACTIONS.CLAIM_SEARCH_FAILED] = (state: ClaimsState, action: any): Claim
     claimSearchByQuery,
     claimSearchByQueryLastPageReached,
     resolvingIds: Array.from(newResolvingIds),
+    failedToResolveIds: Array.from(newFailedToResolveIds),
   });
 };
 

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -730,7 +730,9 @@ export const selectHasChannels = (state: State) => {
 };
 
 export const selectResolvingUris = (state: State) => selectState(state).resolvingUris;
+export const selectFailedToResolveUris = (state: State) => selectState(state).failedToResolveUris;
 export const selectResolvingIds = (state: State) => selectState(state).resolvingIds;
+export const selectFailedToResolveIds = (state: State) => selectState(state).failedToResolveIds;
 
 export const selectChannelImportPending = (state: State) => selectState(state).pendingChannelImport;
 


### PR DESCRIPTION
## Fixes
If `claim_search` on list edit failed (timed out or other reason), the items in the list would get wiped. 

Added something to keep track of failed resolves.