### PR TITLE
Hide shorts setting

### DIFF
--- a/flow-typed/Lbry.js
+++ b/flow-typed/Lbry.js
@@ -124,7 +124,7 @@ declare type ClaimSearchOptions = {|
   media_types?: Array<string>, // filter by 'video/mp4', 'image/png', etc
   fee_currency?: string, // specify fee currency: LBC, BTC, USD
   fee_amount?: number | string, // content download fee (supports equality constraints)
-  duration?: number | string | Array<string>, // duration of video or audio in seconds (supports equality constraints)
+  duration?: ?number | string | Array<string>, // duration of video or audio in seconds (supports equality constraints)
   any_tags?: Array<string>, // find claims containing any of the tags
   all_tags?: Array<string>, // find claims containing every tag
   not_tags?: Array<string>, // find claims not containing any of these tags

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2931,6 +2931,8 @@
   "Channels:": "Channels",
   "Larger comment histories may take time to load": "Larger comment histories may take time to load",
   "Disable Tipping and Boosting": "Disable Tipping and Boosting",
+  "You will not see content under 1min long. Also hides non-video/audio content.": "You will not see content under 1min long. Also hides non-video/audio content.",
+  "Hide short content": "Hide short content",
 
   "--end--": "--end--"
 }

--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -300,13 +300,18 @@ function ClaimListDiscover(props: Props) {
     'orderUser',
     CS.ORDER_BY_TRENDING
   );
-  const durationOption = CsOptHelper.duration(
-    contentTypeParam,
-    durationParam,
-    duration,
-    minDurationMinutes,
-    maxDurationMinutes
-  );
+
+  const durationOption =
+    claimIds && claimIds.length > 0
+      ? undefined
+      : CsOptHelper.duration(
+          contentTypeParam,
+          claimTypeParam,
+          durationParam,
+          duration,
+          minDurationMinutes,
+          maxDurationMinutes
+        );
 
   let options: ClaimSearchOptions = {
     page_size: dynamicPageSize,

--- a/ui/component/claimTilesDiscover/index.js
+++ b/ui/component/claimTilesDiscover/index.js
@@ -118,6 +118,7 @@ function resolveSearchOptions(props) {
     order_by: resolveOrderByOption(orderBy),
     stream_types: streamTypesParam,
     remove_duplicates: true,
+    duration: CsOptHelper.duration(null, claimType, CS.DURATION.ALL),
   };
 
   function resolveOrderByOption(orderBy: string | Array<string>) {

--- a/ui/component/settingContent/index.js
+++ b/ui/component/settingContent/index.js
@@ -11,6 +11,7 @@ const select = (state, props) => ({
   isAuthenticated: selectUserVerifiedEmail(state),
   hideMembersOnlyContent: selectClientSetting(state, SETTINGS.HIDE_MEMBERS_ONLY_CONTENT),
   hideReposts: selectClientSetting(state, SETTINGS.HIDE_REPOSTS),
+  hideShorts: selectClientSetting(state, SETTINGS.HIDE_SHORTS),
   showNsfw: selectShowMatureContent(state),
   instantPurchaseEnabled: selectClientSetting(state, SETTINGS.INSTANT_PURCHASE_ENABLED),
   instantPurchaseMax: selectClientSetting(state, SETTINGS.INSTANT_PURCHASE_MAX),

--- a/ui/component/settingContent/view.jsx
+++ b/ui/component/settingContent/view.jsx
@@ -23,6 +23,7 @@ type Props = {
   isAuthenticated: boolean,
   hideMembersOnlyContent: boolean,
   hideReposts: ?boolean,
+  hideShorts: ?boolean,
   showNsfw: boolean,
   instantPurchaseEnabled: boolean,
   instantPurchaseMax: Price,
@@ -37,6 +38,7 @@ export default function SettingContent(props: Props) {
     isAuthenticated,
     hideMembersOnlyContent,
     hideReposts,
+    hideShorts,
     showNsfw,
     instantPurchaseEnabled,
     instantPurchaseMax,
@@ -75,6 +77,15 @@ export default function SettingContent(props: Props) {
                   }
                   setClientSetting(SETTINGS.HIDE_REPOSTS, !hideReposts);
                 }}
+              />
+            </SettingsRow>
+
+            <SettingsRow title={__('Hide short content')} subtitle={__(HELP.HIDE_SHORTS)}>
+              <FormField
+                type="checkbox"
+                name="hide_shorts"
+                checked={hideShorts}
+                onChange={(e) => setClientSetting(SETTINGS.HIDE_SHORTS, !hideShorts)}
               />
             </SettingsRow>
 
@@ -169,6 +180,7 @@ export default function SettingContent(props: Props) {
 const HELP = {
   HIDE_MEMBERS_ONLY_CONTENT: 'You will not see content that requires a membership subscription.',
   HIDE_REPOSTS: 'You will not see reposts by people you follow or receive email notifying about them.',
+  HIDE_SHORTS: 'You will not see content under 1min long. Also hides non-video/audio content.',
   HIDE_FYP: 'You will not see the personal recommendations in the homepage.',
   SHOW_MATURE: 'Mature content may include nudity, intense sexuality, profanity, or other adult content. By displaying mature content, you are affirming you are of legal age to view mature content in your country or jurisdiction.  ',
   MAX_PURCHASE_PRICE: 'This will prevent you from purchasing any content over a certain cost, as a safety measure.',

--- a/ui/constants/search.js
+++ b/ui/constants/search.js
@@ -36,6 +36,8 @@ export const SEARCH_OPTIONS = {
   TIME_FILTER_THIS_WEEK: 'thisweek',
   TIME_FILTER_THIS_MONTH: 'thismonth',
   TIME_FILTER_THIS_YEAR: 'thisyear',
+  MIN_DURATION: 'min_duration',
+  MAX_DURATION: 'max_duration',
 };
 
 export const SEARCH_PAGE_SIZE = 20;

--- a/ui/constants/settings.js
+++ b/ui/constants/settings.js
@@ -39,6 +39,7 @@ export const HOMEPAGE_ORDER = 'homepage_order';
 export const HOMEPAGE_ORDER_APPLY_TO_SIDEBAR = 'homepage_order_apply_to_sidebar';
 export const HIDE_MEMBERS_ONLY_CONTENT = 'hide_members_only_content';
 export const HIDE_REPOSTS = 'hide_reposts';
+export const HIDE_SHORTS = 'hide_shorts';
 export const HIDE_SCHEDULED_LIVESTREAMS = 'hide_scheduled_livestreams';
 export const SUPPORT_OPTION = 'support_option';
 export const TILE_LAYOUT = 'tile_layout';

--- a/ui/constants/settings.js
+++ b/ui/constants/settings.js
@@ -40,6 +40,7 @@ export const HOMEPAGE_ORDER_APPLY_TO_SIDEBAR = 'homepage_order_apply_to_sidebar'
 export const HIDE_MEMBERS_ONLY_CONTENT = 'hide_members_only_content';
 export const HIDE_REPOSTS = 'hide_reposts';
 export const HIDE_SHORTS = 'hide_shorts';
+export const SHORTS_DURATION_LIMIT = '61';
 export const HIDE_SCHEDULED_LIVESTREAMS = 'hide_scheduled_livestreams';
 export const SUPPORT_OPTION = 'support_option';
 export const TILE_LAYOUT = 'tile_layout';

--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/contentTab/index.js
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/contentTab/index.js
@@ -34,6 +34,7 @@ const select = (state, props) => {
     claim,
     showMature: selectShowMatureContent(state),
     tileLayout: selectClientSetting(state, SETTINGS.TILE_LAYOUT),
+    hideShorts: selectClientSetting(state, SETTINGS.HIDE_SHORTS),
     activeLivestreamForChannel: selectActiveLivestreamForChannel(state, channelClaimId),
     adBlockerFound: selectAdBlockerFound(state),
     hasPremiumPlus: selectUserHasOdyseePremiumPlus(state),

--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/contentTab/internal/searchResults.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/contentTab/internal/searchResults.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import ClaimList from 'component/claimList';
-import { DEBOUNCE_WAIT_DURATION_MS } from 'constants/search';
+import { DEBOUNCE_WAIT_DURATION_MS, SEARCH_OPTIONS } from 'constants/search';
 import * as CS from 'constants/claim_search';
 import { lighthouse } from 'redux/actions/search';
 
@@ -11,12 +11,13 @@ type Props = {
   showMature: ?boolean,
   tileLayout: boolean,
   orderBy?: ?string,
+  minDuration?: ?number,
   onResults?: (results: ?Array<string>) => void,
   doResolveUris: (Array<string>, boolean) => void,
 };
 
 export function SearchResults(props: Props) {
-  const { searchQuery, claimId, showMature, tileLayout, orderBy, onResults, doResolveUris } = props;
+  const { searchQuery, claimId, showMature, tileLayout, orderBy, minDuration, onResults, doResolveUris } = props;
 
   const SEARCH_PAGE_SIZE = 24;
   const [page, setPage] = React.useState(1);
@@ -60,6 +61,7 @@ export function SearchResults(props: Props) {
             `&channel_id=${encodeURIComponent(claimId)}` +
             sortBy +
             `&nsfw=${showMature ? 'true' : 'false'}` +
+            (minDuration ? `&${SEARCH_OPTIONS.MIN_DURATION}=${minDuration}` : '') +
             `&size=${SEARCH_PAGE_SIZE}`
         )
         .then(({ body: results }) => {
@@ -88,7 +90,7 @@ export function SearchResults(props: Props) {
     }, DEBOUNCE_WAIT_DURATION_MS);
 
     return () => clearTimeout(timer);
-  }, [searchQuery, claimId, page, showMature, doResolveUris, sortBy]);
+  }, [searchQuery, claimId, page, showMature, doResolveUris, sortBy, minDuration]);
 
   if (!searchResults) {
     return null;

--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/contentTab/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/contentTab/view.jsx
@@ -3,6 +3,7 @@ import { SIMPLE_SITE } from 'config';
 import { SECTION_TAGS } from 'constants/collections';
 import * as CS from 'constants/claim_search';
 import * as ICONS from 'constants/icons';
+import * as SETTINGS from 'constants/settings';
 import React, { Fragment } from 'react';
 import GeoRestrictionInfo from 'component/geoRestictionInfo';
 import { useHistory } from 'react-router-dom';
@@ -228,7 +229,7 @@ function ContentTab(props: Props) {
                 showMature={showMature}
                 tileLayout={tileLayout}
                 orderBy={orderBy}
-                minDuration={hideShorts ? 61 : undefined}
+                minDuration={hideShorts ? SETTINGS.SHORTS_DURATION_LIMIT : undefined}
                 onResults={(results) => setIsSearching(results !== null)}
                 doResolveUris={doResolveUris}
               />

--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/contentTab/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/contentTab/view.jsx
@@ -43,6 +43,7 @@ type Props = {
   isAuthenticated: boolean,
   showMature: boolean,
   tileLayout: boolean,
+  hideShorts: boolean,
   viewHiddenChannels: boolean,
   doResolveUris: (Array<string>, boolean) => void,
   claimType: string,
@@ -64,6 +65,7 @@ function ContentTab(props: Props) {
     defaultInfiniteScroll = true,
     showMature,
     tileLayout,
+    hideShorts,
     viewHiddenChannels,
     doResolveUris,
     claimType,
@@ -226,6 +228,7 @@ function ContentTab(props: Props) {
                 showMature={showMature}
                 tileLayout={tileLayout}
                 orderBy={orderBy}
+                minDuration={hideShorts ? 61 : undefined}
                 onResults={(results) => setIsSearching(results !== null)}
                 doResolveUris={doResolveUris}
               />

--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/homeTab/internal/homeTabSection/index.js
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/homeTab/internal/homeTabSection/index.js
@@ -19,6 +19,7 @@ import { selectUserHasOdyseePremiumPlus } from 'redux/selectors/memberships';
 import { selectFeaturedChannelsForChannelId } from 'redux/selectors/comments';
 import { CsOptHelper } from 'util/claim-search';
 import HomeTabSection from './view';
+import * as CS from 'constants/claim_search';
 
 const select = (state, props) => {
   const hasPremiumPlus = selectUserHasOdyseePremiumPlus(state);
@@ -45,6 +46,7 @@ const select = (state, props) => {
     no_totals: true,
     index: props.index,
     has_source: true,
+    duration: CsOptHelper.duration(null, claimType, CS.DURATION.ALL),
   };
   const searchKey = createNormalizedClaimSearchKey(options);
 

--- a/ui/util/claim-search.js
+++ b/ui/util/claim-search.js
@@ -65,7 +65,7 @@ export const CsOptHelper = {
           const state = store.getState();
           hideShorts = selectClientSetting(state, SETTINGS.HIDE_SHORTS);
         }
-        x = durationVal || (hideShorts && '>60') || undefined;
+        x = durationVal || (hideShorts && `>=${SETTINGS.SHORTS_DURATION_LIMIT}`) || undefined;
         break;
       case CS.DURATION.SHORT:
         x = '<=240';

--- a/ui/util/claim-search.js
+++ b/ui/util/claim-search.js
@@ -2,7 +2,9 @@
 import type { Duration } from 'constants/claim_search';
 
 import * as CS from 'constants/claim_search';
+import * as SETTINGS from 'constants/settings';
 import { MATURE_TAGS, MEMBERS_ONLY_CONTENT_TAG } from 'constants/tags';
+import { selectClientSetting } from 'redux/selectors/settings';
 
 /**
  * Common logic to generate ClaimSearch option payload.
@@ -26,6 +28,7 @@ export const CsOptHelper = {
    * duration
    *
    * @param contentType
+   * @param claimTypes
    * @param duration Duration type
    * @param durationVal Only applicable is 'duration === all';
    * @param minMinutes Only for 'duration === custom'
@@ -34,16 +37,20 @@ export const CsOptHelper = {
    */
   duration: (
     contentType: ?string,
+    claimTypes: ?any,
     duration: Duration,
     durationVal?: string,
     minMinutes?: number,
     maxMinutes?: number
   ) => {
+    const claimTypesWithDurations = [CS.CLAIM_STREAM, CS.CLAIM_REPOST];
+    const claimTypesArray = Array.isArray(claimTypes) ? claimTypes : [claimTypes];
     if (
-      contentType !== CS.FILE_VIDEO &&
-      contentType !== CS.FILE_AUDIO &&
-      contentType !== null && // Any
-      contentType !== undefined // Any
+      (contentType !== CS.FILE_VIDEO &&
+        contentType !== CS.FILE_AUDIO &&
+        contentType !== null && // Any
+        contentType !== undefined) || // Any
+      (claimTypesArray[0] && !claimTypesArray.some((claimType) => claimTypesWithDurations.includes(claimType)))
     ) {
       return undefined;
     }
@@ -52,7 +59,13 @@ export const CsOptHelper = {
 
     switch (duration) {
       case CS.DURATION.ALL:
-        x = durationVal || undefined;
+        const { store } = window;
+        let hideShorts;
+        if (store) {
+          const state = store.getState();
+          hideShorts = selectClientSetting(state, SETTINGS.HIDE_SHORTS);
+        }
+        x = durationVal || (hideShorts && '>60') || undefined;
         break;
       case CS.DURATION.SHORT:
         x = '<=240';

--- a/ui/util/query-params.js
+++ b/ui/util/query-params.js
@@ -129,7 +129,7 @@ export const getSearchQueryString = (query: string, options: any = {}) => {
       }
     }
     if ((!hasMediaTypeParam || mediaTypeHasDuration) && (!hasClaimTypeParam || claimTypeHasDuration)) {
-      additionalOptions[SEARCH_OPTIONS.MIN_DURATION] = '61';
+      additionalOptions[SEARCH_OPTIONS.MIN_DURATION] = SETTINGS.SHORTS_DURATION_LIMIT;
     }
   }
 

--- a/ui/util/query-params.js
+++ b/ui/util/query-params.js
@@ -1,5 +1,7 @@
 // @flow
 import { SEARCH_OPTIONS } from 'constants/search';
+import * as SETTINGS from 'constants/settings';
+import { selectClientSetting } from 'redux/selectors/settings';
 
 const DEFAULT_SEARCH_RESULT_FROM = 0;
 const DEFAULT_SEARCH_SIZE = 20;
@@ -54,7 +56,6 @@ export const getSearchQueryString = (query: string, options: any = {}) => {
       if (!claimType.includes(SEARCH_OPTIONS.INCLUDE_CHANNELS)) {
         queryParams.push(
           `mediaType=${[
-            SEARCH_OPTIONS.MEDIA_FILE,
             SEARCH_OPTIONS.MEDIA_AUDIO,
             SEARCH_OPTIONS.MEDIA_VIDEO,
             SEARCH_OPTIONS.MEDIA_TEXT,
@@ -98,6 +99,38 @@ export const getSearchQueryString = (query: string, options: any = {}) => {
 
   if (language) {
     additionalOptions[SEARCH_OPTIONS.LANGUAGE] = language;
+  }
+
+  const { store } = window;
+  let hideShorts = false;
+  if (store) {
+    const state = store.getState();
+    hideShorts = selectClientSetting(state, SETTINGS.HIDE_SHORTS);
+  }
+
+  if (hideShorts) {
+    let hasMediaTypeParam = false;
+    let hasClaimTypeParam = false;
+    let mediaTypeHasDuration = false;
+    let claimTypeHasDuration = false;
+    for (const param of queryParams) {
+      if (param.includes('mediaType')) {
+        hasMediaTypeParam = true;
+        const mediaTypesWithDurations = [SEARCH_OPTIONS.MEDIA_VIDEO, SEARCH_OPTIONS.MEDIA_AUDIO];
+        if (mediaTypesWithDurations.some((mediaType) => param.includes(mediaType))) {
+          mediaTypeHasDuration = true;
+        }
+      }
+      if (param.includes('claimType')) {
+        hasClaimTypeParam = true;
+        if (param.includes(SEARCH_OPTIONS.INCLUDE_FILES)) {
+          claimTypeHasDuration = true;
+        }
+      }
+    }
+    if ((!hasMediaTypeParam || mediaTypeHasDuration) && (!hasClaimTypeParam || claimTypeHasDuration)) {
+      additionalOptions[SEARCH_OPTIONS.MIN_DURATION] = '61';
+    }
   }
 
   if (additionalOptions) {


### PR DESCRIPTION
## Fixes

Adds a setting to filter out content <1min
If claim_search or lighthouse query may return results with duration, and the setting is enabled, the duration filter gets added to the query.  

Searching specifically channels/collection/etc. will still work, but these get excluded in more general queries while the setting is enabled.   
Also if  `claim_ids` is set the duration limit is skipped. (Think it's only used with collection items.)  
Also setting the duration to something else than "any", will override the setting.

![2024-05-02_11-29](https://github.com/OdyseeTeam/odysee-frontend/assets/34790748/3692c877-1f4b-424b-bb21-f191e67f7e0a)
