### PR TITLE
Create channel entry with `setting.get`

### DIFF
--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -1785,6 +1785,7 @@ export const doFetchCreatorSettings = (channelId: string) => {
   return async (dispatch: Dispatch, getState: GetState) => {
     const state = getState();
     const myChannels = selectMyChannelClaims(state);
+    const creatorChannel = selectClaimForClaimId(state, channelId);
 
     dispatch({
       type: ACTIONS.COMMENT_FETCH_SETTINGS_STARTED,
@@ -1803,7 +1804,7 @@ export const doFetchCreatorSettings = (channelId: string) => {
 
     return cmd({
       channel_id: channelId,
-      channel_name: (signedName && signedName.name) || undefined,
+      channel_name: (signedName && signedName.name) || creatorChannel?.name,
       signature: (signedName && signedName.signature) || undefined,
       signing_ts: (signedName && signedName.signing_ts) || undefined,
     })

--- a/ui/redux/actions/comments.js
+++ b/ui/redux/actions/comments.js
@@ -1834,7 +1834,6 @@ export const doFetchCreatorSettings = (channelId: string) => {
           devToast(dispatch, `Creator: ${err}`);
           dispatch({
             type: ACTIONS.COMMENT_FETCH_SETTINGS_FAILED,
-            data: { channelId },
           });
         }
 

--- a/ui/redux/reducers/comments.js
+++ b/ui/redux/reducers/comments.js
@@ -1071,20 +1071,10 @@ export default handleActions(
       fetchingSettings: true,
     }),
 
-    [ACTIONS.COMMENT_FETCH_SETTINGS_FAILED]: (state: CommentsState, action: any) => {
-      const { channelId } = action.data;
-      const settingsByChannelId = Object.assign({}, state.settingsByChannelId);
-
-      if (!settingsByChannelId[channelId]) {
-        settingsByChannelId[channelId] = undefined;
-      }
-
-      return {
-        ...state,
-        settingsByChannelId,
-        fetchingSettings: false,
-      };
-    },
+    [ACTIONS.COMMENT_FETCH_SETTINGS_FAILED]: (state: CommentsState, action: any) => ({
+      ...state,
+      fetchingSettings: false,
+    }),
 
     [ACTIONS.COMMENT_FETCH_SETTINGS_COMPLETED]: (state: CommentsState, action: any) => {
       const { channelId, settings, partialUpdate } = action.data;


### PR DESCRIPTION
## Fixes

Commentron all ready supported creating the channel entry on `setting.Get`, but it needed a channel name to be also passed in the request.  
https://github.com/OdyseeTeam/commentron/blob/8aa1adca3464a4ddbf4b39ab37d8ce514554034c/server/services/v2/settings/service.go#L46-L61

This seems to work now.

Also hometab sections will be blank again when there is an error, as now it should be a real error.