### PR TITLE
Handle past_due membership status

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2935,6 +2935,7 @@
   "Hide short content": "Hide short content",
   "Larger upload list may take time to load with filters enabled": "Larger upload list may take time to load with filters enabled",
   "Enable filters": "Enable filters",
+  "Past Due": "Past Due",
 
   "--end--": "--end--"
 }

--- a/ui/page/creatorMemberships/supporterArea/pledgesTab/view.jsx
+++ b/ui/page/creatorMemberships/supporterArea/pledgesTab/view.jsx
@@ -115,7 +115,13 @@ function PledgesTab(props: Props) {
                         ${supportAmount / 100} {currency} / {__(toCapitalCase(interval))}
                       </td>
 
-                      <td>{membership.Subscription.status === 'active' ? __('Active') : __('Cancelled')}</td>
+                      <td>
+                        {membership.Subscription.status === 'active'
+                          ? __('Active')
+                          : membership.Subscription.status === 'past_due'
+                          ? __('Past Due')
+                          : __('Cancelled')}
+                      </td>
 
                       <td>
                         <span dir="auto" className="button__label">

--- a/ui/redux/selectors/memberships.js
+++ b/ui/redux/selectors/memberships.js
@@ -115,7 +115,10 @@ export const selectMyValidMembershipsById = createSelector(selectMembershipMineD
     const purchasedCreatorMemberships = myMembershipsByCreatorId[creatorChannelId];
 
     for (const membership of purchasedCreatorMemberships) {
-      if (membership.Subscription.current_period_end * 1000 > Date.now()) {
+      if (
+        membership.Subscription.status !== 'past_due' &&
+        membership.Subscription.current_period_end * 1000 > Date.now()
+      ) {
         validMembershipsById[creatorChannelId] = new Set(validMembershipsById[creatorChannelId]);
         validMembershipsById[creatorChannelId].add(membership);
         // $FlowFixMe


### PR DESCRIPTION
 Prevents access to membership content, if the subscription status is "past_due" (Payment failed)
 
 Has issue that if canceling membership in that state changes the status to "cancelled", it would allow access again. Don't see how to detect if it was cancelled past_due or while active
