### PR TITLE
Fix comment threads

### DIFF
--- a/ui/component/commentsList/view.jsx
+++ b/ui/component/commentsList/view.jsx
@@ -454,15 +454,30 @@ export default function CommentList(props: Props & StateProps & DispatchProps) {
           >
             {readyToDisplayComments && (
               <>
+                {threadComment && (
+                  <CommentView
+                    key={threadComment.comment_id}
+                    comment={threadComment}
+                    disabled={notAuthedToChat}
+                    {...commentProps}
+                  />
+                )}
                 {pinnedComments &&
-                  !threadCommentId &&
-                  pinnedComments.map((c) => (
-                    <CommentView key={c.comment_id} comment={c} disabled={notAuthedToChat} {...commentProps} />
-                  ))}
+                  pinnedComments.map((c) => {
+                    if (threadComment && threadCommentAncestors && threadCommentAncestors.includes(c.comment_id)) {
+                      // Skip if part of the linked comment thread - thread is shown at the top
+                      return;
+                    }
+                    return <CommentView key={c.comment_id} comment={c} disabled={notAuthedToChat} {...commentProps} />;
+                  })}
 
-                {topLevelComments.map((c) => (
-                  <CommentView key={c.comment_id} comment={c} disabled={notAuthedToChat} {...commentProps} />
-                ))}
+                {topLevelComments.map((c) => {
+                  if (threadComment && threadCommentAncestors && threadCommentAncestors.includes(c.comment_id)) {
+                    // Skip if part of the linked comment thread - thread is shown at the top
+                    return;
+                  }
+                  return <CommentView key={c.comment_id} comment={c} disabled={notAuthedToChat} {...commentProps} />;
+                })}
               </>
             )}
           </ul>


### PR DESCRIPTION
## Fixes
#2428 
#2912

Seems like the comment thread was just forgotten to be added to the top of the comment list. Just adding it seems to make it work great!

Example from a recent user complaint
https://odysee.com/@timcast:c/bill-maher-doesn't-understand-the:3?lc=6169df3e39c416ff8a786b738c178b7084261fac033c199389aace50cdf0166a&tc=6169df3e39c416ff8a786b738c178b7084261fac033c199389aace50cdf0166a

<details>
    <summary>Images</summary>
    
Before: 
![2024-07-14_20-29](https://github.com/user-attachments/assets/df5b97eb-a986-4b22-a7ef-178738d88c25)

 After:  
 
![2024-07-14_20-29_1](https://github.com/user-attachments/assets/a8dcf59a-6f64-45b6-ab1c-7248b3f5b9fa)


</details>

