### PR TITLE
Check memberships are fetched on account deletion

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2941,6 +2941,7 @@
   "Please remove 1 item": "Please remove 1 item",
   "or %extraBytes% characters of text.": "or %extraBytes% characters of text.",
   "or 1 character of text.": "or 1 character of text.",
+  "Failed to fetch memberships": "Failed to fetch memberships",
 
   "--end--": "--end--"
 }

--- a/ui/modal/modalRemoveAccount/thunk.js
+++ b/ui/modal/modalRemoveAccount/thunk.js
@@ -3,7 +3,7 @@ import analytics from 'analytics';
 import { doUpdateBalance, doSpendEverything, doSendCreditsToOdysee } from 'redux/actions/wallet';
 import { doUserFetch, doUserDeleteAccount } from 'redux/actions/user';
 import { selectTotalBalance } from 'redux/selectors/wallet';
-import { selectMyActiveMembershipsById } from 'redux/selectors/memberships';
+import { selectMembershipMineFetched, selectMyActiveMembershipsById } from 'redux/selectors/memberships';
 import { doMembershipCancelForMembershipId } from 'redux/actions/memberships';
 import { selectCardDetails } from 'redux/selectors/stripe';
 import { doGetCustomerStatus, doRemoveCardForPaymentMethodId } from 'redux/actions/stripe';
@@ -14,6 +14,12 @@ export function doRemoveAccountSequence() {
   return async (dispatch: Dispatch, getState: GetState): Promise<Status> => {
     await dispatch(doGetCustomerStatus());
     const state = getState();
+
+    const isMembershipsMineFetched = selectMembershipMineFetched(state);
+    if (!isMembershipsMineFetched) {
+      analytics.error(`doRemoveAccountSequence: Memberships not fetched`);
+      return 'error_occurred';
+    }
 
     const activeMemberships = selectMyActiveMembershipsById(state);
     const activeMembershipChannelIds = Object.keys(activeMemberships);

--- a/ui/page/creatorMemberships/supporterArea/pledgesTab/index.js
+++ b/ui/page/creatorMemberships/supporterArea/pledgesTab/index.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
-
-import { selectMyPurchasedMembershipsFromCreators } from 'redux/selectors/memberships';
+import { selectMembershipMineFetching, selectMyPurchasedMembershipsFromCreators } from 'redux/selectors/memberships';
 import { doMembershipMine } from 'redux/actions/memberships';
 
 import PledgesTab from './view';
 
 const select = (state) => ({
   myPurchasedCreatorMemberships: selectMyPurchasedMembershipsFromCreators(state),
+  isFetchingMemberships: selectMembershipMineFetching(state),
 });
 
 const perform = {

--- a/ui/page/creatorMemberships/supporterArea/pledgesTab/view.jsx
+++ b/ui/page/creatorMemberships/supporterArea/pledgesTab/view.jsx
@@ -16,11 +16,12 @@ import UriIndicator from 'component/uriIndicator';
 type Props = {
   // -- redux --
   myPurchasedCreatorMemberships: Array<MembershipTiers>,
+  isFetchingMemberships: boolean,
   doMembershipMine: () => Promise<MembershipTiers>,
 };
 
 function PledgesTab(props: Props) {
-  const { myPurchasedCreatorMemberships, doMembershipMine } = props;
+  const { myPurchasedCreatorMemberships, isFetchingMemberships, doMembershipMine } = props;
 
   React.useEffect(() => {
     if (myPurchasedCreatorMemberships === undefined) {
@@ -28,10 +29,16 @@ function PledgesTab(props: Props) {
     }
   }, [doMembershipMine, myPurchasedCreatorMemberships]);
 
-  if (myPurchasedCreatorMemberships === undefined) {
+  if (myPurchasedCreatorMemberships === undefined && isFetchingMemberships) {
     return (
       <div className="main--empty">
         <Spinner />
+      </div>
+    );
+  } else if (myPurchasedCreatorMemberships === undefined && !isFetchingMemberships) {
+    return (
+      <div className="main--empty">
+        <p>{__('Failed to fetch memberships')}</p>
       </div>
     );
   }

--- a/ui/page/odyseeMembership/index.js
+++ b/ui/page/odyseeMembership/index.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { doMembershipList } from 'redux/actions/memberships';
 import {
   selectMembershipMineFetched,
+  selectMembershipMineFetching,
   selectMyActiveMembershipsForCreatorId,
   selectMyValidMembershipsForCreatorId,
   selectMyPurchasedMembershipsForChannelClaimId,
@@ -14,6 +15,7 @@ import OdyseeMembership from './view';
 
 const select = (state) => ({
   mineFetched: selectMembershipMineFetched(state),
+  mineFetching: selectMembershipMineFetching(state),
   validMemberships: selectMyValidMembershipsForCreatorId(state, ODYSEE_CHANNEL.ID),
   activeMemberships: selectMyActiveMembershipsForCreatorId(state, ODYSEE_CHANNEL.ID),
   purchasedMemberships: selectMyPurchasedMembershipsForChannelClaimId(state, ODYSEE_CHANNEL.ID),

--- a/ui/page/odyseeMembership/view.jsx
+++ b/ui/page/odyseeMembership/view.jsx
@@ -17,6 +17,7 @@ import './style.scss';
 type Props = {
   // -- redux --
   mineFetched: boolean,
+  mineFetching: boolean,
   validMemberships: ?MembershipTiers,
   activeMemberships: ?MembershipTiers,
   purchasedMemberships: ?MembershipTiers,
@@ -29,6 +30,7 @@ const OdyseeMembershipPage = (props: Props) => {
   const {
     // -- redux --
     mineFetched,
+    mineFetching,
     validMemberships,
     activeMemberships,
     purchasedMemberships,
@@ -45,7 +47,7 @@ const OdyseeMembershipPage = (props: Props) => {
   }, [doMembershipList]);
 
   // we are still waiting from the backend if any of these are undefined
-  const stillWaitingFromBackend = membershipOptions === undefined || !mineFetched;
+  const stillWaitingFromBackend = (membershipOptions === undefined || !mineFetched) && mineFetching;
 
   const urlSearchParams = new URLSearchParams(window.location.search);
   const interval = urlSearchParams.get('interval') || undefined;
@@ -78,6 +80,16 @@ const OdyseeMembershipPage = (props: Props) => {
         <div className="card-stack">
           <div className="main--empty">
             <Spinner />
+          </div>
+        </div>
+      </Page>
+    );
+  } else if (!mineFetched) {
+    return (
+      <Page className="premium-wrapper">
+        <div className="card-stack">
+          <div className="main--empty">
+            <p>Failed to fetch memberships</p>
           </div>
         </div>
       </Page>

--- a/ui/page/odyseeMembership/view.jsx
+++ b/ui/page/odyseeMembership/view.jsx
@@ -89,7 +89,7 @@ const OdyseeMembershipPage = (props: Props) => {
       <Page className="premium-wrapper">
         <div className="card-stack">
           <div className="main--empty">
-            <p>Failed to fetch memberships</p>
+            <p>{__('Failed to fetch memberships')}</p>
           </div>
         </div>
       </Page>

--- a/ui/redux/reducers/memberships.js
+++ b/ui/redux/reducers/memberships.js
@@ -138,7 +138,7 @@ reducers[ACTIONS.GET_MEMBERSHIP_MINE_DATA_SUCCESS] = (state, action) => {
 };
 reducers[ACTIONS.GET_MEMBERSHIP_MINE_DATA_FAIL] = (state, action) => ({
   ...state,
-  membershipMineByCreatorId: {},
+  membershipMineByCreatorId: undefined,
   membershipMineFetching: false,
 });
 


### PR DESCRIPTION
- adds check for that memberships are fetched on account deletion (these should be fetched on page load)
- if fetching memberships fails -> consider memberships not fetched
  - fix infinite loading on premium and donor page caused by the above change 
  *Note: Commits say "infinite loop", but meant infinite loading*
 - empty membership data on successful fetch is still considered as fetched 
<details>
   <summary>Images</summary>
   
![2024-07-26_14-49](https://github.com/user-attachments/assets/da28eca1-e5c2-429c-afc9-08b5cc700e4c)

![2024-07-26_14-51](https://github.com/user-attachments/assets/af512381-eee3-4fb3-a94e-7290c02fb986)

</details>