### PR TITLE
Cap image height in comments

### DIFF
--- a/ui/scss/component/_comments.scss
+++ b/ui/scss/component/_comments.scss
@@ -455,6 +455,7 @@ $thumbnailWidthSmall: 2rem;
       margin-bottom: var(--spacing-xs) !important;
       padding-top: 0 !important;
       border-radius: var(--border-radius);
+      max-height: 300px !important;
     }
   }
 


### PR DESCRIPTION
Before:
![2024-07-29_11-11](https://github.com/user-attachments/assets/cb124f06-aaf0-44a6-b13b-7331f4bfb97f)


After:
![2024-07-29_11-01](https://github.com/user-attachments/assets/142602bd-9651-469b-b58b-d546f1ff2244)
