### PR TITLE
Normalize special letters in channel deletion name string

### DIFF
--- a/ui/modal/modalRevokeClaim/view.jsx
+++ b/ui/modal/modalRevokeClaim/view.jsx
@@ -119,7 +119,7 @@ export default function ModalRevokeClaim(props: Props) {
         actions={
           <div className="section__actions">
             <Button
-              disabled={shouldConfirmChannel && name !== channelName}
+              disabled={shouldConfirmChannel && name.normalize('NFC') !== channelName.normalize('NFC')}
               button="primary"
               label={label}
               onClick={revokeClaim}


### PR DESCRIPTION
## Fixes

In channel deletion these didn't match before:
@ArsecioMúsicaCristiana <-- ú takes one backspace to remove
@ArsecioMúsicaCristiana <-- ú takes two backspaces to remove