### PR TITLE
New Channel discovery improvements

### DIFF
--- a/ui/component/claimListDiscover/view.jsx
+++ b/ui/component/claimListDiscover/view.jsx
@@ -659,6 +659,9 @@ function ClaimListDiscover(props: Props) {
       case CS.ORDER_BY_NEW:
         order_by = CS.ORDER_BY_NEW_VALUE;
         break;
+      case CS.ORDER_BY_NEW_CREATED:
+        order_by = CS.ORDER_BY_NEW_CREATED_VALUE;
+        break;
       case CS.ORDER_BY_NEW_ASC:
         order_by = CS.ORDER_BY_NEW_ASC_VALUE;
         break;

--- a/ui/component/homepageSort/view.jsx
+++ b/ui/component/homepageSort/view.jsx
@@ -67,7 +67,7 @@ function getInitialList(listId, savedOrder, homepageSections, userHasOdyseeMembe
           let followingIndex = activeOrder.indexOf('FOLLOWING');
           if (followingIndex !== -1) activeOrder.splice(followingIndex, 0, key);
           else activeOrder.push(key);
-        } else if (key === 'DISCOVERY_CHANNEL') {
+        } else if (key === 'DISCOVERY_CHANNEL' || key === 'EXPLORABLE_CHANNEL') {
           let followingIndex = activeOrder.indexOf('FOLLOWING');
           if (followingIndex !== -1) activeOrder.splice(followingIndex + 1, 0, key);
           else activeOrder.push(key);

--- a/ui/component/homepageSort/view.jsx
+++ b/ui/component/homepageSort/view.jsx
@@ -67,6 +67,10 @@ function getInitialList(listId, savedOrder, homepageSections, userHasOdyseeMembe
           let followingIndex = activeOrder.indexOf('FOLLOWING');
           if (followingIndex !== -1) activeOrder.splice(followingIndex, 0, key);
           else activeOrder.push(key);
+        } else if (key === 'DISCOVERY_CHANNEL') {
+          let followingIndex = activeOrder.indexOf('FOLLOWING');
+          if (followingIndex !== -1) activeOrder.splice(followingIndex + 1, 0, key);
+          else activeOrder.push(key);
         } else {
           activeOrder.push(key);
         }

--- a/ui/component/router/view.jsx
+++ b/ui/component/router/view.jsx
@@ -369,7 +369,7 @@ function AppRouter(props: Props) {
 
         <Route path={`/`} exact component={HomePage} />
 
-        {(!wildWestDisabled || tagParams) && <Route path={`/$/${PAGES.DISCOVER}`} exact component={DiscoverPage} />}
+        {tagParams && <Route path={`/$/${PAGES.DISCOVER}`} exact component={DiscoverPage} />}
         {categoryPages}
 
         <Route path={`/$/${PAGES.AUTH_SIGNIN}`} exact component={SignInPage} />

--- a/ui/component/upcomingClaims/view.jsx
+++ b/ui/component/upcomingClaims/view.jsx
@@ -88,6 +88,8 @@ const UpcomingClaims = (props: Props & StateProps & DispatchProps) => {
   };
 
   const Header = () => {
+    if (list.total === 0) return null;
+
     return (
       <div
         className="claim-grid__header"
@@ -101,25 +103,13 @@ const UpcomingClaims = (props: Props & StateProps & DispatchProps) => {
           </span>
           <span className="claim-grid__title">{__('Upcoming')}</span>
 
-          {showHideSetting && !hideUpcoming && list.total > 0 && (
-            <div className="upcoming-grid__visibility" onClick={() => hideScheduled(true)}>
-              <Icon icon={ICONS.EYE_OFF} />
-              <span>{__('Hide')}</span>
-            </div>
-          )}
-          {showHideSetting && hideUpcoming && list.total > 0 && (
-            <div className="upcoming-grid__visibility" onClick={() => hideScheduled(false)}>
-              <Icon icon={ICONS.EYE} />
-              {list.total > 0 ? <span>{__('Show')}</span> : <span>{__('Empty')}</span>}
+          {showHideSetting && (
+            <div className="upcoming-grid__visibility" onClick={() => hideScheduled(!hideUpcoming)}>
+              <Icon icon={hideUpcoming ? ICONS.EYE : ICONS.EYE_OFF} />
+              <span>{hideUpcoming ? __('Show') : __('Hide')}</span>
               <div className="upcoming-grid__counter">
-                {list.total < upcomingMax ? list.total : showAllUpcoming ? upcomingMax : upcomingMax * 2}
+                {Math.min(list.total, showAllUpcoming ? upcomingMax : upcomingMax * 2)}
               </div>
-            </div>
-          )}
-          {((showHideSetting && list.total === 0) || (!showHideSetting && list.total === 0)) && (
-            <div className="upcoming-grid__visibility--empty">
-              <span>{__('Empty')}</span>
-              <div className="upcoming-grid__counter">{list.total}</div>
             </div>
           )}
         </div>

--- a/ui/constants/claim_search.js
+++ b/ui/constants/claim_search.js
@@ -38,6 +38,9 @@ export const ORDER_BY_TOP_VALUE = ['effective_amount'];
 export const ORDER_BY_NEW = 'new';
 export const ORDER_BY_NEW_VALUE = ['release_time'];
 
+export const ORDER_BY_NEW_CREATED = 'new_created';
+export const ORDER_BY_NEW_CREATED_VALUE = ['creation_timestamp'];
+
 export const ORDER_BY_NEW_ASC = 'new_asc';
 export const ORDER_BY_NEW_ASC_VALUE = ['^release_time'];
 

--- a/ui/page/channelsFollowingDiscover/index.js
+++ b/ui/page/channelsFollowingDiscover/index.js
@@ -1,12 +1,13 @@
 import { connect } from 'react-redux';
 import { selectSubscriptionIds } from 'redux/selectors/subscriptions';
-import { selectHomepageData, selectHomepageDiscover } from 'redux/selectors/settings';
+import { selectHomepageData, selectHomepageDiscover, selectHomepageDiscoverNew } from 'redux/selectors/settings';
 import ChannelsFollowingDiscover from './view';
 
 const select = (state) => ({
   subscribedChannelIds: selectSubscriptionIds(state),
   homepageData: selectHomepageData(state) || {},
   discoverData: selectHomepageDiscover(state),
+  discoverDataNew: selectHomepageDiscoverNew(state),
 });
 
 export default connect(select)(ChannelsFollowingDiscover);

--- a/ui/page/channelsFollowingDiscover/view.jsx
+++ b/ui/page/channelsFollowingDiscover/view.jsx
@@ -35,7 +35,7 @@ function ChannelsFollowingDiscover(props: Props) {
   return (
     <Page>
       <ClaimListDiscover
-        defaultOrderBy={CS.ORDER_BY_NEW}
+        defaultOrderBy={CS.ORDER_BY_NEW_CREATED}
         defaultFreshness={CS.FRESH_ALL}
         claimType={CS.CLAIM_CHANNEL}
         claimIds={CUSTOM_HOMEPAGE && channelIds ? channelIds : undefined}

--- a/ui/page/channelsFollowingDiscover/view.jsx
+++ b/ui/page/channelsFollowingDiscover/view.jsx
@@ -12,14 +12,17 @@ type Props = {
   blockedChannels: Array<string>,
   homepageData: any,
   discoverData: ?Array<string>,
+  discoverDataNew: ?Array<string>,
 };
 
 function ChannelsFollowingDiscover(props: Props) {
-  const { subscribedChannelIds, homepageData, discoverData } = props;
+  const { subscribedChannelIds, homepageData, discoverData, discoverDataNew } = props;
   const { PRIMARY_CONTENT, LATEST } = homepageData;
 
   let channelIds;
-  if (discoverData) {
+  if (discoverDataNew && discoverDataNew.length > 0) {
+    channelIds = discoverDataNew;
+  } else if (discoverData) {
     channelIds = discoverData;
   } else if (CUSTOM_HOMEPAGE) {
     if (LATEST) {
@@ -32,7 +35,7 @@ function ChannelsFollowingDiscover(props: Props) {
   return (
     <Page>
       <ClaimListDiscover
-        defaultOrderBy={CS.ORDER_BY_TRENDING}
+        defaultOrderBy={CS.ORDER_BY_NEW}
         defaultFreshness={CS.FRESH_ALL}
         claimType={CS.CLAIM_CHANNEL}
         claimIds={CUSTOM_HOMEPAGE && channelIds ? channelIds : undefined}

--- a/ui/redux/selectors/settings.js
+++ b/ui/redux/selectors/settings.js
@@ -143,6 +143,18 @@ export const selectHomepageDiscover = (state) => {
   return homepages ? homepages['en'].discover || [] : [];
 };
 
+export const selectHomepageDiscoverNew = (state) => {
+  const homepageCode = selectHomepageCode(state);
+  const homepages = selectHomepageDb(state);
+  if (homepages) {
+    const discover = homepages[homepageCode]?.discoverNew;
+    if (discover) {
+      return discover;
+    }
+  }
+  return homepages ? homepages['en']?.discoverNew || [] : [];
+};
+
 export const selectHomepageAnnouncement = (state) => {
   const homepageCode = selectHomepageCode(state);
   const homepages = selectHomepageDb(state);


### PR DESCRIPTION
Sort channels on discover page by creation time, and from a wider categorized list. First run will stay the same. 

Later we can add some pins