### PR TITLE
Don't hide "Support" button on own playlists

### DIFF
--- a/ui/page/collection/internal/collectionHeader/internal/collectionHeaderActions/view.jsx
+++ b/ui/page/collection/internal/collectionHeader/internal/collectionHeaderActions/view.jsx
@@ -84,7 +84,7 @@ function CollectionHeaderActions(props: Props) {
                       </div>
                     </Tooltip>
                   )}
-                  {!isMyCollection && <ClaimSupportButton uri={uri} fileAction />}
+                  {<ClaimSupportButton uri={uri} fileAction />}
                   {/* <ClaimRepostButton uri={uri} /> */}
                   <ClaimShareButton uri={uri} collectionId={collectionId} fileAction webShareable />
                 </>


### PR DESCRIPTION
Someone asked about LBC supporting playlist, and happened to notice that Support-button is missing on own playlist for some reason.