### PR TITLE
Convert content prices to preferred currency + EUR paywalling

### DIFF
--- a/flow-typed/stripe.js
+++ b/flow-typed/stripe.js
@@ -9,6 +9,7 @@ declare type StripeState = {
   customerStatusFetching: ?boolean,
   customerStatus: any,
   customerSetupResponse: ?StripeCustomerSetupResponse,
+  currencyRates: {[fromCurrency: string]: {[toCurrency: string]: number}},
 };
 
 declare type StripeAccountInfo = {

--- a/ui/component/common/credit-amount.jsx
+++ b/ui/component/common/credit-amount.jsx
@@ -3,6 +3,7 @@ import 'scss/component/_superchat.scss';
 
 import { getFormattedCreditsAmount, formatFullPrice } from 'util/format-credits';
 import classnames from 'classnames';
+import * as STRIPE from 'constants/stripe';
 import Icon from 'component/common/icon';
 import LbcSymbol from 'component/common/lbc-symbol';
 import React from 'react';
@@ -25,6 +26,7 @@ type Props = {
   hyperChat?: boolean,
   superChatLight?: boolean,
   icon?: string,
+  fiatCurrency?: string,
 };
 
 class CreditAmount extends React.PureComponent<Props> {
@@ -56,6 +58,7 @@ class CreditAmount extends React.PureComponent<Props> {
       hyperChat,
       // superChatLight,
       icon,
+      fiatCurrency,
     } = this.props;
 
     // return null, otherwise it will try and convert undefined to a string
@@ -78,9 +81,11 @@ class CreditAmount extends React.PureComponent<Props> {
         if (showLBC && !isFiat) {
           amountText = <LbcSymbol postfix={amountText} size={size} />;
         } else if (showLBC && isFiat) {
+          const fiatSymbol = STRIPE.CURRENCY[fiatCurrency].symbol;
           amountText = (
             <p style={{ display: 'inline' }}>
-              ${isNaN(Number(amountText)) ? amountText : (Math.round(Number(amount) * 100) / 100).toFixed(2)}
+              {fiatSymbol}
+              {isNaN(Number(amountText)) ? amountText : (Math.round(Number(amount) * 100) / 100).toFixed(2)}
             </p>
           );
         }

--- a/ui/component/filePrice/index.js
+++ b/ui/component/filePrice/index.js
@@ -7,11 +7,18 @@ import {
   selectIsFiatPaidForUri,
   selectIsFetchingPurchases,
   selectCostInfoForUri,
+  selectFiatCurrencyForUri,
 } from 'redux/selectors/claims';
+import { selectPreferredCurrency } from 'redux/selectors/settings';
+import { selectCurrencyRate } from 'redux/selectors/stripe';
 import FilePrice from './view';
 
 const select = (state, props) => {
   const claim = selectClaimForUri(state, props.uri);
+  const preferredCurrency = selectPreferredCurrency(state);
+  const originalCurrency = selectFiatCurrencyForUri(state, props.uri);
+  const canUsePreferredCurrency = Boolean(selectCurrencyRate(state, originalCurrency, preferredCurrency));
+  const currency = canUsePreferredCurrency ? preferredCurrency : originalCurrency;
 
   return {
     claim,
@@ -21,6 +28,8 @@ const select = (state, props) => {
     rentalInfo: selectRentalTagForUri(state, props.uri),
     purchaseInfo: selectPurchaseTagForUri(state, props.uri),
     isFetchingPurchases: selectIsFetchingPurchases(state),
+    currency,
+    canUsePreferredCurrency: Boolean(selectCurrencyRate(state, originalCurrency, preferredCurrency)),
   };
 };
 

--- a/ui/component/filePrice/view.jsx
+++ b/ui/component/filePrice/view.jsx
@@ -14,14 +14,16 @@ type Props = {
   showFullPrice: boolean,
   type?: 'default' | 'filepage' | 'modal' | 'thumbnail',
   uri: string,
-  rentalInfo: { price: number, currency: string, expirationTimeInSeconds: number },
-  purchaseInfo: number,
+  rentalInfo: { price: number, currency: string, expirationTimeInSeconds: number, priceInPreferredCurrency: number },
+  purchaseInfo: { price: number, currency: string, priceInPreferredCurrency: number },
   isFetchingPurchases: boolean,
   // below props are just passed to <CreditAmount />
   customPrices?: { priceFiat: number, priceLBC: number },
   hideFree?: boolean, // hide the file price if it's free
   isFiat?: boolean,
   showLBC?: boolean,
+  currency: string,
+  canUsePreferredCurrency: boolean,
 };
 
 class FilePrice extends React.PureComponent<Props> {
@@ -41,6 +43,8 @@ class FilePrice extends React.PureComponent<Props> {
       purchaseInfo,
       isFetchingPurchases,
       fiatPaid,
+      currency,
+      canUsePreferredCurrency,
     } = this.props;
 
     const fiatRequired = Boolean(purchaseInfo) || Boolean(rentalInfo);
@@ -65,6 +69,10 @@ class FilePrice extends React.PureComponent<Props> {
 
       const hasMultiOptions = Boolean(purchaseInfo) && Boolean(rentalInfo);
       const showIconsOnly = hasMultiOptions && type === 'thumbnail';
+      const purchasePrice =
+        purchaseInfo && (canUsePreferredCurrency ? purchaseInfo.priceInPreferredCurrency : purchaseInfo.price);
+      const rentalPrice =
+        rentalInfo && (canUsePreferredCurrency ? rentalInfo.priceInPreferredCurrency : rentalInfo.price);
 
       return (
         <div
@@ -83,20 +91,22 @@ class FilePrice extends React.PureComponent<Props> {
             <>
               {purchaseInfo && (
                 <CreditAmount
-                  amount={showIconsOnly ? '' : purchaseInfo}
+                  amount={showIconsOnly ? '' : purchasePrice}
                   className={className}
                   isFiat
                   showFullPrice={showFullPrice}
                   icon={ICONS.BUY}
+                  fiatCurrency={currency}
                 />
               )}
               {rentalInfo && (
                 <CreditAmount
-                  amount={showIconsOnly ? '' : rentalInfo.price}
+                  amount={showIconsOnly ? '' : rentalPrice}
                   className={className}
                   isFiat
                   showFullPrice={showFullPrice}
                   icon={ICONS.TIME}
+                  fiatCurrency={currency}
                 />
               )}
             </>

--- a/ui/component/publish/shared/publishPrice/view.jsx
+++ b/ui/component/publish/shared/publishPrice/view.jsx
@@ -15,7 +15,7 @@ import ButtonStripeConnectAccount from 'component/buttonStripeConnectAccount';
 import './style.lazy.scss';
 
 const FEE = { MIN: 1, MAX: 999.99 };
-const CURRENCY_OPTIONS = ['USD']; // ['USD', 'EUR']; // disable EUR until currency approach is determined.
+const CURRENCY_OPTIONS = ['USD', 'EUR'];
 
 type Props = {
   disabled: boolean,

--- a/ui/hocs/withStreamClaimRender/internal/paidContentOverlay/index.js
+++ b/ui/hocs/withStreamClaimRender/internal/paidContentOverlay/index.js
@@ -6,18 +6,25 @@ import {
   selectPurchaseTagForUri,
   selectRentalTagForUri,
   selectCostInfoForUri,
+  selectFiatCurrencyForUri,
 } from 'redux/selectors/claims';
 import PaidContentOvelay from './view';
 import { doOpenModal } from 'redux/actions/app';
 import { selectPreferredCurrency } from 'redux/selectors/settings';
+import { selectCurrencyRate } from 'redux/selectors/stripe';
 
 const select = (state, props) => {
   const { uri } = props;
-
   const preorderContentClaimId = selectPreorderContentClaimIdForUri(state, uri);
 
+  const preferredCurrency = selectPreferredCurrency(state);
+  const originalCurrency = selectFiatCurrencyForUri(state, props.uri);
+  const canUsePreferredCurrency = Boolean(selectCurrencyRate(state, originalCurrency, preferredCurrency));
+  const currency = canUsePreferredCurrency ? preferredCurrency : originalCurrency;
+
   return {
-    preferredCurrency: selectPreferredCurrency(state),
+    currency,
+    canUsePreferredCurrency,
     preorderContentClaim: selectClaimForId(state, preorderContentClaimId),
     preorderTag: selectPreorderTagForUri(state, uri),
     purchaseTag: selectPurchaseTagForUri(state, uri),

--- a/ui/modal/modalPreorderAndPurchaseContent/internal/preorderAndPurchaseContentCard/index.js
+++ b/ui/modal/modalPreorderAndPurchaseContent/internal/preorderAndPurchaseContentCard/index.js
@@ -11,6 +11,7 @@ import {
   selectIsFetchingPurchases,
   selectSdkFeePendingForUri,
   selectPendingPurchaseForUri,
+  selectFiatCurrencyForUri,
 } from 'redux/selectors/claims';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { doPlayUri } from 'redux/actions/content';
@@ -18,6 +19,7 @@ import { doHideModal } from 'redux/actions/app';
 import { doCheckIfPurchasedClaimId } from 'redux/actions/stripe';
 import { doPurchaseClaimForUri } from 'redux/actions/wallet';
 import { selectPreferredCurrency } from 'redux/selectors/settings';
+import { selectCurrencyRate } from 'redux/selectors/stripe';
 import { withRouter } from 'react-router';
 import PreorderAndPurchaseContent from './view';
 
@@ -27,10 +29,16 @@ const select = (state, props) => {
   const claim = selectClaimForUri(state, uri, false);
   const { claim_id: claimId, value_type: claimType } = claim || {};
 
+  const preferredCurrency = selectPreferredCurrency(state);
+  const originalCurrency = selectFiatCurrencyForUri(state, props.uri);
+  const canUsePreferredCurrency = Boolean(selectCurrencyRate(state, originalCurrency, preferredCurrency));
+  const currency = canUsePreferredCurrency ? preferredCurrency : originalCurrency;
+
   return {
     claimId,
     claimType,
-    preferredCurrency: selectPreferredCurrency(state),
+    currency,
+    canUsePreferredCurrency: Boolean(selectCurrencyRate(state, 'USD', preferredCurrency)),
     preorderTag: selectPreorderTagForUri(state, uri),
     purchaseTag: selectPurchaseTagForUri(state, uri),
     rentalTag: selectRentalTagForUri(state, uri),

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -655,9 +655,9 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
 
     // Fill purchase/rental details from the claim
     const rental = parseRentalTag(tags);
-    const purchasePrice = parsePurchaseTag(tags);
+    const purchase = parsePurchaseTag(tags);
 
-    if (rental || purchasePrice) {
+    if (rental || purchase) {
       publishData['paywall'] = PAYWALL.FIAT;
     } else if (fee.amount && Number(fee.amount) > 0) {
       publishData['paywall'] = PAYWALL.SDK;
@@ -669,7 +669,7 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
       publishData.fiatRentalEnabled = true;
       publishData.fiatRentalFee = {
         amount: rental.price,
-        currency: 'USD', // TODO: hardcode until we have a direction on currency
+        currency: rental.currency, // TODO: hardcode until we have a direction on currency
       };
       publishData.fiatRentalExpiration = {
         // Don't know which unit the user picked since we store it as 'seconds'
@@ -679,11 +679,11 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
       };
     }
 
-    if (purchasePrice) {
+    if (purchase) {
       publishData.fiatPurchaseEnabled = true;
       publishData.fiatPurchaseFee = {
-        amount: purchasePrice,
-        currency: 'USD', // TODO: hardcode until we have a direction on currency
+        amount: purchase.price,
+        currency: purchase.currency, // TODO: hardcode until we have a direction on currency
       };
     }
 

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -657,6 +657,8 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
     const rental = parseRentalTag(tags);
     const purchase = parsePurchaseTag(tags);
 
+    const currency = rental?.currency || purchase?.currency || 'USD';
+
     if (rental || purchase) {
       publishData['paywall'] = PAYWALL.FIAT;
     } else if (fee.amount && Number(fee.amount) > 0) {
@@ -669,7 +671,7 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
       publishData.fiatRentalEnabled = true;
       publishData.fiatRentalFee = {
         amount: rental.price,
-        currency: rental.currency, // TODO: hardcode until we have a direction on currency
+        currency: currency,
       };
       publishData.fiatRentalExpiration = {
         // Don't know which unit the user picked since we store it as 'seconds'
@@ -677,13 +679,24 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
         value: rental.expirationTimeInSeconds / TO_SECONDS['days'],
         unit: 'days',
       };
+    } else {
+      // Make sure currency matches purchase
+      publishData.fiatRentalFee = {
+        amount: 1,
+        currency: currency,
+      };
     }
 
     if (purchase) {
       publishData.fiatPurchaseEnabled = true;
       publishData.fiatPurchaseFee = {
         amount: purchase.price,
-        currency: purchase.currency, // TODO: hardcode until we have a direction on currency
+        currency: currency,
+      };
+    } else {
+      publishData.fiatPurchaseFee = {
+        amount: 1,
+        currency: currency,
       };
     }
 

--- a/ui/redux/reducers/publish.js
+++ b/ui/redux/reducers/publish.js
@@ -138,6 +138,13 @@ export const publishReducer = handleActions(
         }
       }
 
+      // -- fiat fee currency
+      if (data.fiatPurchaseFee) {
+        auto.fiatRentalFee = { amount: state.fiatRentalFee.amount, currency: data.fiatPurchaseFee.currency };
+      } else if (data.fiatRentalFee) {
+        auto.fiatPurchaseFee = { amount: state.fiatPurchaseFee.amount, currency: data.fiatRentalFee.currency };
+      }
+
       // -- channel
       const channel = data.hasOwnProperty('channel') ? data.channel : state.channel;
       if (channel === undefined) {

--- a/ui/redux/reducers/stripe.js
+++ b/ui/redux/reducers/stripe.js
@@ -14,6 +14,7 @@ const defaultState: StripeState = {
   customerStatusFetching: undefined,
   customerStatus: undefined,
   customerSetupResponse: undefined,
+  currencyRates: { USD: { EUR: 0.9123 } },
 };
 
 reducers[ACTIONS.STRIPE_ACCOUNT_STATUS_START] = (state, action) => ({ ...state, accountStatusFetching: true });

--- a/ui/redux/selectors/stripe.js
+++ b/ui/redux/selectors/stripe.js
@@ -11,6 +11,7 @@ export const selectAccountTransactions = (state: State) => selectState(state).ac
 export const selectCustomerStatus = (state: State) => selectState(state).customerStatus;
 export const selectCustomerStatusFetching = (state: State) => selectState(state).customerStatusFetching;
 export const selectCustomerSetupResponse = (state: State) => selectState(state).customerSetupResponse;
+export const selectCurrencyRates = (state: State) => selectState(state).currencyRates;
 
 export const selectAccountStatus = (state: State) => selectState(state).accountStatus;
 export const selectAccountStatusFetching = (state: State) => selectState(state).accountStatusFetching;
@@ -23,6 +24,11 @@ export const selectAccountInfo = (state: State) => {
 export const selectAccountDefaultCurrency = (state: State) => {
   const accountInfo = selectAccountInfo(state);
   return accountInfo && accountInfo.default_currency;
+};
+
+export const selectCurrencyRate = (state: State, from: string = 'USD', to: string) => {
+  const rates = selectCurrencyRates(state);
+  return from in rates ? rates[from][to] : undefined;
 };
 
 export const selectAccountUnpaidBalance = (state: State) => selectAccountStatus(state)?.total_received_unpaid || 0;

--- a/ui/util/publish.js
+++ b/ui/util/publish.js
@@ -337,7 +337,7 @@ const PAYLOAD = {
         // Purchase
         if (fiatPurchaseEnabled && fiatPurchaseFee?.currency && Number(fiatPurchaseFee.amount) > 0) {
           tagSet.add(PURCHASE_TAG);
-          tagSet.add(`${PURCHASE_TAG}:${fiatPurchaseFee.amount.toFixed(2)}`);
+          tagSet.add(`${PURCHASE_TAG}:${fiatPurchaseFee.amount.toFixed(2)}:${fiatPurchaseFee.currency}`);
         }
 
         // Rental
@@ -350,7 +350,7 @@ const PAYLOAD = {
         ) {
           const seconds = fiatRentalExpiration.value * (TO_SECONDS[fiatRentalExpiration.unit] || 3600);
           tagSet.add(RENTAL_TAG);
-          tagSet.add(`${RENTAL_TAG}:${fiatRentalFee.amount.toFixed(2)}:${seconds}`);
+          tagSet.add(`${RENTAL_TAG}:${fiatRentalFee.amount.toFixed(2)}:${seconds}:${fiatRentalFee.currency}`);
         }
       }
     },

--- a/ui/util/stripe.js
+++ b/ui/util/stripe.js
@@ -28,7 +28,7 @@ export function parseRentalTag(tags: ?Array<string>) {
       const parts = rentalTag.substring(prefix.length).split(':');
       const price = parseFloat(parts[0]);
       const expirationTimeInSeconds = parseInt(parts[1]);
-      const currency = 'USD';
+      const currency = (parts[2] && parts[2].toUpperCase()) || 'USD';
 
       if (Number.isFinite(price) && Number.isFinite(expirationTimeInSeconds)) {
         return { price, expirationTimeInSeconds, currency, priceInPreferredCurrency: null };
@@ -49,8 +49,7 @@ export function parsePurchaseTag(tags: ?Array<string>) {
     if (purchaseTag) {
       const parts = purchaseTag.substring(prefix.length).split(':');
       const price = parseFloat(parts[0]);
-      const currency = 'USD';
-
+      const currency = (parts[1] && parts[1].toUpperCase()) || 'USD';
       if (Number.isFinite(price)) {
         return { price, currency, priceInPreferredCurrency: null };
       } else {

--- a/ui/util/stripe.js
+++ b/ui/util/stripe.js
@@ -28,9 +28,10 @@ export function parseRentalTag(tags: ?Array<string>) {
       const parts = rentalTag.substring(prefix.length).split(':');
       const price = parseFloat(parts[0]);
       const expirationTimeInSeconds = parseInt(parts[1]);
+      const currency = 'USD';
 
       if (Number.isFinite(price) && Number.isFinite(expirationTimeInSeconds)) {
-        return { price, expirationTimeInSeconds };
+        return { price, expirationTimeInSeconds, currency, priceInPreferredCurrency: null };
       } else {
         return null; // invalid format
       }
@@ -48,9 +49,10 @@ export function parsePurchaseTag(tags: ?Array<string>) {
     if (purchaseTag) {
       const parts = purchaseTag.substring(prefix.length).split(':');
       const price = parseFloat(parts[0]);
+      const currency = 'USD';
 
       if (Number.isFinite(price)) {
-        return price;
+        return { price, currency, priceInPreferredCurrency: null };
       } else {
         return null; // invalid format
       }


### PR DESCRIPTION
If rate for preferred currency is known, convert prices to it. 
If rate couldn't be fetched, use original price in original currency.

Will extent currency to purchase tag, for example: `c:purchase:2.00:eur`. (If currency is missing, defaults to USD)