### PR TITLE
Fix mobile comment input (went out of screen)

### DIFF
--- a/ui/component/textareaWithSuggestions/render-input.jsx
+++ b/ui/component/textareaWithSuggestions/render-input.jsx
@@ -81,7 +81,15 @@ const TextareaSuggestionsInput = (props: Props) => {
     );
 
     return (
-      <TextField inputRef={inputRef} variant="outlined" multiline minRows={1} select={false} {...autocompleteProps} />
+      <TextField
+        inputRef={inputRef}
+        variant="outlined"
+        multiline
+        minRows={1}
+        maxRows={15}
+        select={false}
+        {...autocompleteProps}
+      />
     );
   }
 


### PR DESCRIPTION
Limits mobile comment input to 15 rows.

OLD: No row limit, long comment kind of breaks the UX
![2024-10-23_17-25](https://github.com/user-attachments/assets/70cffbbf-c75b-4f9d-82cd-78184243f501)

NEW: Should be better
![2024-10-23_17-23](https://github.com/user-attachments/assets/9cfc6fab-da53-467b-b5ac-e457dedd696a)
