### PR TITLE
Show block confirmation modal for personal blocks

### DIFF
--- a/ui/modal/modalBlockChannel/view.jsx
+++ b/ui/modal/modalBlockChannel/view.jsx
@@ -204,12 +204,15 @@ export default function ModalBlockChannel(props: Props) {
   // **************************************************************************
   // **************************************************************************
 
+  // Confirm before blocking
+  /*
   if (isPersonalTheOnlyTab && !isTimeoutAvail) {
     // There's only 1 option. Just execute it and don't show the modal.
     doCommentModBlock(commenterUri, offendingCommentId);
     doHideModal();
     return null;
   }
+  */
 
   return (
     <Modal isOpen type="card" onAborted={doHideModal}>


### PR DESCRIPTION
User complaint. Says that "Block" being close to "Reply" can cause annoying accidental blocks. 

Would now show modal also for just personal blocks.
![2024-10-25_18-16](https://github.com/user-attachments/assets/c662e5d3-e9ff-4879-b8d8-1ee797ff40ce)
