### PR TITLE
Let users know that "Submit Feedback" can be used for email change

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2955,6 +2955,7 @@
   "Are you a supermodel or rockstar that received a custom Credits code? Claim it here.": "Are you a supermodel or rockstar that received a custom Credits code? Claim it here.",
   "Default action when clicking a playlist.": "Default action when clicking a playlist.",
   "Default playlist action": "Default playlist action",
+  "Optionally the email change can be requested using \"Submit Feedback\" button below.": "Optionally the email change can be requested using \"Submit Feedback\" button below.",
   
   "--end--": "--end--"
 }

--- a/ui/page/help/view.jsx
+++ b/ui/page/help/view.jsx
@@ -82,10 +82,15 @@ export default function HelpPage(props: Props) {
       <Card
         title={__('Email change')}
         subtitle={
-          <I18nMessage tokens={{ channel: <strong>#support</strong>, help_email: SITE_HELP_EMAIL }}>
-            Email address changes are processed manually on request via email. Email must come from the original email
-            being changed, or we'll need to verify ownership another way.
-          </I18nMessage>
+          <>
+            <I18nMessage tokens={{ channel: <strong>#support</strong>, help_email: SITE_HELP_EMAIL }}>
+              Email address changes are processed manually on request via email. Email must come from the original email
+              being changed, or we'll need to verify ownership another way.
+            </I18nMessage>{' '}
+            <I18nMessage>
+              Optionally the email change can be requested using "Submit Feedback" button below.
+            </I18nMessage>
+          </>
         }
         actions={
           <Button button="secondary" label={__('Email Us')} icon={ICONS.WEB} href={`mailto:${SITE_HELP_EMAIL}`} />


### PR DESCRIPTION
The "Email Us" button in same cases fails open the email app.   Some user had trouble finding the email, thought it's shown on the page.  

Since user feedback is now easy to track, added a mention that it can also be used for email change requests.