### PR TITLE
Don't show "tip not sent with comment" warning, when it's sent with a tip

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -787,6 +787,7 @@ export function CommentCreate(props: Props) {
               setDisableSubmitButton={setDisableReviewButton}
               setTipError={setTipError}
               tipError={tipError}
+              isComment
             />
           )}
 

--- a/ui/component/walletTipAmountSelector/view.jsx
+++ b/ui/component/walletTipAmountSelector/view.jsx
@@ -28,6 +28,7 @@ type Props = {
   tipError: string,
   uri: string,
   canReceiveFiatTips: ?boolean,
+  isComment?: boolean,
   onChange: (number) => void,
   setConvertedAmount?: (number) => void,
   setDisableSubmitButton: (boolean) => void,
@@ -49,6 +50,7 @@ function WalletTipAmountSelector(props: Props) {
     fiatConversion,
     tipError,
     canReceiveFiatTips,
+    isComment,
     onChange,
     setConvertedAmount,
     setDisableSubmitButton,
@@ -275,6 +277,7 @@ function WalletTipAmountSelector(props: Props) {
           ? getHelpMessage(__('Only creators that verify cash accounts can receive tips.'))
           : getHelpMessage(__('Send a tip directly from your attached card.')))}
       {activeTab === TAB_FIAT &&
+        !isComment &&
         getHelpMessage(
           __(
             'IMPORTANT: this donation is sent without a comment. If you want to include a comment, click the $ next to the comment input area.'


### PR DESCRIPTION
OLD:
![2024-11-17_13-13](https://github.com/user-attachments/assets/40d8a0d8-2e6e-46eb-a77b-cb31100cc9a8)

NEW (removes the warning from comment tips):
![2024-11-17_13-20](https://github.com/user-attachments/assets/9420cb69-45f4-495d-8c7b-8bdbea923a10)
