### PR TITLE
Fix: Video not showing as "Saved" if in public list

### DIFF
--- a/ui/redux/actions/app.js
+++ b/ui/redux/actions/app.js
@@ -16,6 +16,7 @@ import * as DAEMON_SETTINGS from 'constants/daemon_settings';
 import * as SHARED_PREFERENCES from 'constants/shared_preferences';
 import Lbry from 'lbry';
 import { doFetchChannelListMine, doCheckPendingClaims } from 'redux/actions/claims';
+import { doFetchCollectionListMine } from 'redux/actions/collections';
 import { selectClaimForUri, selectClaimIsMineForUri } from 'redux/selectors/claims';
 import { doFetchFileInfos } from 'redux/actions/file_info';
 import { doClearSupport, doBalanceSubscribe } from 'redux/actions/wallet';
@@ -580,6 +581,7 @@ export function doSignIn() {
     dispatch(doCheckPendingClaims());
     dispatch(doBalanceSubscribe());
     dispatch(doFetchChannelListMine());
+    dispatch(doFetchCollectionListMine());
     dispatch(doMembershipMine());
   };
 }

--- a/ui/redux/selectors/collections.js
+++ b/ui/redux/selectors/collections.js
@@ -244,14 +244,17 @@ export const selectClaimSavedForUrl = createSelector(
   (state, url) => url,
   selectBuiltinCollections,
   selectMyPublicLocalCollections,
-  selectMyPublicLocalCollections,
   selectMyUnpublishedCollections,
   selectMyEditedCollections,
   (url, bLists, myRLists, uLists, eLists) => {
     const collections = [bLists, uLists, eLists, myRLists];
-
     // $FlowFixMe
-    return collections.some((list) => Object.values(list).some(({ items }) => items?.some((item) => item === url)));
+    const claimId = url.match(/[a-f0-9]{40}/)?.at(0);
+
+    return collections.some((list) =>
+      // $FlowFixMe
+      Object.values(list).some(({ items }) => items?.some((item) => item === url || item === claimId))
+    );
   }
 );
 


### PR DESCRIPTION
Fetch public lists on app launch.
Check if item is in lists also with claimId, in case of public list.

Also removed duplicate:
```
selectMyPublicLocalCollections,
selectMyPublicLocalCollections,
```
Based on variable names/amount it looks like it wasn't intentional.