### PR TITLE
Prevent playlist publish/edit while in arrange mode

### DIFF
--- a/ui/page/collection/internal/collectionActions/internal/publishButton/view.jsx
+++ b/ui/page/collection/internal/collectionActions/internal/publishButton/view.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import FileActionButton from 'component/common/file-action-button';
 
 type Props = {
+  showEdit?: boolean,
   // redux
   collectionHasEdits: boolean,
   claimIsPending: boolean,
@@ -13,7 +14,7 @@ type Props = {
 };
 
 function CollectionPublishButton(props: Props) {
-  const { collectionHasEdits, claimIsPending, collectionLength } = props;
+  const { showEdit, collectionHasEdits, claimIsPending, collectionLength } = props;
 
   const { push } = useHistory();
 
@@ -27,7 +28,7 @@ function CollectionPublishButton(props: Props) {
       onClick={() => push(`?${CP.QUERIES.VIEW}=${CP.VIEWS.PUBLISH}`)}
       icon={ICONS.PUBLISH}
       iconSize={18}
-      disabled={claimIsPending}
+      disabled={claimIsPending || showEdit}
     />
   );
 }

--- a/ui/page/collection/internal/collectionHeader/internal/collectionHeaderActions/view.jsx
+++ b/ui/page/collection/internal/collectionHeader/internal/collectionHeaderActions/view.jsx
@@ -23,7 +23,7 @@ type Props = {
   claimId?: string,
   isMyCollection: boolean,
   collectionId: string,
-  // showEdit: boolean,
+  showEdit: boolean,
   // isHeader: boolean,
   setShowEdit: (boolean) => void,
   isBuiltin: boolean,
@@ -45,7 +45,7 @@ function CollectionHeaderActions(props: Props) {
     collectionId,
     isBuiltin,
     claimIsPending,
-    // showEdit,
+    showEdit,
     // isHeader,
     setShowEdit,
     // collectionSavedForId,
@@ -70,7 +70,7 @@ function CollectionHeaderActions(props: Props) {
         <SectionElement>
           {!isBuiltin && (
             <>
-              {isMyCollection && <CollectionPublishButton uri={uri} collectionId={collectionId} />}
+              {isMyCollection && <CollectionPublishButton uri={uri} collectionId={collectionId} showEdit={showEdit} />}
               {uri && (
                 <>
                   {claimIsPending && (
@@ -102,7 +102,7 @@ function CollectionHeaderActions(props: Props) {
               <Icon size={20} icon={ICONS.MORE_VERTICAL} />
             </MenuButton>
             <MenuList className="menu__list">
-              {isMyCollection && isNotADefaultList && (
+              {isMyCollection && isNotADefaultList && !showEdit && (
                 <MenuItem
                   className="comment__menu-option"
                   onSelect={() =>


### PR DESCRIPTION
*Issue:* Arrange mode doesn't get disabled when entering Publish/Edit page, and would confusingly still be toggled on when returning from those pages. 

*Fix:* Disabling Publish/Edit button/option until user has exited arrange-mode.  
(Don't want to auto handle it when exiting Publish/Edit, as the Cancelling in those would also clear possible unsaved changes that were done in arrange mode.)

Makes arrange-mode look like this:
![2024-12-23_09-47](https://github.com/user-attachments/assets/187b04d1-2afc-442c-8111-c3c2a1c26c19)

