### PR TITLE
Highlight tag if it contains mature word

### DIFF
--- a/ui/component/tag/view.jsx
+++ b/ui/component/tag/view.jsx
@@ -16,7 +16,7 @@ type Props = {
 
 export default function Tag(props: Props) {
   const { name, onClick, type = 'link', disabled = false } = props;
-  const isMature = MATURE_TAGS.includes(name);
+  const isMature = name.split(' ').some((word) => MATURE_TAGS.includes(word));
   const clickProps = onClick ? { onClick } : { navigate: `/$/${PAGES.DISCOVER}?t=${encodeURIComponent(name)}` };
 
   let title;


### PR DESCRIPTION
Fixes #3192 

Not sure how make a note so it won't be just more confusing.  Ok to just highlight usage of mature word for now?

![2025-01-07_09-33](https://github.com/user-attachments/assets/d599088c-a998-4b9f-a2d3-14bf71ad46ab)


