### PR TITLE
Don't push invisible `FYP` in homepage (affected non-premium users)

### DIFF
--- a/ui/page/home/helper.jsx
+++ b/ui/page/home/helper.jsx
@@ -46,7 +46,7 @@ export function getSortedRowData(
         if (dataIndex !== -1) {
           sortedRowData.push(rowData[dataIndex]);
           rowData.splice(dataIndex, 1);
-        } else if (key === 'FYP') {
+        } else if (key === 'FYP' && hasMembership) {
           // Special-case injection (not part of category definition):
           sortedRowData.push(FYP_SECTION);
         } else if (key === 'BANNER' && hasBanner) {


### PR DESCRIPTION
Fixes this blank page when there are no categories. For non-premium users there was an invisible FYP which still counted as a homepage row.
![2025-01-11_13-24](https://github.com/user-attachments/assets/c56c7ec8-a724-41ee-bf13-91cc4f09c19e)

Now would look like this also in those cases.
![2025-01-11_13-24_1](https://github.com/user-attachments/assets/90f17cf2-b49e-4743-9076-305954d45c9f)

