### PR TITLE
Auto increase bid to minimum

### DIFF
--- a/ui/component/publish/shared/publishBid/view.jsx
+++ b/ui/component/publish/shared/publishBid/view.jsx
@@ -23,6 +23,13 @@ function PublishBid(props: Props) {
   const previousBidAmount = myClaimForUri && Number(myClaimForUri.amount);
 
   useEffect(() => {
+    if (bid < MINIMUM_PUBLISH_BID) {
+      updatePublishForm({ bid: parseFloat(MINIMUM_PUBLISH_BID) });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     const totalAvailableBidAmount = previousBidAmount ? previousBidAmount + balance : balance;
 
     let bidError;

--- a/ui/page/collection/internal/collectionPublishForm/internal/collectionGeneralTab/internal/additionalOptions/view.jsx
+++ b/ui/page/collection/internal/collectionPublishForm/internal/collectionGeneralTab/internal/additionalOptions/view.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 import SUPPORTED_LANGUAGES from 'constants/supported_languages';
 import * as PUBLISH from 'constants/publish';
+import { MINIMUM_PUBLISH_BID } from 'constants/claim';
 
 import { FormField } from 'component/common/form';
 import { handleBidChange, handleLanguageChange } from 'util/publish';
@@ -43,9 +44,17 @@ function CollectionPublishAdditionalOptions(props: Props) {
     setHideSection(!hideSection);
   }
 
+  const isFirstRun = React.useRef(true);
   React.useEffect(() => {
+    let bid = formParams.bid;
+    if (isFirstRun.current) {
+      isFirstRun.current = false;
+      if (bid < MINIMUM_PUBLISH_BID) {
+        bid = MINIMUM_PUBLISH_BID;
+      }
+    }
     handleBidChange(
-      parseFloat(formParams.bid),
+      parseFloat(bid),
       amount,
       balance,
       (value) => {


### PR DESCRIPTION
If old bid on claim is less than `MINIMUM_PUBLISH_BID`, auto increase it. 

Handles playlists and uploads.

Channels seem to be fine with too low bid when it's not changed, so left it as is.