### PR TITLE
DryRun the comment creation before submitting the tip

### DIFF
--- a/flow-typed/Comment.js
+++ b/flow-typed/Comment.js
@@ -33,6 +33,7 @@ declare type CommentSubmitParams = {
   environment?: ?string,
   sticker: boolean,
   is_protected?: boolean,
+  dry_run?: boolean,
 };
 
 // ****************************************************************************

--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -63,7 +63,7 @@ type Props = {
   onCancelReplying?: () => void,
   onDoneReplying?: () => void,
   // redux
-  doCommentCreate: (uri: string, isLivestream?: boolean, params: CommentSubmitParams, dryRun?: boolean) => Promise<any>,
+  doCommentCreate: (uri: string, isLivestream?: boolean, params: CommentSubmitParams) => Promise<any>,
   doFetchCreatorSettings: (channelId: string) => Promise<any>,
   doToast: ({ message: string }) => void,
   doCommentById: (commentId: string, toastIfNotFound: boolean) => Promise<any>,

--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -399,7 +399,7 @@ export function CommentCreate(props: Props) {
         }
 
         // DryRun comment creation before submitting the tip
-        handleCreateComment(null, null, null, true).then((res) => {
+        handleCreateComment(undefined, undefined, undefined, true).then((res) => {
           if (res !== 'success') {
             setSubmitting(false);
             return;
@@ -507,24 +507,20 @@ export function CommentCreate(props: Props) {
 
     const stickerValue = selectedSticker && buildValidSticker(selectedSticker.name);
 
-    return doCommentCreate(
-      uri,
-      isLivestream,
-      {
-        comment: stickerValue || commentValue,
-        claim_id: claimId,
-        parent_id: parentId,
-        txid,
-        payment_intent_id,
-        environment,
-        sticker: !!stickerValue,
-        is_protected: Boolean(isLivestreamChatMembersOnly || areCommentsMembersOnly),
-      },
-      dryRun
-    )
+    return doCommentCreate(uri, isLivestream, {
+      comment: stickerValue || commentValue,
+      claim_id: claimId,
+      parent_id: parentId,
+      txid,
+      payment_intent_id,
+      environment,
+      sticker: !!stickerValue,
+      is_protected: Boolean(isLivestreamChatMembersOnly || areCommentsMembersOnly),
+      dry_run: dryRun,
+    })
       .then((res) => {
         if (dryRun) {
-          return res;
+          return res.comment_id ? 'success' : 'fail';
         }
         setSubmitting(false);
         if (setQuickReply) setQuickReply(res);


### PR DESCRIPTION
Handles the multiple channels error, and should also handle other possible comment creation errors caused by front end.