### PR TITLE
Only reset player recoveryAttempts if video really started to play

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs-events.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs-events.jsx
@@ -116,11 +116,6 @@ const VideoJsEvents = ({
   function onInitialPlay() {
     const player = playerRef.current;
 
-    // Reset recovery attempts on successful playback
-    if (player.appState) {
-      player.appState.recoveryAttempts = 0;
-    }
-
     updateMediaSession();
 
     // $FlowIssue
@@ -361,7 +356,14 @@ const VideoJsEvents = ({
     player.on('volumechange', onVolumeChange);
     player.on('error', onError);
 
-    player.on('playing', resetRecoveryAttempts);
+    player.on('playing', () => {
+      let startTime = player.currentTime();
+      setTimeout(() => {
+        if (player.currentTime() > startTime) {
+          resetRecoveryAttempts();
+        }
+      }, 500);
+    });
 
     // custom tracking plugin, event used for watchman data, and marking view/getting rewards
     player.on('tracking:firstplay', doTrackingFirstPlay);


### PR DESCRIPTION
Noticed infinite looping with retry attempts on this video.
(User didn't mentioned about them, just about the crashing itself. Saw it here in FF/Brave, so maybe device specific?)

Now it only would only reset the attempts if the current time actually changes when the video is "playing". 

Happens when skipping to around 30mins in this video. Think it has some corrupted section in the middle there.
https://odysee.com/@%D9%85%D8%B1%D9%83%D8%B2_%D8%A7%D9%84%D8%B2%D9%87%D8%B1%D8%A7%D8%A1_%D8%B9%D9%84%D9%8A%D9%87%D8%A7_%D8%A7%D9%84%D8%B3%D9%84%D8%A7%D9%85:3/2025-01-22-%D8%B3%D9%88%D8%B1%D8%A9-%D8%A7%D9%84%D9%83%D9%87%D9%81-%D8%A7%D9%84%D8%B1%D8%AC%D8%A7%D9%84-%D8%A7%D9%84%D9%81%D8%A7%D8%A6%D8%B2%D9%88%D9%86:7



