### PR TITLE
Fix tip currency change on mobile hyperchats

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -302,7 +302,8 @@ export function CommentCreate(props: Props) {
         isTipOnly: true,
         hasSelectedTab: tab,
         customText: __('Preview Comment Tip'),
-        setAmount: (amount) => {
+        setAmount: (amount, activeTab) => {
+          setActiveTab(activeTab);
           setTipAmount(amount);
           setReviewingSupportComment(true);
         },

--- a/ui/component/walletSendTip/view.jsx
+++ b/ui/component/walletSendTip/view.jsx
@@ -60,7 +60,7 @@ type Props = {
     ?(any) => void
   ) => string,
   doSendTip: (SupportParams, boolean) => void, // function that comes from lbry-redux
-  setAmount?: (number) => void,
+  setAmount?: (number, string) => void,
   preferredCurrency: string,
   modalProps?: any,
 };
@@ -208,7 +208,7 @@ export default function WalletSendTip(props: Props) {
     if (!tipAmount || !claimId) return;
 
     if (setAmount) {
-      setAmount(tipAmount);
+      setAmount(tipAmount, activeTab);
       doHideModal();
       return;
     }
@@ -282,7 +282,7 @@ export default function WalletSendTip(props: Props) {
   }
 
   React.useEffect(() => {
-    if (!hasSelected && hasSelectedTab && activeTab !== hasSelectedTab) {
+    if (!hasSelected && hasSelectedTab) {
       setActiveTab(claimIsMine ? TAB_BOOST : hasSelectedTab);
       setSelected(true);
     }


### PR DESCRIPTION
On mobile changing the hyperchat currency in the tipping modal didn't affected the currency of the actual tip. 
