### PR TITLE
Connect modal

### DIFF
--- a/flow-typed/stripe.js
+++ b/flow-typed/stripe.js
@@ -12,7 +12,7 @@ declare type StripeState = {
   customerStatus: any,
   customerSetupResponse: ?StripeCustomerSetupResponse,
   arAccountUpdating: false,
-  arAccountUpdatingError: undefined,
+  arAccountUpdatingError?: string,
 };
 
 declare type StripeAccountInfo = {

--- a/ui/component/walletBalance/index.js
+++ b/ui/component/walletBalance/index.js
@@ -15,8 +15,6 @@ import {
 import { selectArweaveBalance } from 'redux/selectors/arwallet';
 import {
   selectAccountStatus,
-  selectAPIArweaveActiveAccount,
-  selectAPIArweaveActiveAddress,
   selectFullAPIArweaveStatus,
 } from 'redux/selectors/stripe';
 import { doFetchUtxoCounts, doUtxoConsolidate } from 'redux/actions/wallet';
@@ -42,8 +40,6 @@ const select = (state) => ({
   utxoCounts: selectUtxoCounts(state),
   consolidateIsPending: selectPendingConsolidateTxid(state),
   massClaimIsPending: selectPendingMassClaimTxid(state),
-  activeAPIArAccountAddress: selectAPIArweaveActiveAddress(state),
-  activeAPIArAccount: selectAPIArweaveActiveAccount(state),
   arweaveAccountStatus: selectFullAPIArweaveStatus(state),
 });
 

--- a/ui/component/walletBalance/view.jsx
+++ b/ui/component/walletBalance/view.jsx
@@ -60,8 +60,6 @@ const WalletBalance = (props: Props) => {
     doOpenModal,
     doUtxoConsolidate,
     doFetchUtxoCounts,
-    activeAPIArAccountAddress,
-    activeAPIArAccount,
   } = props;
 
   const [detailsExpanded, setDetailsExpanded] = React.useState(false);

--- a/ui/modal/modalArweaveConnect/index.js
+++ b/ui/modal/modalArweaveConnect/index.js
@@ -1,10 +1,11 @@
 import ModalArweaveConnect from './view';
 import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
-import { doArConnect } from 'redux/actions/arwallet';
+import { doArConnect, doArDisconnect } from 'redux/actions/arwallet';
 import {
   selectAPIArweaveActiveAddresses,
-  selectAPIArweaveDefaultAddress, selectArAccountUpdating,
+  selectAPIArweaveDefaultAddress,
+  selectArAccountUpdating,
   selectFullAPIArweaveStatus,
 } from 'redux/selectors/stripe';
 import { doRegisterArweaveAddress, doUpdateArweaveAddress, doUpdateArweaveAddressDefault } from 'redux/actions/stripe';
@@ -23,6 +24,7 @@ const select = (state) => ({
 const perform = {
   doHideModal,
   doArConnect,
+  doArDisconnect,
   doRegisterArweaveAddress,
   doUpdateArweaveAddress,
   doUpdateArweaveAddressDefault,

--- a/ui/modal/modalArweaveConnect/index.js
+++ b/ui/modal/modalArweaveConnect/index.js
@@ -2,22 +2,30 @@ import ModalArweaveConnect from './view';
 import { connect } from 'react-redux';
 import { doHideModal } from 'redux/actions/app';
 import { doArConnect } from 'redux/actions/arwallet';
-import { selectAPIArweaveActiveAddress, selectFullAPIArweaveStatus } from 'redux/selectors/stripe';
-import { doRegisterArweaveAddress } from 'redux/actions/stripe';
+import {
+  selectAPIArweaveActiveAddresses,
+  selectAPIArweaveDefaultAddress, selectArAccountUpdating,
+  selectFullAPIArweaveStatus,
+} from 'redux/selectors/stripe';
+import { doRegisterArweaveAddress, doUpdateArweaveAddress, doUpdateArweaveAddressDefault } from 'redux/actions/stripe';
 
 const select = (state) => ({
   connecting: state.arwallet.connecting,
   error: state.arwallet.error,
-  activeApiAddress: selectAPIArweaveActiveAddress(state),
+  activeApiAddresses: selectAPIArweaveActiveAddresses(state),
+  defaultApiAddress: selectAPIArweaveDefaultAddress(state),
   fullAPIArweaveStatus: selectFullAPIArweaveStatus(state),
   walletAddress: state.arwallet.address,
   walletBalance: state.arwallet.balance,
+  isArAccountUpdating: selectArAccountUpdating(state),
 });
 
 const perform = {
   doHideModal,
   doArConnect,
   doRegisterArweaveAddress,
+  doUpdateArweaveAddress,
+  doUpdateArweaveAddressDefault,
 };
 
 export default connect(select, perform)(ModalArweaveConnect);

--- a/ui/modal/modalArweaveConnect/view.jsx
+++ b/ui/modal/modalArweaveConnect/view.jsx
@@ -54,11 +54,11 @@ export default function ModalAnnouncements(props: Props) {
           <div className="section__actions">
             <Button
               button="primary"
-              label={'Register'}
+              label={__('Register')}
               disabled={isArAccountUpdating}
               onClick={() => doRegisterArweaveAddress(walletAddress, true)}
             />
-            <Button button="alt" label={'Done'} disabled={isArAccountUpdating} onClick={doHideModal} />
+            <Button button="alt" label={__('Nevermind')} disabled={isArAccountUpdating} onClick={doHideModal} />
           </div>
         }
       />
@@ -90,11 +90,11 @@ export default function ModalAnnouncements(props: Props) {
           <div className="section__actions">
             <Button
               button="primary"
-              label={'Make Default'}
+              label={__('Make Default')}
               disabled={isArAccountUpdating}
               onClick={handleMakeDefault}
             />
-            <Button button="alt" label={'Disconnect'} disabled={isArAccountUpdating} onClick={handleDisconnect} />
+            <Button button="alt" label={__('Disconnect')} disabled={isArAccountUpdating} onClick={handleDisconnect} />
           </div>
         }
       />
@@ -120,8 +120,8 @@ export default function ModalAnnouncements(props: Props) {
         }
         actions={
           <div className="section__actions">
-            <Button button="primary" label={'Top Up'} disabled={isArAccountUpdating} onClick={redirectToTopup} />
-            <Button button="alt" label={'Done'} disabled={isArAccountUpdating} onClick={doHideModal} />
+            <Button button="primary" label={__('Top Up')} disabled={isArAccountUpdating} onClick={redirectToTopup} />
+            <Button button="alt" label={__('Not Now')} disabled={isArAccountUpdating} onClick={doHideModal} />
           </div>
         }
       />

--- a/ui/modal/modalArweaveConnect/view.jsx
+++ b/ui/modal/modalArweaveConnect/view.jsx
@@ -11,7 +11,8 @@ import { useHistory } from 'react-router';
 
 type Props = {
   doHideModal: () => void,
-  doRegisterArweaveAddress: (string) => void,
+  doArDisconnect: () => void,
+  doRegisterArweaveAddress: (string, boolean) => void,
   doUpdateArweaveAddressDefault: (number) => void,
   activeApiAddresses: string[],
   defaultApiAddress: string,
@@ -25,6 +26,7 @@ export default function ModalAnnouncements(props: Props) {
   const { push } = useHistory();
   const {
     doHideModal,
+    doArDisconnect,
     fullAPIArweaveStatus,
     defaultApiAddress,
     walletAddress,
@@ -50,7 +52,12 @@ export default function ModalAnnouncements(props: Props) {
         )}
         actions={
           <div className="section__actions">
-            <Button button="primary" label={'Register'} disabled={isArAccountUpdating} onClick={() => doRegisterArweaveAddress(walletAddress, true)} />
+            <Button
+              button="primary"
+              label={'Register'}
+              disabled={isArAccountUpdating}
+              onClick={() => doRegisterArweaveAddress(walletAddress, true)}
+            />
             <Button button="alt" label={'Done'} disabled={isArAccountUpdating} onClick={doHideModal} />
           </div>
         }
@@ -60,7 +67,14 @@ export default function ModalAnnouncements(props: Props) {
 
   // if address is found, but not default
   const handleMakeDefault = () => {
-    doUpdateArweaveAddressDefault(id);
+    if (id !== null) {
+      doUpdateArweaveAddressDefault(id);
+    }
+  };
+
+  const handleDisconnect = () => {
+    doArDisconnect();
+    doHideModal();
   };
   const MakeDefaultCard = () => {
     return (
@@ -74,8 +88,13 @@ export default function ModalAnnouncements(props: Props) {
         }
         actions={
           <div className="section__actions">
-            <Button button="primary" label={'Make Default'}  disabled={isArAccountUpdating} onClick={handleMakeDefault} />
-            <Button button="alt" label={'Not Now'} disabled={isArAccountUpdating} onClick={doHideModal} />
+            <Button
+              button="primary"
+              label={'Make Default'}
+              disabled={isArAccountUpdating}
+              onClick={handleMakeDefault}
+            />
+            <Button button="alt" label={'Disconnect'} disabled={isArAccountUpdating} onClick={handleDisconnect} />
           </div>
         }
       />

--- a/ui/modal/modalArweaveConnect/view.jsx
+++ b/ui/modal/modalArweaveConnect/view.jsx
@@ -7,42 +7,36 @@ import React from 'react';
 import Card from 'component/common/card';
 import Button from 'component/button';
 import { Modal } from 'modal/modal';
-import { FormField } from '../../component/common/form';
+import { useHistory } from 'react-router';
 
 type Props = {
-  connected?: boolean,
-  connecting?: boolean,
-  error?: string,
-  walletAddress?: string,
-  doArConnect: () => void,
   doHideModal: () => void,
   doRegisterArweaveAddress: (string) => void,
-  activeApiAddress: string,
+  doUpdateArweaveAddressDefault: (number) => void,
+  activeApiAddresses: string[],
+  defaultApiAddress: string,
   fullAPIArweaveStatus: any, // [ {status: 'active', address: '0x1234'}, ...]
   walletAddress: string,
   walletBalance: any,
+  isArAccountUpdating: boolean,
 };
 
 export default function ModalAnnouncements(props: Props) {
+  const { push } = useHistory();
   const {
-    connecting,
-    error,
-    doArConnect,
     doHideModal,
     fullAPIArweaveStatus,
-    activeApiAddress,
+    defaultApiAddress,
     walletAddress,
     walletBalance,
     doRegisterArweaveAddress,
+    doUpdateArweaveAddressDefault,
+    isArAccountUpdating,
   } = props;
 
-  const [makeDefault, setMakeDefault] = React.useState(false);
-
-  const handleRegister = () => {
-    doRegisterArweaveAddress(walletAddress, makeDefault);
-  };
-
-  const apiHasAddress = fullAPIArweaveStatus.find((status) => status.address === walletAddress);
+  const apiEntryWithAddress = fullAPIArweaveStatus.find((status) => status.address === walletAddress);
+  const id = apiEntryWithAddress ? apiEntryWithAddress.id : null;
+  const usdcBalance = walletBalance ? walletBalance.usdc : 0;
 
   // if connected address is not registered at all
   const RegisterCard = () => {
@@ -51,29 +45,13 @@ export default function ModalAnnouncements(props: Props) {
         className="announcement"
         title={__('Unregistered Wallet Address')}
         subtitle={__(
-          'Your arconnect address, %address%, is not onboarded with the payments system. You can switch your arconnect extension address, or register this one for use.',
+          'Your Wander address, %address%, is not onboarded with the payments system. You can switch your Wander extension address, or register this one for use.',
           { address: walletAddress }
         )}
-        body={
-          <div className="section">
-            <FormField
-              name="make-default"
-              type="checkbox"
-              label={__('Make this address my default wallet address')}
-              helper={__('This is only for regulatory compliance and the data will not be stored.')}
-              checked={makeDefault}
-              onChange={() => setMakeDefault(!makeDefault)}
-            />
-            {__(
-              'Your arconnect address, %address%, is not onboarded with the payments system. You can switch your arconnect extension address, or register this one.',
-              { address: walletAddress }
-            )}
-          </div>
-        }
         actions={
           <div className="section__actions">
-            <Button button="primary" label={'Register'} onClick={() => doRegisterArweaveAddress(walletAddress, true)} />
-            <Button button="alt" label={'Done'} onClick={doHideModal} />
+            <Button button="primary" label={'Register'} disabled={isArAccountUpdating} onClick={() => doRegisterArweaveAddress(walletAddress, true)} />
+            <Button button="alt" label={'Done'} disabled={isArAccountUpdating} onClick={doHideModal} />
           </div>
         }
       />
@@ -81,7 +59,9 @@ export default function ModalAnnouncements(props: Props) {
   };
 
   // if address is found, but not default
-  const handleMakeDefault = () => {};
+  const handleMakeDefault = () => {
+    doUpdateArweaveAddressDefault(id);
+  };
   const MakeDefaultCard = () => {
     return (
       <Card
@@ -89,20 +69,23 @@ export default function ModalAnnouncements(props: Props) {
         title={__('Make Default Wallet Address')}
         body={
           <div className="section">
-            {__('Your arconnect address, %address%, is not your primary wallet right now.', { address: walletAddress })}
+            {__('Your Wander address, %address%, is not your primary wallet right now.', { address: walletAddress })}
           </div>
         }
         actions={
           <div className="section__actions">
-            <Button button="primary" label={'Make Default'} onClick={handleMakeDefault} />
-            <Button button="alt" label={'Not Now'} onClick={doHideModal} />
+            <Button button="primary" label={'Make Default'}  disabled={isArAccountUpdating} onClick={handleMakeDefault} />
+            <Button button="alt" label={'Not Now'} disabled={isArAccountUpdating} onClick={doHideModal} />
           </div>
         }
       />
     );
   };
 
-  const redirectToTopup = () => {};
+  const redirectToTopup = () => {
+    push('/$/paymentaccount?tab=buy');
+    doHideModal();
+  };
   const TopUpCard = () => {
     return (
       <Card
@@ -110,16 +93,16 @@ export default function ModalAnnouncements(props: Props) {
         title={__('No Balance')}
         body={
           <div className="section">
-            {__('Your arconnect address, %address%, has a balance of %balance%. Would you like to top up?', {
+            {__('Your Wander address, %address%, has a balance of %balance%. Would you like to top up?', {
               address: walletAddress,
-              balance: walletBalance,
+              balance: usdcBalance,
             })}
           </div>
         }
         actions={
           <div className="section__actions">
-            <Button button="primary" label={'Top Up'} onClick={redirectToTopup} />
-            <Button button="alt" label={'Done'} onClick={doHideModal} />
+            <Button button="primary" label={'Top Up'} disabled={isArAccountUpdating} onClick={redirectToTopup} />
+            <Button button="alt" label={'Done'} disabled={isArAccountUpdating} onClick={doHideModal} />
           </div>
         }
       />
@@ -127,10 +110,10 @@ export default function ModalAnnouncements(props: Props) {
   };
 
   return (
-    <Modal type="card" isOpen onAborted={doHideModal}>
-      {!apiHasAddress && <RegisterCard />}
-      {apiHasAddress && activeApiAddress !== walletAddress && <MakeDefaultCard />}
-      {walletBalance === 0 && <TopUpCard />}
+    <Modal type="card" isOpen onAborted={doHideModal} disableOutsideClick>
+      {!apiEntryWithAddress && <RegisterCard />}
+      {apiEntryWithAddress && defaultApiAddress !== walletAddress && <MakeDefaultCard />}
+      {apiEntryWithAddress && defaultApiAddress === walletAddress && <TopUpCard />}
     </Modal>
   );
 }

--- a/ui/page/paymentAccount/index.js
+++ b/ui/page/paymentAccount/index.js
@@ -6,9 +6,9 @@ import PaymentAccountPage from './view';
 
 const select = (state) => ({
   arWalletStatus: selectArweaveConnected(state),
-  balance: selectArweaveBalance(state).usdc,
+  balance: selectArweaveBalance(state).usdc || 0,
   fetching: selectArweaveFetching(state),
-  theme: selectThemePath(state),  
+  theme: selectThemePath(state),
 });
 
 export default connect(select, {

--- a/ui/redux/actions/arwallet.js
+++ b/ui/redux/actions/arwallet.js
@@ -12,7 +12,7 @@ import {
   AR_TIP_STATUS_ERROR,
 } from 'constants/action_types';
 import { dryrun, message, createDataItemSigner } from '@permaweb/aoconnect';
-import { selectAPIArweaveActiveAddress } from '../selectors/stripe';
+import { selectAPIArweaveDefaultAddress } from '../selectors/stripe';
 import { doOpenModal } from './app';
 const gFlags = {
   arconnectWalletSwitchListenerAdded: false,
@@ -48,7 +48,7 @@ export function doArConnect() {
 
         const address = await global.window.arweaveWallet.getActiveAddress();
         const currentState = getState();
-        const apiActiveAddress = selectAPIArweaveActiveAddress(currentState);
+        const apiDefaultAddress = selectAPIArweaveDefaultAddress(currentState);
 
         const USDCBalance = await fetchUSDCBalance(address);
         dispatch({
@@ -62,7 +62,7 @@ export function doArConnect() {
         });
 
         // if needs interaction, launch modal
-        if (apiActiveAddress !== address) {
+        if (apiDefaultAddress !== address) {
           dispatch(doOpenModal(MODALS.ARWEAVE_CONNECT));
           return;
         }

--- a/ui/redux/actions/arwallet.js
+++ b/ui/redux/actions/arwallet.js
@@ -250,3 +250,36 @@ const fetchUSDCBalance = async (address: string) => {
     return 0;
   }
 };
+
+const updateAddress = async (id: string, status: string) => {
+  try {
+    const res = await Lbryio.call('arweave/address', 'update', { id, status }, 'post');
+    return;
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+const updateDefault = async (id: string) => {
+  try {
+    const res = await Lbryio.call('arweave/address', 'update', { id, set_default: true }, 'post');
+    return;
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+const registerAddress = async (address: string, currency = 'USD') => {
+  try {
+    const pub_key = window.arweaveWallet.getActivePublicKey();
+    const data = new TextEncoder().encode(address);
+    const signature = await window.arweaveWallet.signMessage(data);
+    const res = await Lbryio.call('arweave/address', 'add', { currency, address, pub_key, signature }, 'post');
+    return;
+    // get public key
+    // sign the address
+    // send to api with
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/ui/redux/actions/stripe.js
+++ b/ui/redux/actions/stripe.js
@@ -211,7 +211,7 @@ const registerAddress = async (address: string, makeDefault: boolean, currency =
   }
 };
 
-const updateAddress = async (id: string, status: string) => {
+const updateAddressStatus = async (id: string, status: string) => {
   try {
     const res = await Lbryio.call('arweave/address', 'update', { id, status }, 'post');
     return res;
@@ -243,10 +243,10 @@ export const doRegisterArweaveAddress = (address: string, makeDefault: boolean) 
   }
 };
 
-export const doUpdateArweaveAddress = (id: string, status: string) => async (dispatch: Dispatch) => {
+export const doUpdateArweaveAddress = (id: string, status: 'active' | 'inactive') => async (dispatch: Dispatch) => {
   dispatch({ type: ACTIONS.AR_ADDR_UPDATE_STARTED });
   try {
-    await updateAddress(id, status);
+    await updateAddressStatus(id, status);
     // now do account status
     await dispatch(doTipAccountStatus());
     dispatch({ type: ACTIONS.AR_ADDR_UPDATE_SUCCESS });

--- a/ui/redux/selectors/stripe.js
+++ b/ui/redux/selectors/stripe.js
@@ -13,16 +13,29 @@ export const selectCustomerStatusFetching = (state: State) => selectState(state)
 export const selectCustomerSetupResponse = (state: State) => selectState(state).customerSetupResponse;
 
 export const selectAccountStatus = (state: State) => selectState(state).accountStatus;
+
+export const selectArAccountUpdating = (state: State) => selectState(state).arAccountUpdating;
 export const selectFullAPIArweaveStatus = (state: State) => selectState(state).arweaveStatus;
 // find in arweaveStatus[] where active = true
-export const selectAPIArweaveActiveAccount = (state: State) => {
+export const selectAPIArweaveActiveAccounts = (state: State) => {
   const arweaveStatus = selectFullAPIArweaveStatus(state);
-  return arweaveStatus && arweaveStatus.find((status) => status.status === 'active');
+  return arweaveStatus ? arweaveStatus.filter((entry) => entry.status === 'active') : [];
 };
 
-export const selectAPIArweaveActiveAddress = (state: State) => {
-  const activeAccount = selectAPIArweaveActiveAccount(state);
-  return activeAccount ? activeAccount.address : null;
+export const selectAPIArweaveDefaultAccount = (state: State) => {
+  const arweaveStatus = selectFullAPIArweaveStatus(state);
+  // find and return each match
+  return arweaveStatus ? arweaveStatus.find((entry) => entry.default) : null;
+};
+
+export const selectAPIArweaveDefaultAddress = (state: State) => {
+  const defaultAccount = selectAPIArweaveDefaultAccount(state);
+  return defaultAccount ? defaultAccount.address : null;
+};
+
+export const selectAPIArweaveActiveAddresses = (state: State) => {
+  const activeAccounts = selectAPIArweaveActiveAccounts(state);
+  return activeAccounts ? activeAccounts.map(a => a.address) : null;
 };
 
 export const selectArweaveTipDataForId = (state: State, id: string) => {


### PR DESCRIPTION
Renamed some selectors
Moved to checking for *default* wallet rather than "active" since many can be active.
Disabled clicking out of the connect modal.