### PR TITLE
Fix memebrship content refresh in some cases

### DIFF
--- a/ui/hocs/withStreamClaimRender/view.jsx
+++ b/ui/hocs/withStreamClaimRender/view.jsx
@@ -269,7 +269,7 @@ const withStreamClaimRender = (StreamClaimComponent: FunctionalComponentParam) =
         playingOptions.source = 'markdown';
       }
 
-      if (!isLivestreamClaim) {
+      if (!isLivestreamClaim && !streamingUrl) {
         doFileGetForUri(uri, fileGetOptions);
       }
       if (shouldStartFloating || !check) {


### PR DESCRIPTION
Membership content `streaming_url` changes every time it's fetched with `/api/v1/proxy?m=get`, so the source changes and player resets.

This change makes it so that `/api/v1/proxy?m=get` is only run once for each uri.

Don't understand the whole player flow, but pretty sure that `streaming_url` is only known if `doFileGetForUri()` was already run for the uri, so think this shouldn't have any surprises.