### PR TITLE
Fix "Now playing" covering the comment input on mobile

### DIFF
--- a/ui/scss/component/_swipeable-drawer.scss
+++ b/ui/scss/component/_swipeable-drawer.scss
@@ -33,6 +33,10 @@
   background-color: var(--color-text);
 }
 
+.MuiDrawer-root {
+  z-index: 10000;
+}
+
 .MuiDrawer-root > .MuiPaper-root {
   overflow: visible;
   color: var(--color-text);


### PR DESCRIPTION

Fixes this:
![2025-03-02_17-48](https://github.com/user-attachments/assets/82d1b5c2-eb66-4db1-8612-29673ca86026)
