### PR TITLE
Use encodeUri in iframe embeds

### DIFF
--- a/ui/component/embedTextArea/view.jsx
+++ b/ui/component/embedTextArea/view.jsx
@@ -3,7 +3,7 @@ import * as ICONS from 'constants/icons';
 import { FormField } from 'component/common/form';
 import Button from 'component/button';
 import React, { useRef } from 'react';
-import { generateEmbedUrl, generateEmbedIframeData } from 'util/web';
+import { generateEmbedUrlEncoded, generateEmbedIframeData } from 'util/web';
 
 type Props = {
   copyable: string,
@@ -27,7 +27,7 @@ export default function EmbedTextArea(props: Props) {
   const { canonical_url: canonicalUri } = claim;
   const input = useRef();
 
-  const streamUrl = generateEmbedUrl(
+  const streamUrl = generateEmbedUrlEncoded(
     canonicalUri,
     includeStartTime && startTime,
     referralCode,

--- a/ui/util/web.js
+++ b/ui/util/web.js
@@ -33,11 +33,14 @@ function generateEmbedUrl(claimUri, startTime, referralLink, newestType, autopla
   return `${embedUrl}${embedUrlParams}`;
 }
 
-function generateEmbedUrlEncoded(claimUri, startTime, referralLink, autoplay) {
+function generateEmbedUrlEncoded(claimUri, startTime, referralLink, newestType, autoplay, uriAccessKey) {
   const uriPath = claimUri.replace('lbry://', '').replace(/#/g, ':');
   const encodedUri = encodeURIComponent(uriPath).replace(/'/g, '%27').replace(/\(/g, '%28').replace(/\)/g, '%29');
 
-  return generateEmbedUrl(encodedUri, startTime, referralLink, false, autoplay).replace(/\$/g, '%24');
+  return generateEmbedUrl(encodedUri, startTime, referralLink, newestType, autoplay, uriAccessKey).replace(
+    /\$/g,
+    '%24'
+  );
 }
 
 function generateEmbedIframeData(src) {

--- a/web/src/oEmbed.js
+++ b/web/src/oEmbed.js
@@ -53,7 +53,7 @@ function generateOEmbedData(claim, embedlyReferrer, timestamp, referral) {
   const thumbnailUrl = value && value.thumbnail && value.thumbnail.url && getThumbnailCardCdnUrl(value.thumbnail.url);
   const autoplay = true;
 
-  const embedUrl = generateEmbedUrlEncoded(claim.canonical_url, timestamp, referral, autoplay);
+  const embedUrl = generateEmbedUrlEncoded(claim.canonical_url, timestamp, referral, null, autoplay);
   const videoUrl =
     embedUrl + (embedlyReferrer ? `referrer=${encodeURIComponent(escapeHtmlProperty(embedlyReferrer))}` : '');
 


### PR DESCRIPTION
#### Issue:
This claim generated an iframe code which had some issues on hugo
https://odysee.com/@GoodGodFather:d/Normie's-Guide-to-Satanism:7

Also using the the generated iframe src in address bar gave same error (but worked in embed outside of hugo)
https://odysee.com/$/embed/@GoodGodFather:d/Normie&#039;s-Guide-to-Satanism:7

#### Fix:
Changed iframes to use encodedURL
New src would look like this: https://odysee.com/%24/embed/%40GoodGodFather%3Ad%2FNormie%27s-Guide-to-Satanism%3A7