### PR TITLE
Fix free comments not working after hyperchat

### DIFF
--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -539,7 +539,7 @@ export function CommentCreate(props: Props) {
       environment,
       sticker: !!stickerValue,
       is_protected: Boolean(isLivestreamChatMembersOnly || areCommentsMembersOnly),
-      amount: activeTab === TAB_LBC || activeTab === TAB_FIAT ? tipAmount : undefined,
+      amount: !!txid || !!payment_intent_id ? tipAmount : undefined,
       currency: activeTab === TAB_LBC ? 'LBC' : activeTab === TAB_FIAT ? 'USDC' : undefined,
       dry_run: dryRun,
     })


### PR DESCRIPTION
Fixes this:

![2025-03-08_10-26](https://github.com/user-attachments/assets/cbf09585-c33e-4ead-8f18-148e514d0a3d)

https://discord.com/channels/721806979928162404/914205457864880209/1347755826181443725

The `activeTab` doesn't get unset after it has been set once, so amount was getting passed for free comments too, and that didn't work with the commentron updates.



