### PR TITLE
Minor collection fixes

### DIFF
--- a/ui/redux/actions/collections.js
+++ b/ui/redux/actions/collections.js
@@ -94,6 +94,8 @@ export function doCollectionPublish(options: CollectionPublishCreateParams, coll
   return (dispatch: Dispatch, getState: GetState): Promise<any> => {
     const state = getState();
     const isPrivate = selectIsCollectionPrivateForId(state, collectionId);
+    const collection = selectCollectionForId(state, collectionId);
+    const createdAtTimestamp = collection.createdAt;
 
     // $FlowFixMe
     const params: GenericPublishCreateParams = {
@@ -140,6 +142,9 @@ export function doCollectionPublish(options: CollectionPublishCreateParams, coll
 
       function success(response: CollectionCreateResponse) {
         const collectionClaim = response.outputs[0];
+        if (!collectionClaim?.meta.creation_timestamp) collectionClaim.meta.creation_timestamp = createdAtTimestamp;
+        if (!collectionClaim?.timestamp) collectionClaim.timestamp = Date.now();
+
         dispatch({ type: ACTIONS.DELETE_ID_FROM_LOCAL_COLLECTIONS, data: collectionId });
 
         dispatch(

--- a/ui/util/collections.js
+++ b/ui/util/collections.js
@@ -27,8 +27,8 @@ export function claimToStoredCollection(claim: CollectionClaim) {
 
   Object.assign(storedCollection, {
     id: claim.claim_id,
-    name: claim.value.title,
-    title: claim.value.title,
+    name: claim.value.title || claim.name,
+    title: claim.value.title || claim.name,
     items: claimIds || [],
     itemCount: claimIds ? claimIds.length : 0,
     description: claim.value.description,


### PR DESCRIPTION
-Pending collections temporarily lost their timestamps, making them appear at the bottom in some sorts. -> Filled in the timestamps.
-Sorting of claims in "Save to..." broke if there were nameless collections. -> Defaults to claim name when title is missing.