### PR TITLE
Fix tip unlock

### DIFF
--- a/ui/component/supportsLiquidate/view.jsx
+++ b/ui/component/supportsLiquidate/view.jsx
@@ -23,7 +23,7 @@ type Props = {
 const SupportsLiquidate = (props: Props) => {
   const defaultAmountPercent = 25;
   const { claim, abandonSupportForClaim, handleClose, abandonClaimError } = props;
-  const [previewBalance, setPreviewBalance] = useState(-1);
+  const [previewBalance, setPreviewBalance] = useState(undefined);
   const [amount, setAmount] = useState(-1);
   const [sliderPosition, setSliderPosition] = useState(defaultAmountPercent);
   const [error, setError] = useState(false);
@@ -53,7 +53,7 @@ const SupportsLiquidate = (props: Props) => {
   }
 
   function handleChange(a, isFromSlider) {
-    if (!isNaN(Number(a))) setSliderPosition((Number(a) / previewBalance) * 100);
+    if (!isNaN(Number(a)) && !isNaN(previewBalance)) setSliderPosition((Number(a) / Number(previewBalance)) * 100);
     setAmount((isFromSlider && !isNaN(Number(a)) && Number(a).toFixed(2)) || a);
 
     if (a === undefined || isNaN(Number(a))) {
@@ -85,7 +85,7 @@ const SupportsLiquidate = (props: Props) => {
   }
 
   React.useEffect(() => {
-    if (previewBalance) handleChange(previewBalance * (defaultAmountPercent / 100));
+    if (previewBalance) handleChange(previewBalance * (defaultAmountPercent / 100), true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [previewBalance]); //
 
@@ -151,8 +151,8 @@ const SupportsLiquidate = (props: Props) => {
                     />
                     <label className="range__label">
                       <span>0</span>
-                      <span>{previewBalance / 2}</span>
-                      <span>{previewBalance}</span>
+                      <span>{!isNaN(previewBalance) && Number(previewBalance / 2).toFixed(2)}</span>
+                      <span>{!isNaN(previewBalance) && Number(previewBalance).toFixed(2)}</span>
                     </label>
                     <FormField
                       type="text"

--- a/ui/component/supportsLiquidate/view.jsx
+++ b/ui/component/supportsLiquidate/view.jsx
@@ -71,8 +71,9 @@ const SupportsLiquidate = (props: Props) => {
     } else if (Number(a) > Number(previewBalance) / 2) {
       setMessage(__('Your content will do better with more staked on it'));
       setError(false);
-    } else if (Number(a) === 0) {
+    } else if (Number(a) <= 0) {
       setMessage(__('Amount cannot be zero'));
+      setAmount(0);
       setError(true);
     } else if (Number(a) <= Number(previewBalance) / 2) {
       setMessage(__('A prudent choice'));

--- a/ui/redux/actions/wallet.js
+++ b/ui/redux/actions/wallet.js
@@ -646,6 +646,8 @@ export function doSupportAbandonForClaim(claimId, claimType, keep, preview) {
     return Lbry.support_abandon(params)
       .then((res) => {
         if (!preview) {
+          dispatchToast(dispatch, __('Successfully unlocked your tip!'), '', 'long', false);
+
           dispatch({
             type: ACTIONS.ABANDON_CLAIM_SUPPORT_COMPLETED,
             data: { claimId, txid: res.txid, effective: res.outputs[0].amount, type: claimType },
@@ -655,6 +657,8 @@ export function doSupportAbandonForClaim(claimId, claimType, keep, preview) {
         return res;
       })
       .catch((e) => {
+        dispatchToast(dispatch, __('Error unlocking your tip'), e.message || e, 'long');
+
         dispatch({
           type: ACTIONS.ABANDON_CLAIM_SUPPORT_FAILED,
           data: e.message,


### PR DESCRIPTION
The slider in here didn't work at all. It had the percentages and the actual amount mixed up. And the text input didn't worked well with decimals.  

Now they should work like expected.  
Also added some toast message to tip unlock success/fail.. There was no feedback on success before.

![2025-04-13_18-20](https://github.com/user-attachments/assets/c008e3dd-f8f6-45c6-a12a-ca2884acaefe)


