### PR TITLE
Add channel required to comment info

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2972,6 +2972,9 @@
   "Your account has been connected, but charges are disabled. Please view the account on Stripe.": "Your account has been connected, but charges are disabled. Please view the account on Stripe.",
   "Send us an email to %help_email% if you continue to see this message. You can continue to use %site_name% without this feature.": "Send us an email to %help_email% if you continue to see this message. You can continue to use %site_name% without this feature.",
   "I understand this is a permanent action, and that another bank account can't be connected after the removal.": "I understand this is a permanent action, and that another bank account can't be connected after the removal.",
-
+  "Channel is required for commenting": "Channel is required for commenting",
+  "You'll need a channel to comment on this upload.": "You'll need a channel to comment on this upload.",
+  "Continue to channel creation": "Continue to channel creation",
+  
   "--end--": "--end--"
 }

--- a/ui/component/commentCreate/view.jsx
+++ b/ui/component/commentCreate/view.jsx
@@ -707,12 +707,20 @@ export function CommentCreate(props: Props) {
             return;
           }
 
-          const pathPlusRedirect = `/$/${PAGES.CHANNEL_NEW}?redirect=${pathname}`;
-          if (isLivestream) {
-            window.open(pathPlusRedirect);
-          } else {
-            push(pathPlusRedirect);
-          }
+          doOpenModal(MODALS.CONFIRM, {
+            title: __('Channel is required for commenting'),
+            subtitle: __("You'll need a channel to comment on this upload."),
+            labelOk: __('Continue to channel creation'),
+            onConfirm: (closeModal) => {
+              const pathPlusRedirect = `/$/${PAGES.CHANNEL_NEW}?redirect=${pathname}`;
+              if (isLivestream) {
+                window.open(pathPlusRedirect);
+              } else {
+                push(pathPlusRedirect);
+              }
+              closeModal();
+            },
+          });
         }}
       >
         <FormField
@@ -963,9 +971,10 @@ export function CommentCreate(props: Props) {
               />
             )}
           </div>
-
         )}
-        {activeTab === TAB_FIAT && STRIPE_DISABLED && (<div className={'help'}>{__('Payment Services are temporarily disabled. Please check back later.')}</div>)}
+        {activeTab === TAB_FIAT && STRIPE_DISABLED && (
+          <div className={'help'}>{__('Payment Services are temporarily disabled. Please check back later.')}</div>
+        )}
         <div className="chat-resize">
           <div />
           <div />


### PR DESCRIPTION
When user tries to comment without a channel, show this modal. (It used to re-direct to channel creations with no info.)

![2025-04-25_17-06_1](https://github.com/user-attachments/assets/fc3fb728-69fe-42b1-a1e6-7f0efd6846c6)
  
  
![2025-04-25_17-06](https://github.com/user-attachments/assets/e9c0be3a-9c35-4f26-a9a6-f2c9510df32f)
