### PR TITLE
Increase menu-button hitbox

### DIFF
--- a/ui/scss/component/_claim-preview.scss
+++ b/ui/scss/component/_claim-preview.scss
@@ -11,6 +11,10 @@
     top: var(--spacing-xxxxs);
     right: 0;
     padding: 2px;
+    padding-bottom: 20px;
+    padding-left: 20px;
+    min-width: 50px;
+    min-height: 30px;
     border-radius: 50%;
     z-index: 2;
 
@@ -34,7 +38,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 100%;
-    margin-right: var(--spacing-m);
+    margin-right: var(--spacing-xl);
     color: rgba(var(--color-text-base), 0.9);
   }
 


### PR DESCRIPTION
User complained about 3-dot button in claim tiles being difficult to click on mobile. But I think it's kind of small on desktop too.

<details>
<summary>Old</summary>

![2025-04-27_14-17](https://github.com/user-attachments/assets/406bc878-9dfa-4b6c-a2c7-416f88536e59)
![2025-04-27_14-27](https://github.com/user-attachments/assets/a07fbc65-5fbf-4c7a-ac91-ff447a1aa4e8)

</details>


<details>
<summary>New</summary>

![2025-04-27_14-16](https://github.com/user-attachments/assets/d79b1349-975e-436e-a2b9-2788535ed752)
![2025-04-27_14-17_2](https://github.com/user-attachments/assets/cf377474-2f93-46d4-8740-ea3134b05970)
</details>

<details>
<summary>When button is clicked, the icon will be miss aligned. But centering it would look strange when it's not clicked. Don't know how to make it better</summary>

![2025-04-27_14-17_1](https://github.com/user-attachments/assets/2fba99ad-816f-4047-ada5-60288cad75a5)
</details>



