### PR TITLE
Prevent claims from getting stuck in pending

### DIFF
--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -1023,45 +1023,34 @@ export const doCheckPendingClaims = (onChannelConfirmed: Function) => (dispatch:
   const checkTxoList = () => {
     const state = getState();
     const pendingById = Object.assign({}, selectPendingClaimsById(state));
-    const pendingTxos = (Object.values(pendingById): any).map((p) => p.txid);
 
-    if (pendingTxos.length) {
-      Lbry.txo_list({ txid: pendingTxos })
-        .then((result) => {
-          const txos = result.items;
-          const idsToConfirm = [];
-          txos.forEach((txo) => {
-            if (txo.claim_id && txo.confirmations > 0) {
-              idsToConfirm.push(txo.claim_id);
-              delete pendingById[txo.claim_id];
-            }
-          });
-          return { idsToConfirm, pendingById };
-        })
-        .then((results) => {
-          const { idsToConfirm, pendingById } = results;
-          if (idsToConfirm.length) {
-            return Lbry.claim_list({ claim_id: idsToConfirm, resolve: true }).then((results) => {
-              const claims = results.items;
-
-              dispatch({
-                type: ACTIONS.UPDATE_CONFIRMED_CLAIMS,
-                data: {
-                  claims: claims,
-                  pending: pendingById,
-                },
-              });
-
-              const channelClaims = claims.filter((claim) => claim.value_type === 'channel');
-              if (channelClaims.length && onChannelConfirmCallback) {
-                channelClaims.forEach((claim) => onChannelConfirmCallback(claim));
-              }
-              if (Object.keys(pendingById).length === 0) {
-                clearInterval(checkPendingInterval);
-              }
-            });
+    if (Object.keys(pendingById).length) {
+      return Lbry.claim_list({ claim_id: Object.keys(pendingById), resolve: true }).then((results) => {
+        const claims = results.items;
+        const confirmedClaims = [];
+        claims.forEach((claim) => {
+          if (claim.claim_id && claim.confirmations > 0) {
+            confirmedClaims.push(claim);
+            delete pendingById[claim.claim_id];
           }
         });
+
+        dispatch({
+          type: ACTIONS.UPDATE_CONFIRMED_CLAIMS,
+          data: {
+            claims: confirmedClaims,
+            pending: pendingById,
+          },
+        });
+
+        const channelClaims = confirmedClaims.filter((claim) => claim.value_type === 'channel');
+        if (channelClaims.length && onChannelConfirmCallback) {
+          channelClaims.forEach((claim) => onChannelConfirmCallback(claim));
+        }
+        if (Object.keys(pendingById).length === 0) {
+          clearInterval(checkPendingInterval);
+        }
+      });
     } else {
       clearInterval(checkPendingInterval);
     }

--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -1029,7 +1029,7 @@ export const doCheckPendingClaims = (onChannelConfirmed: Function) => (dispatch:
         const claims = results.items;
         const confirmedClaims = [];
         claims.forEach((claim) => {
-          if (claim.claim_id && claim.confirmations > 0) {
+          if (claim.claim_id && claim.confirmations > 0 && pendingById[claim.claim_id].txid === claim.txid) {
             confirmedClaims.push(claim);
             delete pendingById[claim.claim_id];
           }


### PR DESCRIPTION
Sometimes txs get stuck in pending and show 0 confirmations when checking with `txo_list`. Need log out/in to fix.  

It seems that the results in `claim_list` don't get affected by this bug and return correct confirmations. 

Tested claim creation and editing. Seems to work fine with both.