### PR TITLE
Use future timestamps with unlisted content to avoid new content notifications

### DIFF
--- a/ui/component/dateTimeClaim/view.jsx
+++ b/ui/component/dateTimeClaim/view.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import moment from 'moment';
 
 import { formatDateStr } from './helper';
-import { SCHEDULED_TAGS } from 'constants/tags';
+import { SCHEDULED_TAGS, VISIBILITY_TAGS } from 'constants/tags';
 
 type Props = {
   uri: ?string,
@@ -26,7 +26,8 @@ function DateTimeClaim(props: Props) {
 
   function resolveDate(tags: ?Array<string>, claimTsList: ClaimTsList): ?Date {
     // Defaults should match selectDateForUri()
-    const defaultTs = claimTsList.released || claimTsList.created;
+    const forceCreationTimestamp = tags?.includes(VISIBILITY_TAGS.UNLISTED);
+    const defaultTs = !forceCreationTimestamp ? claimTsList.released || claimTsList.created : claimTsList.created;
     return defaultTs ? new Date(defaultTs * 1000) : undefined;
   }
 

--- a/ui/component/publish/shared/publishAdditionalOptions/view.jsx
+++ b/ui/component/publish/shared/publishAdditionalOptions/view.jsx
@@ -46,7 +46,7 @@ function PublishAdditionalOptions(props: Props) {
   } = props;
 
   const [hideSection, setHideSection] = useState(disabled);
-  const showReleaseDate = !showSchedulingOptions && (visibility === 'public' || visibility === 'unlisted');
+  const showReleaseDate = !showSchedulingOptions && visibility === 'public';
 
   function toggleHideSection() {
     setHideSection(!hideSection);

--- a/ui/redux/selectors/claims.js
+++ b/ui/redux/selectors/claims.js
@@ -543,10 +543,11 @@ export const selectClaimReleaseInPastForUri = (state: State, uri: string) =>
 export const selectDateForUri = createCachedSelector(
   selectClaimForUri, // input: (state, uri, ?returnRepost)
   (claim) => {
+    const forceCreationTimestamp = claim.value.tags?.includes(TAG.VISIBILITY_TAGS.UNLISTED);
     const timestamp =
       claim &&
       claim.value &&
-      (claim.value.release_time
+      (claim.value.release_time && !forceCreationTimestamp
         ? claim.value.release_time * 1000
         : claim.meta && claim.meta.creation_timestamp
         ? claim.meta.creation_timestamp * 1000

--- a/ui/util/publish.js
+++ b/ui/util/publish.js
@@ -220,6 +220,7 @@ const PAYLOAD = {
     const isEditing = Boolean(claimToEdit);
     const { liveEditType } = publishData;
 
+    const unlistedFixedPublishDate = 2147483647; // Backend relies to future dates to skip sending of new content notifications
     const past = {};
 
     if (isEditing && claimToEdit) {
@@ -237,6 +238,9 @@ const PAYLOAD = {
       case 'private':
       case 'unlisted':
         if (isEditing) {
+          if (Number(past.release_time) === unlistedFixedPublishDate) {
+            return past.creation_timestamp || nowTs; // The future date was used to skip notification about new content, so it's not needed on edit. Reseting also helps when switching to public.
+          }
           if (past.isStreamPlaceholder) {
             assert(liveEditType === 'use_replay' || liveEditType === 'upload_replay' || liveEditType === 'update_only');
 
@@ -254,6 +258,9 @@ const PAYLOAD = {
             return userEnteredTs;
           }
         } else {
+          if (publishData.visibility === 'unlisted') {
+            return unlistedFixedPublishDate;
+          }
           if (userEnteredTs === undefined) {
             return nowTs;
           } else {


### PR DESCRIPTION
Changes for unlisted content:
-Hide date picker on upload form
-Use fixed future date on upload + reset that date to creation_timestamp on edit. (Helps if toggling from unlisted to public)
-On UI use creation timestamp as release time.