### PR TITLE
Show playlist items count while adding/removing item

### DIFF
--- a/ui/redux/actions/content.js
+++ b/ui/redux/actions/content.js
@@ -31,6 +31,8 @@ import {
   selectCollectionForIdHasClaimUrl,
   selectFirstItemUrlForCollection,
   selectIsLastCollectionItemForIdAndUri,
+  selectHasPrivateCollectionForId,
+  selectCollectionHasItemsResolvedForId,
 } from 'redux/selectors/collections';
 import { doCollectionEdit, doLocalCollectionCreate, doFetchItemsInCollection } from 'redux/actions/collections';
 import { doToast } from 'redux/actions/notifications';
@@ -377,15 +379,23 @@ export function doPlaylistAddAndAllowPlaying({
         }
       }
     } else {
+      const hasItemsResolved = selectCollectionHasItemsResolvedForId(state, collectionId);
+      const isPrivateVersion = selectHasPrivateCollectionForId(state, collectionId);
+      let collectionUrls;
+      if (hasItemsResolved || isPrivateVersion) {
+        collectionUrls = selectUrlsForCollectionId(state, collectionId);
+      }
+
       const handleEdit = () =>
         // $FlowFixMe
         dispatch(push({ pathname: `/$/${PAGES.PLAYLIST}/${collectionId}`, state: { showEdit: true } }));
 
       dispatch(
         doToast({
-          message: __(remove ? 'Removed from %playlist_name%' : 'Added to %playlist_name%', {
-            playlist_name: collectionName,
-          }),
+          message:
+            __(remove ? 'Removed from %playlist_name%' : 'Added to %playlist_name%', {
+              playlist_name: collectionName,
+            }) + (collectionUrls?.length ? ` (${remove ? collectionUrls.length - 1 : collectionUrls.length + 1})` : ''),
           actionText: isPlayingCollection || hasItemPlaying || remove ? __('Edit Playlist') : __('Start Playing'),
           action: isPlayingCollection || hasItemPlaying || remove ? handleEdit : startPlaying,
           secondaryActionText: isPlayingCollection || hasItemPlaying || remove ? undefined : __('Edit Playlist'),


### PR DESCRIPTION
Shows total items in list in the item added/removed toast. 
Doesn't show count if list hasn't yet been resolved. Should only happen during the first edit. 

![2025-08-07_11-55](https://github.com/user-attachments/assets/d66ec703-82a8-486e-a194-5742a2062c46)
