### PR TITLE
Fix some shuffle issues

### DIFF
--- a/ui/redux/actions/content.js
+++ b/ui/redux/actions/content.js
@@ -597,17 +597,17 @@ export const doEnableCollectionShuffle =
       dispatch(doChangePlayingUri(newPlayingCollectionObj));
     } else {
       dispatch(doStartFloatingPlayingUri({ uri: newUrls[0], ...newPlayingCollectionObj }));
+
+      const navigateUrl = formatLbryUrlForWeb(newUrls[0]);
+
+      dispatch(
+        push({
+          pathname: navigateUrl,
+          search: generateListSearchUrlParams(collectionId),
+          state: { collectionId, forceAutoplay: true },
+        })
+      );
     }
-
-    const navigateUrl = formatLbryUrlForWeb(newUrls[0]);
-
-    dispatch(
-      push({
-        pathname: navigateUrl,
-        search: generateListSearchUrlParams(collectionId),
-        state: { collectionId, forceAutoplay: true },
-      })
-    );
   };
 
 export const doToggleShuffleList =
@@ -619,7 +619,7 @@ export const doToggleShuffleList =
     if (!listIsShuffledForId) {
       dispatch(doEnableCollectionShuffle({ collectionId, currentUri }));
     } else {
-      dispatch(doChangePlayingUri({ collection: { shuffle: undefined } }));
+      dispatch(doChangePlayingUri({ collection: { collectionId, shuffle: undefined } }));
     }
 
     if (!hideToast) {


### PR DESCRIPTION
Fixes:
-Clicking shuffle used to navigate to a new new video instead of just enabling shuffle mode (caused sometimes also strange things with mini player popping up, seemed to happen at least after manual reloading the playing collection page and then enabling shuffle). Now clicking it just enables shuffle mode.
-Disabling shuffle used to make the player leave the playlist