### PR TITLE
Handle own filtered content similar to own blocked content

### DIFF
--- a/ui/component/claimPreview/view.jsx
+++ b/ui/component/claimPreview/view.jsx
@@ -372,7 +372,7 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
       !hideJoin &&
       (!banState.muted || showUserBlocked) && (
         <div className={'membership-button-wrapper' + (type ? ' ' + type : '')}>
-          <JoinMembershipButton uri={uri}  />
+          <JoinMembershipButton uri={uri} />
         </div>
       ),
     [banState.muted, claimIsMine, hideJoin, isChannelUri, showUserBlocked, type, uri]
@@ -571,6 +571,18 @@ const ClaimPreview = forwardRef<any, {}>((props: Props, ref: any) => {
                     }}
                   >
                     <div className="dmca-info">{__('DMCA flagged')}</div>
+                  </a>
+                )}
+                {banState.filtered && claimIsMine && (
+                  <a
+                    href="https://help.odysee.tv/category-uploading/dmca-content/#receiving-a-dmca-notice"
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
+                  >
+                    <div className="dmca-info">{__('Filtered')}</div>
                   </a>
                 )}
                 {(pending || !!reflectingProgress) && <PublishPending uri={uri} />}

--- a/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/index.js
+++ b/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/index.js
@@ -10,7 +10,7 @@ import {
   selectThumbnailForUri,
   makeSelectTagInClaimOrChannelForUri,
 } from 'redux/selectors/claims';
-import { selectIsClaimBlackListedForUri } from 'lbryinc';
+import { selectIsClaimBlackListedForUri, selectIsClaimFilteredForUri } from 'lbryinc';
 import { LINKED_COMMENT_QUERY_PARAM, THREAD_COMMENT_QUERY_PARAM } from 'constants/comment';
 import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
 import { selectCommentsListTitleForUri, selectCommentsDisabledSettingForChannelId } from 'redux/selectors/comments';
@@ -49,6 +49,7 @@ const select = (state, props) => {
     contentUnlocked: claimId && selectNoRestrictionOrUserIsMemberForContentClaimId(state, claimId),
     isLivestream: selectIsStreamPlaceholderForUri(state, uri),
     isClaimBlackListed: selectIsClaimBlackListedForUri(state, uri),
+    isClaimFiltered: selectIsClaimFilteredForUri(state, uri),
   };
 };
 

--- a/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/view.jsx
@@ -36,6 +36,7 @@ type Props = {
   contentUnlocked: boolean,
   isLivestream: boolean,
   isClaimBlackListed: boolean,
+  isClaimFiltered: boolean,
   doSetContentHistoryItem: (uri: string) => void,
   doSetPrimaryUri: (uri: ?string) => void,
   doToggleAppDrawer: (type: string) => void,
@@ -57,6 +58,7 @@ const StreamClaimPage = (props: Props) => {
     contentUnlocked,
     isLivestream,
     isClaimBlackListed,
+    isClaimFiltered,
     doSetContentHistoryItem,
     doSetPrimaryUri,
     doToggleAppDrawer,
@@ -64,6 +66,8 @@ const StreamClaimPage = (props: Props) => {
 
   const isMobile = useIsMobile();
   const isLandscapeRotated = useIsMobileLandscape();
+
+  const hideContent = isClaimFiltered || isClaimBlackListed;
 
   const cost = costInfo ? costInfo.cost : null;
   const isMarkdown = renderMode === RENDER_MODES.MARKDOWN;
@@ -85,7 +89,7 @@ const StreamClaimPage = (props: Props) => {
     return () => doSetPrimaryUri(null);
   }, [doSetContentHistoryItem, doSetPrimaryUri, uri]);
 
-  if (!isClaimBlackListed && isMarkdown) {
+  if (!hideContent && isMarkdown) {
     return (
       <React.Suspense fallback={null}>
         <MarkdownPostPage uri={uri} accessStatus={accessStatus} />
@@ -93,7 +97,7 @@ const StreamClaimPage = (props: Props) => {
     );
   }
 
-  if (!isClaimBlackListed && RENDER_MODES.FLOATING_MODES.includes(renderMode)) {
+  if (!hideContent && RENDER_MODES.FLOATING_MODES.includes(renderMode)) {
     if (isLivestream) {
       return (
         <React.Suspense fallback={null}>
@@ -166,6 +170,26 @@ const StreamClaimPage = (props: Props) => {
     );
   }
 
+  function filteredInfo() {
+    return (
+      <section className="card--section dmca-info">
+        <p>{__('This content violates the terms and conditions of Odysee and has been filtered.')}</p>
+        <p>
+          {__('Please remove the content, or reach out to %email% if you think there has been a mistake.', {
+            email: 'help@odysee.com',
+          })}
+        </p>
+        <div className="section__actions">
+          <Button
+            button="link"
+            href="https://help.odysee.tv/category-uploading/dmca-content/#receiving-a-dmca-notice"
+            label={__('Read More')}
+          />
+        </div>
+      </section>
+    );
+  }
+
   if (isMature) {
     return (
       <>
@@ -181,8 +205,8 @@ const StreamClaimPage = (props: Props) => {
   return (
     <>
       <div className={classnames('section card-stack', `file-page__${renderMode}`)}>
-        {!isClaimBlackListed && renderClaimLayout()}
-        {isClaimBlackListed && dmcaInfo()}
+        {!hideContent && renderClaimLayout()}
+        {(isClaimBlackListed && dmcaInfo()) || (isClaimFiltered && filteredInfo())}
 
         <FileTitleSection uri={uri} accessStatus={accessStatus} />
 


### PR DESCRIPTION
Creator had no indication of their content being filtered, other than it disappearing from channel page. 

Changed to work similar to blocked content. 
![2025-08-13_13-47](https://github.com/user-attachments/assets/a1ffaeb4-025c-46f7-ba2e-83854499c01e)
![2025-08-13_13-46](https://github.com/user-attachments/assets/8633b760-a1ec-43b8-bc0e-bd0eceeaea22)
