### PR TITLE
Allow viewing prefer embed

### DIFF
--- a/extras/lbryinc/index.js
+++ b/extras/lbryinc/index.js
@@ -37,7 +37,7 @@ export { syncReducer } from './redux/reducers/sync';
 
 // selectors
 export { selectAuthToken, selectIsAuthenticating } from './redux/selectors/auth';
-export { selectBlackListedData, selectIsClaimBlackListedForUri } from './redux/selectors/blacklist';
+export { selectBlackListedData, selectBlackListDataForUri } from './redux/selectors/blacklist';
 export { selectFilteredData, selectFilterDataForUri } from './redux/selectors/filtered';
 // export {
 //   selectFeaturedUris,

--- a/extras/lbryinc/index.js
+++ b/extras/lbryinc/index.js
@@ -38,7 +38,7 @@ export { syncReducer } from './redux/reducers/sync';
 // selectors
 export { selectAuthToken, selectIsAuthenticating } from './redux/selectors/auth';
 export { selectBlackListedData, selectIsClaimBlackListedForUri } from './redux/selectors/blacklist';
-export { selectFilteredData, selectIsClaimFilteredForUri } from './redux/selectors/filtered';
+export { selectFilteredData, selectFilterDataForUri } from './redux/selectors/filtered';
 // export {
 //   selectFeaturedUris,
 //   selectFetchingFeaturedUris,

--- a/extras/lbryinc/redux/selectors/blacklist.js
+++ b/extras/lbryinc/redux/selectors/blacklist.js
@@ -5,7 +5,7 @@ export const selectState = (state) => state.blacklist || {};
 
 export const selectBlackListedData = (state) => selectState(state).blackListedData;
 
-export const selectIsClaimBlackListedForUri = (state, uri) => {
+export const selectBlackListDataForUri = (state, uri) => {
   const claim = selectClaimForUri(state, uri);
   const channelClaim = getChannelFromClaim(claim);
 

--- a/extras/lbryinc/redux/selectors/filtered.js
+++ b/extras/lbryinc/redux/selectors/filtered.js
@@ -5,7 +5,7 @@ export const selectState = (state) => state.filtered || {};
 
 export const selectFilteredData = (state) => selectState(state).filteredData;
 
-export const selectIsClaimFilteredForUri = (state, uri) => {
+export const selectFilterDataForUri = (state, uri) => {
   const claim = selectClaimForUri(state, uri);
   const channelClaim = getChannelFromClaim(claim);
 

--- a/ui/hocs/withResolvedClaimRender/index.js
+++ b/ui/hocs/withResolvedClaimRender/index.js
@@ -2,8 +2,7 @@ import { connect } from 'react-redux';
 import Comments from 'comments';
 import withResolvedClaimRender from './view';
 
-import { PREFERENCE_EMBED } from 'constants/tags';
-import { selectIsClaimBlackListedForUri, selectIsClaimFilteredForUri } from 'lbryinc';
+import { selectIsClaimBlackListedForUri, selectFilterDataForUri } from 'lbryinc';
 
 import { selectGblAvailable } from 'redux/selectors/blocked';
 import {
@@ -12,7 +11,6 @@ import {
   selectClaimIsMine,
   selectGeoRestrictionForUri,
   selectIsUriUnlisted,
-  makeSelectTagInClaimOrChannelForUri,
 } from 'redux/selectors/claims';
 import { selectContentStates } from 'redux/selectors/content';
 import { selectUser, selectUserVerifiedEmail } from 'redux/selectors/user';
@@ -26,14 +24,15 @@ const select = (state, props) => {
 
   const claim = selectClaimForUri(state, uri);
 
-  const preferEmbed = makeSelectTagInClaimOrChannelForUri(uri, PREFERENCE_EMBED)(state);
+  const filterData = selectFilterDataForUri(state, uri);
+  const isClaimFiltered = filterData && filterData.tag_name !== 'internal-hide-trending';
 
   return {
     uri,
     claim,
     hasClaim: selectHasClaimForUri(state, uri),
     isClaimBlackListed: selectIsClaimBlackListedForUri(state, uri),
-    isClaimFiltered: selectIsClaimFilteredForUri(state, uri),
+    isClaimFiltered,
     claimIsMine: selectClaimIsMine(state, claim),
     isUnlisted: selectIsUriUnlisted(state, uri),
     isAuthenticated: selectUserVerifiedEmail(state),
@@ -41,7 +40,6 @@ const select = (state, props) => {
     uriAccessKey: selectContentStates(state).uriAccessKeys[uri],
     geoRestriction: selectGeoRestrictionForUri(state, uri),
     gblAvailable: selectGblAvailable(state),
-    preferEmbed,
     verifyClaimSignature: Comments.verify_claim_signature,
   };
 };

--- a/ui/hocs/withResolvedClaimRender/index.js
+++ b/ui/hocs/withResolvedClaimRender/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import Comments from 'comments';
 import withResolvedClaimRender from './view';
 
-import { selectIsClaimBlackListedForUri, selectFilterDataForUri } from 'lbryinc';
+import { selectBlackListDataForUri, selectFilterDataForUri } from 'lbryinc';
 
 import { selectGblAvailable } from 'redux/selectors/blocked';
 import {
@@ -31,7 +31,7 @@ const select = (state, props) => {
     uri,
     claim,
     hasClaim: selectHasClaimForUri(state, uri),
-    isClaimBlackListed: selectIsClaimBlackListedForUri(state, uri),
+    isClaimBlackListed: Boolean(selectBlackListDataForUri(state, uri)),
     isClaimFiltered,
     claimIsMine: selectClaimIsMine(state, claim),
     isUnlisted: selectIsUriUnlisted(state, uri),

--- a/ui/hocs/withResolvedClaimRender/view.jsx
+++ b/ui/hocs/withResolvedClaimRender/view.jsx
@@ -27,7 +27,6 @@ type Props = {
   uriAccessKey: ?UriAccessKey,
   geoRestriction: ?GeoRestriction,
   gblAvailable: boolean,
-  preferEmbed: boolean,
   verifyClaimSignature: (params: VerifyClaimSignatureParams) => Promise<VerifyClaimSignatureResponse>,
   doResolveUri: (uri: string, returnCached?: boolean, resolveReposts?: boolean, options?: any) => void,
   doBeginPublish: (type: PublishType, name: ?string) => void,
@@ -59,7 +58,6 @@ const withResolvedClaimRender = (ClaimRenderComponent: FunctionalComponentParam)
       uriAccessKey,
       geoRestriction,
       gblAvailable,
-      preferEmbed,
       verifyClaimSignature,
       doResolveUri,
       doBeginPublish,
@@ -70,8 +68,7 @@ const withResolvedClaimRender = (ClaimRenderComponent: FunctionalComponentParam)
 
     const { streamName, /* channelName, */ isChannel } = parseURI(uri);
 
-    const claimIsRestricted =
-      !claimIsMine && (geoRestriction !== null || isClaimBlackListed || (isClaimFiltered && !preferEmbed));
+    const claimIsRestricted = !claimIsMine && (geoRestriction !== null || isClaimBlackListed || isClaimFiltered);
 
     const resolveRequired =
       claim === undefined || (claim && claim.value?.fee && claim.purchase_receipt === undefined && isAuthenticated);
@@ -247,7 +244,7 @@ const withResolvedClaimRender = (ClaimRenderComponent: FunctionalComponentParam)
         );
       }
 
-      if (isClaimFiltered && !preferEmbed) {
+      if (isClaimFiltered) {
         return (
           <Wrapper>
             <div className="main--empty">

--- a/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/index.js
+++ b/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/index.js
@@ -10,7 +10,7 @@ import {
   selectThumbnailForUri,
   makeSelectTagInClaimOrChannelForUri,
 } from 'redux/selectors/claims';
-import { selectIsClaimBlackListedForUri, selectIsClaimFilteredForUri } from 'lbryinc';
+import { selectIsClaimBlackListedForUri, selectFilterDataForUri } from 'lbryinc';
 import { LINKED_COMMENT_QUERY_PARAM, THREAD_COMMENT_QUERY_PARAM } from 'constants/comment';
 import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
 import { selectCommentsListTitleForUri, selectCommentsDisabledSettingForChannelId } from 'redux/selectors/comments';
@@ -35,6 +35,9 @@ const select = (state, props) => {
 
   const commentSettingDisabled = selectCommentsDisabledSettingForChannelId(state, channelId);
 
+  const filterData = selectFilterDataForUri(state, uri);
+  const isClaimFiltered = filterData && filterData.tag_name !== 'internal-hide-trending';
+
   return {
     commentsListTitle: selectCommentsListTitleForUri(state, uri),
     costInfo: selectCostInfoForUri(state, uri),
@@ -49,7 +52,7 @@ const select = (state, props) => {
     contentUnlocked: claimId && selectNoRestrictionOrUserIsMemberForContentClaimId(state, claimId),
     isLivestream: selectIsStreamPlaceholderForUri(state, uri),
     isClaimBlackListed: selectIsClaimBlackListedForUri(state, uri),
-    isClaimFiltered: selectIsClaimFilteredForUri(state, uri),
+    isClaimFiltered,
   };
 };
 

--- a/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/index.js
+++ b/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/index.js
@@ -10,7 +10,7 @@ import {
   selectThumbnailForUri,
   makeSelectTagInClaimOrChannelForUri,
 } from 'redux/selectors/claims';
-import { selectIsClaimBlackListedForUri, selectFilterDataForUri } from 'lbryinc';
+import { selectBlackListDataForUri, selectFilterDataForUri } from 'lbryinc';
 import { LINKED_COMMENT_QUERY_PARAM, THREAD_COMMENT_QUERY_PARAM } from 'constants/comment';
 import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
 import { selectCommentsListTitleForUri, selectCommentsDisabledSettingForChannelId } from 'redux/selectors/comments';
@@ -51,7 +51,7 @@ const select = (state, props) => {
     isProtectedContent: Boolean(selectProtectedContentTagForUri(state, uri)),
     contentUnlocked: claimId && selectNoRestrictionOrUserIsMemberForContentClaimId(state, claimId),
     isLivestream: selectIsStreamPlaceholderForUri(state, uri),
-    isClaimBlackListed: selectIsClaimBlackListedForUri(state, uri),
+    isClaimBlackListed: Boolean(selectBlackListDataForUri(state, uri)),
     isClaimFiltered,
   };
 };


### PR DESCRIPTION
-Allow viewing content filtered with the tag `internal-hide-trending`
-Removed `preferEmbed` check from the file page, didn't seemed necessary there when we know the tag names, but left it else where as is.
-Rename `selectIsClaimFilteredForUri` to `selectFilterDataForUri` since it's what it does now. Same for blaclisted.
-Will still show the "Filtered" tag on channel preview and in uploads for the creator. (?)