### PR TITLE
Minor fixes/clarification to some membership issues

### DIFF
--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2977,7 +2977,6 @@
   "Continue to channel creation": "Continue to channel creation",
   "Failed to apply membership tiers. Access to the content may still be restricted.": "Failed to apply membership tiers. Access to the content may still be restricted.",
   "If the issue persists, please reach out to help@odysee.com": "If the issue persists, please reach out to help@odysee.com",
-  "Waiting for tier info...": "Waiting for tier info...",
   
   "--end--": "--end--"
 }

--- a/static/app-strings.json
+++ b/static/app-strings.json
@@ -2975,6 +2975,9 @@
   "Channel is required for commenting": "Channel is required for commenting",
   "You'll need a channel to comment on this upload.": "You'll need a channel to comment on this upload.",
   "Continue to channel creation": "Continue to channel creation",
+  "Failed to apply membership tiers. Access to the content may still be restricted.": "Failed to apply membership tiers. Access to the content may still be restricted.",
+  "If the issue persists, please reach out to help@odysee.com": "If the issue persists, please reach out to help@odysee.com",
+  "Waiting for tier info...": "Waiting for tier info...",
   
   "--end--": "--end--"
 }

--- a/ui/component/previewOverlayProtectedContent/index.js
+++ b/ui/component/previewOverlayProtectedContent/index.js
@@ -5,7 +5,7 @@ import { selectClaimForUri, selectClaimIsMine, selectProtectedContentTagForUri }
 import {
   selectUserIsMemberOfProtectedContentForId,
   selectPriceOfCheapestPlanForClaimId,
-  selectProtectedContentMembershipsForClaimId,
+  selectProtectedContentMembershipsForContentClaimId,
 } from 'redux/selectors/memberships';
 
 import { doMembershipList } from 'redux/actions/memberships';
@@ -21,7 +21,7 @@ const select = (state, props) => {
   return {
     channel,
     claimIsMine: selectClaimIsMine(state, claim),
-    protectedMembershipIds: channel && selectProtectedContentMembershipsForClaimId(state, channel.claim_id, claimId), // TODO Protected Content
+    protectedMembershipIds: claimId && selectProtectedContentMembershipsForContentClaimId(state, claimId),
     userIsAMember: selectUserIsMemberOfProtectedContentForId(state, claimId),
     cheapestPlanPrice: selectPriceOfCheapestPlanForClaimId(state, claimId),
     hasProtectedContentTag: Boolean(selectProtectedContentTagForUri(state, props.uri)),

--- a/ui/component/previewOverlayProtectedContent/view.jsx
+++ b/ui/component/previewOverlayProtectedContent/view.jsx
@@ -38,7 +38,7 @@ const PreviewOverlayProtectedContent = (props: Props) => {
     );
   }
 
-  if (protectedMembershipIds && userIsAMember !== undefined && cheapestPlanPrice && hasProtectedContentTag) {
+  if (userIsAMember !== undefined && hasProtectedContentTag) {
     return (
       <div className="protected-content__wrapper">
         <div className="protected-content__lock">

--- a/ui/component/previewOverlayProtectedContent/view.jsx
+++ b/ui/component/previewOverlayProtectedContent/view.jsx
@@ -38,24 +38,22 @@ const PreviewOverlayProtectedContent = (props: Props) => {
     );
   }
 
-  if (userIsAMember !== undefined && hasProtectedContentTag) {
+  if (hasProtectedContentTag) {
     return (
       <div className="protected-content__wrapper">
         <div className="protected-content__lock">
           <Icon icon={ICONS.LOCK} />
         </div>
-        <div className="protected-content__label-wrapper">
-          <div className="protected-content__label-container">
-            <div className="protected-content__label">
-              {__('Members Only')}
-              {cheapestPlanPrice ? (
+        {userIsAMember !== undefined && protectedMembershipIds && cheapestPlanPrice && (
+          <div className="protected-content__label-wrapper">
+            <div className="protected-content__label-container">
+              <div className="protected-content__label">
+                {__('Members Only')}
                 <span>{__('Join for $%membership_price% per month', { membership_price: cheapestPlanPrice })}</span>
-              ) : (
-                <span>{__('Waiting for tier info...')}</span>
-              )}
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/ui/component/previewOverlayProtectedContent/view.jsx
+++ b/ui/component/previewOverlayProtectedContent/view.jsx
@@ -48,7 +48,11 @@ const PreviewOverlayProtectedContent = (props: Props) => {
           <div className="protected-content__label-container">
             <div className="protected-content__label">
               {__('Members Only')}
-              <span>{__('Join for $%membership_price% per month', { membership_price: cheapestPlanPrice })}</span>
+              {cheapestPlanPrice ? (
+                <span>{__('Join for $%membership_price% per month', { membership_price: cheapestPlanPrice })}</span>
+              ) : (
+                <span>{__('Waiting for tier info...')}</span>
+              )}
             </div>
           </div>
         </div>

--- a/ui/hocs/withStreamClaimRender/internal/protectedContentOverlay/view.jsx
+++ b/ui/hocs/withStreamClaimRender/internal/protectedContentOverlay/view.jsx
@@ -46,13 +46,13 @@ const ProtectedContentOverlay = (props: Props) => {
   const isEmbed = React.useContext(EmbedContext);
   const membershipFetching = myMembership === undefined;
 
-  const clickProps = React.useMemo(
-    () =>
-      isEmbed
-        ? { href: `${formatLbryUrlForWeb(uri)}?${getModalUrlParam(MODALS.JOIN_MEMBERSHIP, { uri, fileUri })}` }
-        : { onClick: () => doOpenModal(MODALS.JOIN_MEMBERSHIP, { uri, fileUri }) },
-    [doOpenModal, fileUri, isEmbed, uri]
-  );
+  const clickProps = React.useMemo(() => {
+    if (!joinEnabled) return;
+
+    return isEmbed
+      ? { href: `${formatLbryUrlForWeb(uri)}?${getModalUrlParam(MODALS.JOIN_MEMBERSHIP, { uri, fileUri })}` }
+      : { onClick: () => doOpenModal(MODALS.JOIN_MEMBERSHIP, { uri, fileUri }) };
+  }, [doOpenModal, fileUri, isEmbed, uri, joinEnabled]);
 
   React.useEffect(() => {
     if (passClickPropsToParent) {
@@ -74,7 +74,7 @@ const ProtectedContentOverlay = (props: Props) => {
         <>
           <span>{__('Only @%channel_name% members can view this content.', { channel_name: channelName })}</span>
           <span>{__('New members are not currently accepted.')}</span>
-          </>
+        </>
       )}
       {joinEnabled && (
         <>
@@ -96,7 +96,7 @@ const ProtectedContentOverlay = (props: Props) => {
             {...clickProps}
           />
         </>
-    )}
+      )}
     </div>
   );
 };

--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -1048,6 +1048,8 @@ export const doCheckPendingClaims = (onChannelConfirmed: Function) => (dispatch:
     const state = getState();
     const pendingById = Object.assign({}, selectPendingClaimsById(state));
 
+    dispatch(doMembershipContentForStreamClaimIds(Object.keys(pendingById)));
+
     if (Object.keys(pendingById).length) {
       return Lbry.claim_list({ claim_id: Object.keys(pendingById), resolve: true }).then((results) => {
         const claims = results.items;

--- a/ui/redux/actions/claims.js
+++ b/ui/redux/actions/claims.js
@@ -2,6 +2,8 @@
 import * as ACTIONS from 'constants/action_types';
 import * as ABANDON_STATES from 'constants/abandon_states';
 import * as FILE_LIST from 'constants/file_list';
+import * as TAGS from 'constants/tags';
+
 import { Lbryio, doFetchViewCount } from 'lbryinc';
 import Lbry from 'lbry';
 import { normalizeURI } from 'util/lbryURI';
@@ -1048,16 +1050,19 @@ export const doCheckPendingClaims = (onChannelConfirmed: Function) => (dispatch:
     const state = getState();
     const pendingById = Object.assign({}, selectPendingClaimsById(state));
 
-    dispatch(doMembershipContentForStreamClaimIds(Object.keys(pendingById)));
-
     if (Object.keys(pendingById).length) {
       return Lbry.claim_list({ claim_id: Object.keys(pendingById), resolve: true }).then((results) => {
         const claims = results.items;
         const confirmedClaims = [];
+        const membershipCheckClaimIds = [];
         claims.forEach((claim) => {
           if (claim.claim_id && claim.confirmations > 0 && pendingById[claim.claim_id].txid === claim.txid) {
             confirmedClaims.push(claim);
             delete pendingById[claim.claim_id];
+          }
+
+          if (claim.value?.tags?.includes(TAGS.MEMBERS_ONLY_CONTENT_TAG)) {
+            membershipCheckClaimIds.push(claim.claim_id);
           }
         });
 
@@ -1068,6 +1073,8 @@ export const doCheckPendingClaims = (onChannelConfirmed: Function) => (dispatch:
             pending: pendingById,
           },
         });
+
+        dispatch(doMembershipContentForStreamClaimIds(membershipCheckClaimIds));
 
         const channelClaims = confirmedClaims.filter((claim) => claim.value_type === 'channel');
         if (channelClaims.length && onChannelConfirmCallback) {

--- a/ui/redux/actions/memberships.js
+++ b/ui/redux/actions/memberships.js
@@ -511,6 +511,18 @@ export const doSaveMembershipRestrictionsForContent =
         return response;
       })
       .catch((e) => {
+        if (memberRestrictionTierIds?.length > 0) {
+          dispatch(
+            doToast({
+              isError: true,
+              message: __(
+                'Failed to apply membership tiers. Access to the content may still be restricted.' +
+                  ' Error: ' +
+                  (e?.message || e)
+              ),
+            })
+          );
+        }
         // dispatch({ type: ACTIONS.SET_MEMBERSHIP_TIERS_FOR_CONTENT_FAILED, data: contentClaimId });
         return e;
       });

--- a/ui/redux/actions/memberships.js
+++ b/ui/redux/actions/memberships.js
@@ -455,7 +455,7 @@ export const doMembershipContentForStreamClaimIds =
 
     await Lbryio.call('membership_v2/member_content', 'resolve', { claim_ids: claimIdsCsv }, 'post')
       .then((response: MembershipContentResponse) => {
-        dispatch({ type: ACTIONS.GET_CLAIM_MEMBERSHIP_TIERS_SUCCESS, data: response });
+        dispatch({ type: ACTIONS.GET_CLAIM_MEMBERSHIP_TIERS_SUCCESS, data: { idsToFetch, response } });
         return response;
       })
       .catch((e) => {

--- a/ui/redux/actions/memberships.js
+++ b/ui/redux/actions/memberships.js
@@ -516,9 +516,11 @@ export const doSaveMembershipRestrictionsForContent =
             doToast({
               isError: true,
               message: __(
-                'Failed to apply membership tiers. Access to the content may still be restricted.' +
+                __('Failed to apply membership tiers. Access to the content may still be restricted.') +
                   ' Error: ' +
-                  (e?.message || e)
+                  (e?.message || e) +
+                  '\n' +
+                  __('If the issue persists, please reach out to help@odysee.com')
               ),
             })
           );

--- a/ui/redux/actions/publish.js
+++ b/ui/redux/actions/publish.js
@@ -9,7 +9,7 @@ import * as PUBLISH_TYPES from 'constants/publish_types';
 import { batchActions } from 'util/batch-actions';
 import { THUMBNAIL_CDN_SIZE_LIMIT_BYTES, WEB_PUBLISH_SIZE_LIMIT_GB } from 'config';
 import { doCheckPendingClaims } from 'redux/actions/claims';
-import { selectProtectedContentMembershipsForClaimId } from 'redux/selectors/memberships';
+import { selectProtectedContentMembershipsForContentClaimId } from 'redux/selectors/memberships';
 import { doSaveMembershipRestrictionsForContent, doMembershipContentforStreamClaimId } from 'redux/actions/memberships';
 import {
   makeSelectClaimForUri,
@@ -715,16 +715,15 @@ export const doPrepareEdit = (claim: StreamClaim, uri: string, claimType: string
     if (publishDataTags.has(MEMBERS_ONLY_CONTENT_TAG)) {
       if (channelId) {
         // Repopulate membership restriction IDs
-        let protectedMembershipIds: Array<number> = selectProtectedContentMembershipsForClaimId(
+        let protectedMembershipIds: Array<number> = selectProtectedContentMembershipsForContentClaimId(
           state,
-          channelId,
           claim.claim_id
         );
 
         if (protectedMembershipIds === undefined) {
           await dispatch(doMembershipContentforStreamClaimId(claim.claim_id));
           state = getState();
-          protectedMembershipIds = selectProtectedContentMembershipsForClaimId(state, channelId, claim.claim_id);
+          protectedMembershipIds = selectProtectedContentMembershipsForContentClaimId(state, claim.claim_id);
         }
 
         if (protectedMembershipIds && protectedMembershipIds.length > 0) {

--- a/ui/redux/reducers/memberships.js
+++ b/ui/redux/reducers/memberships.js
@@ -65,11 +65,11 @@ reducers[ACTIONS.USER_LEGACY_ODYSEE_PREMIUM_CHECK_STARTED] = (state, action) => 
   channelIds.forEach((id) => {
     fetchingSet.add(id);
   });
-  return { ...state, fetchingOdysePremiumIds: Array.from(fetchingSet)};
+  return { ...state, fetchingOdysePremiumIds: Array.from(fetchingSet) };
 };
 
 reducers[ACTIONS.USER_LEGACY_ODYSEE_PREMIUM_CHECK_SUCCESS] = (state, action) => {
-  const { membershipsById } = action.data;   // [{ [claimId: string]: 'Premium' | null}]
+  const { membershipsById } = action.data; // [{ [claimId: string]: 'Premium' | null}]
   const { fetchingOdysePremiumIds: currentFetching, legacyOdyseePremiumById } = state;
 
   const newLegacyOdyseePremiumById = Object.assign({}, legacyOdyseePremiumById);
@@ -79,7 +79,11 @@ reducers[ACTIONS.USER_LEGACY_ODYSEE_PREMIUM_CHECK_SUCCESS] = (state, action) => 
     fetchingSet.delete(channelId);
   });
 
-  return { ...state, fetchingOdysePremiumIds: Array.from(fetchingSet), legacyOdyseePremiumById: newLegacyOdyseePremiumById };
+  return {
+    ...state,
+    fetchingOdysePremiumIds: Array.from(fetchingSet),
+    legacyOdyseePremiumById: newLegacyOdyseePremiumById,
+  };
 };
 
 reducers[ACTIONS.USER_LEGACY_ODYSEE_PREMIUM_CHECK_FAILURE] = (state, action) => {
@@ -89,7 +93,7 @@ reducers[ACTIONS.USER_LEGACY_ODYSEE_PREMIUM_CHECK_FAILURE] = (state, action) => 
   channelIds.forEach((id) => {
     fetchingSet.delete(id);
   });
-  return { ...state, fetchingOdysePremiumIds: Array.from(fetchingSet)};
+  return { ...state, fetchingOdysePremiumIds: Array.from(fetchingSet) };
 };
 
 reducers[ACTIONS.CHANNEL_MEMBERSHIP_CHECK_STARTED] = (state, action) => {
@@ -152,10 +156,10 @@ reducers[ACTIONS.SET_MEMBERSHIP_BUY_SUCCESFUL] = (state, action) => {
   return { ...state, pendingBuyIds: Array.from(newPendingBuyIds) };
 };
 reducers[ACTIONS.SET_MEMBERSHIP_BUY_FAILED] = (state, action) => {
-  const { id, error }  = action.data;
+  const { id, error } = action.data;
   const newPendingBuyIds = new Set(state.pendingBuyIds);
   newPendingBuyIds.delete(id);
-  return { ...state, pendingBuyIds: Array.from(newPendingBuyIds), membershipBuyError: error  };
+  return { ...state, pendingBuyIds: Array.from(newPendingBuyIds), membershipBuyError: error };
 };
 
 reducers[ACTIONS.SET_MEMBERSHIP_CANCEL_STARTED] = (state, action) => {
@@ -244,16 +248,19 @@ reducers[ACTIONS.GET_CLAIM_MEMBERSHIP_TIERS_START] = (state, action) => {
   return { ...state, claimMembershipTiersFetchingIds: newClaimMembershipTiersFetchingIds };
 };
 reducers[ACTIONS.GET_CLAIM_MEMBERSHIP_TIERS_SUCCESS] = (state, action) => {
-  const response: MembershipContentResponse = action.data;
+  const response: MembershipContentResponse = action.data.response;
+  const idsToFetch = action.data.idsToFetch;
 
   const newProtectedContentClaims = Object.assign({}, state.protectedContentClaimsByCreatorId);
   const newClaimMembershipTiersFetchingIds = new Set(state.claimMembershipTiersFetchingIds);
 
+  for (const claimId in idsToFetch) {
+    newClaimMembershipTiersFetchingIds.delete(claimId);
+  }
+
   if (response && response.length > 0) {
     response.forEach((membershipContent: MembershipContentResponseItem) => {
       const { channel_id: creatorId, claim_id: claimId, membership_id: membershipId } = membershipContent;
-
-      newClaimMembershipTiersFetchingIds.delete(claimId);
 
       const creatorContentMemberships = newProtectedContentClaims[creatorId];
       const newCreatorContentMemberships = Object.assign({}, creatorContentMemberships);

--- a/ui/redux/reducers/memberships.js
+++ b/ui/redux/reducers/memberships.js
@@ -254,7 +254,7 @@ reducers[ACTIONS.GET_CLAIM_MEMBERSHIP_TIERS_SUCCESS] = (state, action) => {
   const newProtectedContentClaims = Object.assign({}, state.protectedContentClaimsByCreatorId);
   const newClaimMembershipTiersFetchingIds = new Set(state.claimMembershipTiersFetchingIds);
 
-  for (const claimId in idsToFetch) {
+  for (const claimId of idsToFetch) {
     newClaimMembershipTiersFetchingIds.delete(claimId);
   }
 

--- a/ui/redux/selectors/memberships.js
+++ b/ui/redux/selectors/memberships.js
@@ -540,7 +540,7 @@ export const selectProtectedContentMembershipsForContentClaimId = (state: State,
     }
   }
 
-  return undefined;
+  return null;
 };
 
 export const selectContentHasProtectedMembershipIds = (state: State, claimId: string) => {

--- a/ui/redux/selectors/memberships.js
+++ b/ui/redux/selectors/memberships.js
@@ -18,7 +18,6 @@ import {
   selectClaimIsMineForId,
   selectClaimIdForUri,
 } from 'redux/selectors/claims';
-import { getChannelIdFromClaim } from 'util/claim';
 import { ODYSEE_CHANNEL } from 'constants/channels';
 import * as MEMBERSHIP_CONSTS from 'constants/memberships';
 
@@ -337,8 +336,6 @@ export const selectMembershipForCreatorIdAndChannelId = createCachedSelector(
   selectMyValidMembershipsForCreatorId,
   selectMyChannelClaimIds,
   (channelId, creatorMemberships, myValidCreatorMemberships, myChannelClaimIds) => {
-    const channelIsMine = new Set(myChannelClaimIds).has(channelId);
-
     // if (channelIsMine) {
     //   if (!myValidCreatorMemberships) return myValidCreatorMemberships;
     //
@@ -531,10 +528,19 @@ export const selectProtectedContentMembershipsForClaimId = (state: State, channe
   return protectedClaimsById && protectedClaimsById[claimId] && protectedClaimsById[claimId].memberships; // array of mids ['1234']
 };
 export const selectProtectedContentMembershipsForContentClaimId = (state: State, claimId: string) => {
-  const claimChannelId = getChannelIdFromClaim(selectClaimForId(state, claimId));
-  const protectedClaimsById = claimChannelId && selectProtectedContentClaimsForId(state, claimChannelId);
+  // Prefer resolving purely by content-claim id to avoid issues when channel id is incorrect
+  const protectedByCreator = selectProtectedContentClaimsById(state);
 
-  return protectedClaimsById && protectedClaimsById[claimId] && protectedClaimsById[claimId].memberships;
+  if (!protectedByCreator) return undefined;
+
+  for (const creatorId in protectedByCreator) {
+    const claimsForCreator = protectedByCreator[creatorId];
+    if (claimsForCreator && claimsForCreator[claimId] && claimsForCreator[claimId].memberships) {
+      return claimsForCreator[claimId].memberships;
+    }
+  }
+
+  return undefined;
 };
 
 export const selectContentHasProtectedMembershipIds = (state: State, claimId: string) => {
@@ -548,17 +554,22 @@ export const selectContentHasProtectedMembershipIds = (state: State, claimId: st
 };
 
 export const selectProtectedContentMembershipsForId = (state: State, claimId: ClaimId) => {
-  const claimChannelId = getChannelIdFromClaim(selectClaimForId(state, claimId));
-  const protectedContentMembershipIds = new Set(
-    claimChannelId && selectProtectedContentMembershipsForClaimId(state, claimChannelId, claimId)
-  );
-  const creatorMemberships = claimChannelId && selectMembershipTiersForCreatorId(state, claimChannelId);
+  const membershipIds = selectProtectedContentMembershipsForContentClaimId(state, claimId);
+  if (!membershipIds) return membershipIds;
 
-  return (
-    creatorMemberships &&
-    // $FlowIgnore
-    creatorMemberships.filter((membership) => protectedContentMembershipIds.has(membership.membership_id)) // m.Membership.id
-  );
+  const membershipIdsSet = new Set(membershipIds);
+  const membershipsById = selectMembershipsById(state);
+
+  if (!membershipsById) return undefined;
+
+  // Map the restricted membership IDs to their full membership objects if available
+  const result = [];
+  membershipIdsSet.forEach((id) => {
+    const membership = membershipsById[id];
+    if (membership) result.push(membership);
+  });
+
+  return result;
 };
 
 export const selectMyProtectedContentMembershipForId = createSelector(
@@ -625,9 +636,7 @@ export const selectCheapestPlanForRestrictedIds = (state: State, restrictedIds: 
 };
 
 export const selectCheapestProtectedContentMembershipForId = (state: State, claimId: ClaimId) => {
-  const claimChannelId = getChannelIdFromClaim(selectClaimForId(state, claimId));
-  const protectedContentMembershipIds =
-    claimChannelId && selectProtectedContentMembershipsForClaimId(state, claimChannelId, claimId);
+  const protectedContentMembershipIds = selectProtectedContentMembershipsForContentClaimId(state, claimId);
 
   return protectedContentMembershipIds && selectCheapestPlanForRestrictedIds(state, protectedContentMembershipIds);
 };


### PR DESCRIPTION
-If content has `c:membership` tag, show the membership overlay, even if no tiers, and also for the creator. (If it has tiers, it will show just the green lock for the creator like before)  
-Fix claimIds with no tiers getting stuck in fetching state (basically there was only one tier check per page load, if it wasn't returned on first try)  
-Show toast error if failed to apply membership tiers. (Only made it show on apply for now, so it won't error every time user just moves content to a different channel, since it makes empty modify call in those cases too)  


Now shows this "Waiting tier info..." text if tiers aren't fetched, so it doesn't confuse creators as much just after the upload, but still catches attention if it doesn't go away after a while.
![2025-08-18_19-40](https://github.com/user-attachments/assets/f0ab3eb9-0a21-46da-9a7f-3b7864c15a61)
