### PR TITLE
Updated claim preview tile margins and added pointer cursor on hover

### DIFF
--- a/ui/scss/component/_claim-preview.scss
+++ b/ui/scss/component/_claim-preview.scss
@@ -92,12 +92,16 @@
 }
 
 .claim-preview--tile {
-  margin-bottom: var(--spacing-m);
+  margin-bottom: var(--spacing-l);
   margin-right: 0;
   margin-top: 0;
   margin-left: var(--spacing-m);
   justify-content: flex-start;
   list-style: none;
+
+  &:hover {
+    cursor: pointer;
+  }
 
   .menu__button {
     right: calc(var(--spacing-xs) * -1);
@@ -1495,7 +1499,6 @@
   margin-top: var(--spacing-xxxs);
   color: var(--color-subtitle);
   padding: 0px;
-  padding-bottom: var(--spacing-l);
 
   .channel-thumbnail {
     @include handleChannelGif(1.9rem);


### PR DESCRIPTION
## Fixes

Issue Number: N/A (nothing reported as it may or may not be a bug 

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Currently, the area that opens the video is way too big. If you accidentally click beneath a video or its author, it opens the video and it makes no intuitive sense.
<img width="674" height="458" alt="image" src="https://github.com/user-attachments/assets/c0ae7d56-abf1-4f57-8a1e-c2a2da4bfc20" />
<img width="720" height="607" alt="image" src="https://github.com/user-attachments/assets/f3cf896d-2cf3-4c5f-8d83-5714986263d2" />

## What is the new behavior?

The new behavior would be that only the entire video card would be clickable (and would have a `pointer` cursor which indicates it being clickable) and nothing below it. Overall, I'd say this makes it more intuitive.
<img width="554" height="463" alt="image" src="https://github.com/user-attachments/assets/a08d47fd-8ab5-4f12-9c01-3fc5cb9dfe59" />

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: In my eyes, this is more of a bug than anything else as it 

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
