### PR TITLE
Improve upload filter buttons fit on mobile

### DIFF
--- a/ui/page/fileListPublished/internal/fileListHeader/view.jsx
+++ b/ui/page/fileListPublished/internal/fileListHeader/view.jsx
@@ -55,7 +55,9 @@ export default function ClaimListHeader(props: Props) {
                     label={__(info.label)}
                     aria-label={info.ariaLabel}
                     onClick={() => handleFilterTypeChange(info.key)}
-                    className={classnames(`button-toggle`, { 'button-toggle--active': filterType === info.key })}
+                    className={classnames(`button-toggle`, `button-toggle__upload-type-filter`, {
+                      'button-toggle--active': filterType === info.key,
+                    })}
                   />
                 ))}
               </div>

--- a/ui/scss/component/_claim-search.scss
+++ b/ui/scss/component/_claim-search.scss
@@ -296,6 +296,12 @@
   }
 }
 
+.button-toggle__upload-type-filter {
+  @media (max-width: $breakpoint-small) {
+    font-size: var(--font-xxsmall);
+  }
+}
+
 .claim-search__tags-link {
   margin-left: var(--spacing-s);
   .button__label {


### PR DESCRIPTION
Using smaller font size on uploads page filter buttons on mobile.

User reported issue https://discord.com/channels/721806979928162404/1412154396820639886/1412154396820639886

Should still be legible enough
![2025-09-02_15-48](https://github.com/user-attachments/assets/563b2af1-3bfe-49a4-acee-cd2b7924f6f6)
