### PR TITLE
fix: url encoding for "@" to ensure YouTube compatibility

### DIFF
--- a/ui/util/url.js
+++ b/ui/util/url.js
@@ -159,8 +159,9 @@ export const generateShareUrl = (
 
   const encodedUrl = buildURI(uriParts, false, false);
   const lbryWebUrl = encodedUrl.replace(/#/g, ':');
+  const encodedLbryWebUrl = lbryWebUrl.replace(/@/g, '%40');
 
-  const url = `${domain}/${lbryWebUrl}` + (urlParamsString === '' ? '' : `?${urlParamsString}`);
+  const url = `${domain}/${encodedLbryWebUrl}` + (urlParamsString === '' ? '' : `?${urlParamsString}`);
   return url;
 };
 
@@ -198,7 +199,8 @@ export const generateShortShareUrl = async (
 
   const encodedUrl = buildURI(uriParts, false, false);
   const lbryWebUrl = encodedUrl.replace(/#/g, ':');
-  const baseUrl = `${domain}/${lbryWebUrl}`;
+  const encodedLbryWebUrl = lbryWebUrl.replace(/@/g, '%40');
+  const baseUrl = `${domain}/${encodedLbryWebUrl}`;
 
   // -- Append params that we want to shorten:
   const urlToShorten = new URL(baseUrl);


### PR DESCRIPTION
Fixes YouTube comment / link breaking when sharing Odysee links containing an "@". Only fixes from within share modal.

## Fixes

Issue Number: N/A

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
Sharing modal uses "@"

## What is the new behavior?

Sharing modal uses url encoded "%40" instead of "@". Fixes broken Youtube links. 

## Other information

Response to reports that links to Odysee from Youtube are broken. Confirmed that reason for this was inability to handle "@" within a URL. Encoding as "%40" fixes. 

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [X] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X] I have checked that this PR does not introduce a breaking change
- [X] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
