### PR TITLE
Hide "about" page on channel when no content exists

### DIFF
--- a/ui/component/common/tabs.jsx
+++ b/ui/component/common/tabs.jsx
@@ -93,11 +93,12 @@ function TabList(props: TabListProps) {
 // Flow doesn't understand we don't have to pass it in ourselves
 type TabProps = {
   isSelected?: Boolean,
+  className?: string,
 };
 function Tab(props: TabProps) {
   // @reach/tabs provides an `isSelected` prop
   // We could also useContext to read it manually
-  const { isSelected } = props;
+  const { isSelected, className, ...rest } = props;
   const [rect, setRect] = React.useState();
 
   // Recalculate "Rect" on window resize
@@ -117,7 +118,7 @@ function Tab(props: TabProps) {
     if (isSelected) setSelectedRect(rect);
   }, [isSelected, rect, setSelectedRect]);
 
-  return <ReachTab ref={ref} {...props} className="tab" type="button" />;
+  return <ReachTab ref={ref} {...rest} className={classnames('tab', className)} type="button" />;
 }
 
 //

--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/view.jsx
@@ -110,16 +110,21 @@ function ChannelPage(props: Props) {
   const { meta } = claim;
   const { claims_in_channel } = meta;
   const showClaims = Boolean(claims_in_channel) && !preferEmbed && !banState.filtered && !banState.blacklisted;
+  const hideAboutTab = !showClaims;
 
   const [viewBlockedChannel, setViewBlockedChannel] = React.useState(false);
 
   const urlParams = new URLSearchParams(search);
   const viewParam = urlParams.get(CHANNEL_PAGE.QUERIES.VIEW);
   const isHomeTab = !viewParam;
-  const currentView =
-    !showClaims && (isHomeTab || TABS_FOR_CHANNELS_WITH_CONTENT.includes(viewParam))
-      ? CHANNEL_PAGE.VIEWS.ABOUT
-      : viewParam || CHANNEL_PAGE.VIEWS.HOME;
+  let currentView = viewParam || CHANNEL_PAGE.VIEWS.HOME;
+
+  if (
+    !showClaims &&
+    (isHomeTab || TABS_FOR_CHANNELS_WITH_CONTENT.includes(viewParam) || viewParam === CHANNEL_PAGE.VIEWS.ABOUT)
+  ) {
+    currentView = hideAboutTab ? CHANNEL_PAGE.VIEWS.DISCUSSION : CHANNEL_PAGE.VIEWS.ABOUT;
+  }
 
   const [discussionWasMounted, setDiscussionWasMounted] = React.useState(false);
   const editing = currentView === CHANNEL_PAGE.VIEWS.EDIT;
@@ -272,7 +277,9 @@ function ChannelPage(props: Props) {
         search += `?${CHANNEL_PAGE.QUERIES.VIEW}=${CHANNEL_PAGE.VIEWS.DISCUSSION}`;
         break;
       case 6:
-        search += `?${CHANNEL_PAGE.QUERIES.VIEW}=${CHANNEL_PAGE.VIEWS.ABOUT}`;
+        if (!hideAboutTab) {
+          search += `?${CHANNEL_PAGE.QUERIES.VIEW}=${CHANNEL_PAGE.VIEWS.ABOUT}`;
+        }
         break;
       case 7:
         search += `?${CHANNEL_PAGE.QUERIES.VIEW}=${CHANNEL_PAGE.VIEWS.SETTINGS}`;
@@ -486,7 +493,11 @@ function ChannelPage(props: Props) {
               <Tab aria-selected={tabIndex === 5} disabled={editing} onClick={() => onTabChange(5)}>
                 {__('Community')}
               </Tab>
-              <Tab aria-selected={tabIndex === 6} onClick={() => onTabChange(6)}>
+              <Tab
+                className={classnames({ 'tab--hidden': hideAboutTab })}
+                aria-selected={tabIndex === 6}
+                onClick={() => onTabChange(6)}
+              >
                 {editing ? __('Editing Your Channel') : __('About --[tab title in Channel Page]--')}
               </Tab>
               <Tab aria-selected={tabIndex === 7} disabled={editing} onClick={() => onTabChange(7)}>
@@ -534,7 +545,7 @@ function ChannelPage(props: Props) {
               {(showDiscussion || currentView === CHANNEL_PAGE.VIEWS.DISCUSSION) && <CommunityTab uri={uri} />}
             </TabPanel>
             <TabPanel>
-              {currentView === CHANNEL_PAGE.VIEWS.ABOUT && (
+              {!hideAboutTab && currentView === CHANNEL_PAGE.VIEWS.ABOUT && (
                 <AboutTab uri={uri} channelIsBlackListed={channelIsBlackListed} />
               )}
             </TabPanel>

--- a/ui/scss/component/tabs.scss
+++ b/ui/scss/component/tabs.scss
@@ -115,6 +115,10 @@
   }
 }
 
+.tab--hidden {
+  display: none !important;
+}
+
 .tab__divider {
   position: absolute;
   margin-top: -46px;


### PR DESCRIPTION
Spam reduction measure. No channel description if no content / community tab.

## Fixes

Issue Number: NA

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

Channel page for a channel lacking any uploads / community shows the "About" page with channel description. 

## What is the new behavior?

This has been massively abused so if a channel has no uploads we will not show the "about" page

## Other information

This was being abused via mass channel claims displaying a channel description linking to a Telegram channel or other illicit link. 

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [ X] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [X ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [X ] I have checked that this PR does not introduce a breaking change
- [ X] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
