### PR TITLE
Fix playlist items getting too wide with long channel name

### DIFF
--- a/ui/page/playlists/style.scss
+++ b/ui/page/playlists/style.scss
@@ -19,6 +19,9 @@
         color: var(--color-text);
       }
     }
+    li {
+        min-width: 0;
+    }
   }
 
   .claim-grid__wrapper:last-of-type {


### PR DESCRIPTION
Long channel title in an item caused the playlist claim list to get too wide. 
Issue didn't happened in other claim list row views.
Seems it was something with draggable stuff setting the `min-width` to something high or something like that.
This seems to fix. 

Channel with the long title: https://odysee.com/@SeekTruth:b?view=content