### PR TITLE
In save to collection, make the check mark reflect the actual status

### DIFF
--- a/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/view.jsx
+++ b/ui/modal/modalClaimCollectionAdd/internal/claimCollectionAdd/internal/collectionSelectItem/view.jsx
@@ -20,11 +20,7 @@ function CollectionSelectItem(props: Props) {
   const id = collection.id;
   const name = getLocalizedNameForCollectionId(id) || collection.name;
 
-  const [checked, setChecked] = React.useState(collectionHasClaim);
-
   function handleChange() {
-    setChecked((prevChecked) => !prevChecked);
-
     doPlaylistAddAndAllowPlaying({ uri, collectionId: id, collectionName: name });
   }
 
@@ -35,7 +31,7 @@ function CollectionSelectItem(props: Props) {
   return (
     <li className="collection-select__item">
       <FormField
-        checked={checked}
+        checked={collectionHasClaim}
         disabled={collectionPending}
         icon={icon}
         type="checkbox"


### PR DESCRIPTION
The check mark will only appear once the item is in the list.
Helpful if list wasn't yet resolved and item adding failed. (There used to be false check mark) 
But this change does make adding the first new item to a public list slower. 