### PR TITLE
Fix Wallet tabs stuck when currency param missing/malformed

### DIFF
--- a/ui/redux/actions/wallet.js
+++ b/ui/redux/actions/wallet.js
@@ -482,7 +482,7 @@ export function doSendTip(params, isSupport, successCallback, errorCallback, sho
             message: shouldSupport ? __('Boost transaction successful.') : __('Tip successfully sent.'),
             subMessage: __("I'm sure they appreciate it!"),
             linkText: `${params.amount} LBC`,
-            linkTarget: `/${PAGES.WALLET}?tab=fiat-payment-history`,
+            linkTarget: `/${PAGES.WALLET}?tab=fiat-payment-history&currency=credits`,
           })
         );
       }


### PR DESCRIPTION
Fixes a bug where the Credits/Tips/Rentals tabs in Wallet could become blocked when opening tab=fiat-payment-history without the currency parameter (leaving the tabs in an invalid state).

Normalizes the query string in Wallet to tolerate the malformed case ¤cy/%C2%A4cy and convert it to currency, preventing the UI from breaking if the link arrives with that variant.

Updates the toast post-tip link to include currency=credits, ensuring that the deep link to the history always lands in a valid tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed malformed currency URL parameters to ensure proper parsing across wallet views
  * Improved wallet tab selection logic with more reliable defaults for missing or invalid currency values
  * Enhanced navigation consistency when switching between wallet tabs through improved URL parameter handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->