### PR TITLE
(Minor & UI) Always show scroll bar for sidebar

### DIFF
--- a/ui/scss/component/_navigation.scss
+++ b/ui/scss/component/_navigation.scss
@@ -42,7 +42,7 @@
 .navigation {
   position: fixed;
   left: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   top: var(--header-height);
   width: var(--side-nav-width);
@@ -71,6 +71,15 @@
   .button--secondary {
     background-color: var(--color-odysee) !important;
     color: var(--color-odysee-contrast) !important;
+  }
+
+  @media (min-width: $breakpoint-medium) {
+    overflow-y: hidden;
+    justify-content: space-between;
+
+    &:hover {
+      overflow-y: scroll;
+    }
   }
 
   @media (max-width: $breakpoint-medium) {
@@ -107,6 +116,10 @@
 
 .navigation--push {
   transform: translateX(0);
+
+  &:not(.navigation--micro) {
+    overflow-y: scroll;
+  }
 }
 
 .navigation--mac {


### PR DESCRIPTION
## Closes
This will close issue #2875 

## What is the current behavior?
The sidebar's scrollbar is only visible when hovering it, which can be confusing for some whether you can scroll or not.

## What is the new behavior?
The sidebar's scrollbar will always be visible if there is overflowing.

## Other information
Before: <img width="264" height="534" alt="image" src="https://github.com/user-attachments/assets/7e3b0996-1461-4582-882a-6819bc3cb04f" /> 

After: <img width="328" height="969" alt="image" src="https://github.com/user-attachments/assets/e984c179-d87f-4987-8168-283c7ba59149" />

## PR Checklist
<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [x] Other - Please describe: UI improvement

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Navigation scrolling behavior simplified: overflow now consistently uses scroll instead of changing on hover or at specific desktop widths.
  * Desktop hover-triggered scrolling and width adjustments removed for more predictable interaction.
  * Compact/micro navigation state still preserves its special behavior so the condensed look remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->