### PR TITLE
Disable shorts player in playlists

### DIFF
--- a/ui/component/videoRenderFloating/index.js
+++ b/ui/component/videoRenderFloating/index.js
@@ -76,7 +76,7 @@ const select = (state, props) => {
     canViewFile: selectCanViewFileForUri(state, uri),
     sidePanelOpen: selectShortsSidePanelOpen(state),
     isClaimShort: isClaimShort(claim),
-    disableShortsView: selectClientSetting(state, SETTINGS.DISABLE_SHORTS_VIEW),
+    disableShortsView: !!collectionSidebarId || selectClientSetting(state, SETTINGS.DISABLE_SHORTS_VIEW),
   };
 };
 

--- a/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/index.js
+++ b/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { doSetContentHistoryItem, doSetPrimaryUri } from 'redux/actions/content';
 import { withRouter } from 'react-router-dom';
+import * as COLLECTIONS_CONSTS from 'constants/collections';
 import {
   selectClaimIsNsfwForUri,
   selectClaimForUri,
@@ -17,14 +18,13 @@ import { selectCommentsListTitleForUri, selectCommentsDisabledSettingForChannelI
 import { doToggleAppDrawer } from 'redux/actions/app';
 import { selectClientSetting } from 'redux/selectors/settings';
 import * as SETTINGS from 'constants/settings';
-import { getChannelIdFromClaim } from 'util/claim';
+import { getChannelIdFromClaim, isClaimShort } from 'util/claim';
 
 import * as TAGS from 'constants/tags';
 
 import { selectNoRestrictionOrUserIsMemberForContentClaimId } from 'redux/selectors/memberships';
 
 import StreamClaimPage from './view';
-import { isClaimShort } from '../../../../../../util/claim';
 
 const select = (state, props) => {
   const { uri } = props;
@@ -41,6 +41,8 @@ const select = (state, props) => {
   const filterData = selectFilteredDataForUri(state, uri);
   const isClaimFiltered = filterData && filterData.tag_name !== 'internal-hide-trending';
 
+  const collectionSidebarId = urlParams.get(COLLECTIONS_CONSTS.COLLECTION_ID);
+
   return {
     commentsListTitle: selectCommentsListTitleForUri(state, uri),
     costInfo: selectCostInfoForUri(state, uri),
@@ -55,7 +57,7 @@ const select = (state, props) => {
     contentUnlocked: claimId && selectNoRestrictionOrUserIsMemberForContentClaimId(state, claimId),
     isLivestream: selectIsStreamPlaceholderForUri(state, uri),
     isClaimBlackListed: Boolean(selectBlackListedDataForUri(state, uri)),
-    disableShortsView: selectClientSetting(state, SETTINGS.DISABLE_SHORTS_VIEW),
+    disableShortsView: !!collectionSidebarId || selectClientSetting(state, SETTINGS.DISABLE_SHORTS_VIEW),
     isClaimFiltered,
     isClaimShort: isClaimShort(claim),
   };


### PR DESCRIPTION
Force normal player for shorts if there is `lid` param in the url, like https://odysee.com/@OurFreeSociety:2/Roblox-is-a-video-game-that-allows-pedos-targeting-of-children:0?lid=c575651b6817b2f34f1ab06658aef80848352f71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shorts view now reliably disables when browsing collections or playlists, even if a user setting would otherwise enable it, ensuring consistent display while navigating collection/playlist pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->