### PR TITLE
Possibly fix local prefs getting set on Odysee

### DIFF
--- a/ui/redux/middleware/shared-state.js
+++ b/ui/redux/middleware/shared-state.js
@@ -45,15 +45,18 @@ export const buildSharedStateMiddleware = (
       shared[key] = value;
     });
 
-    if (!isEqual(oldShared, shared)) {
-      // only update if the preference changed from last call in the same session
-      oldShared = shared;
-      dispatch(doPreferenceSet(preferenceKey, shared, SHARED_PREFERENCE_VERSION));
-    }
+    // Skip prefSet for 'local' preferences
+    if (preferenceKey === 'shared') {
+      if (!isEqual(oldShared, shared)) {
+        // only update if the preference changed from last call in the same session
+        oldShared = shared;
+        dispatch(doPreferenceSet(preferenceKey, shared, SHARED_PREFERENCE_VERSION));
+      }
 
-    if (sharedStateCb) {
-      // Pass dispatch to the callback to consumers can dispatch actions in response to preference set
-      sharedStateCb({ dispatch, getState, syncId: timeout });
+      if (sharedStateCb) {
+        // Pass dispatch to the callback to consumers can dispatch actions in response to preference set
+        sharedStateCb({ dispatch, getState, syncId: timeout });
+      }
     }
     clearTimeout(timeout);
     return actionResult;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Preference handling now explicitly distinguishes shared vs local: only shared preferences trigger state preparation, propagation, and dispatches.
  * Callback invocation for shared preference changes is restricted to the shared path; local preference updates no longer initiate shared-state construction or related callbacks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->