### PR TITLE
Fix nag convering bottom Save/Cancel on playlist arrange mode

### DIFF
--- a/ui/scss/component/_collection.scss
+++ b/ui/scss/component/_collection.scss
@@ -282,3 +282,7 @@
     }
   }
 }
+
+body:has(.nag) .card-fixed-bottom {
+  bottom: 3rem;
+}


### PR DESCRIPTION
Moves the playlist arrange bottom buttons above the nag if nag exist.

Old
![2026-01-27_14-22](https://github.com/user-attachments/assets/520a7bd6-a789-462c-a2ea-399b7157a612)

New
![2026-01-27_14-24](https://github.com/user-attachments/assets/8a1178e6-ebe4-4ab2-b4f3-c146df74d451)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the positioning of a fixed bottom card component to properly account for on-screen notifications, ensuring optimal layout alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->