### PR TITLE
Use resize observer

### DIFF
--- a/ui/component/videoRenderFloating/view.jsx
+++ b/ui/component/videoRenderFloating/view.jsx
@@ -21,7 +21,6 @@ import VideoRender from 'component/videoClaimRender';
 import UriIndicator from 'component/uriIndicator';
 import usePersistedState from 'effects/use-persisted-state';
 import Draggable from 'react-draggable';
-import { onFullscreenChange } from 'util/full-screen';
 import { formatLbryUrlForWeb, generateListSearchUrlParams, formatLbryChannelName } from 'util/url';
 import { useIsMobile, useIsMobileLandscape, useIsLandscapeScreen } from 'effects/use-screensize';
 import debounce from 'util/debounce';
@@ -288,17 +287,16 @@ function VideoRenderFloating(props: Props) {
       resizedBetweenFloating.current = true;
     }
 
-    function onWindowResize() {
+    const element = document.querySelector(`.${PRIMARY_PLAYER_WRAPPER_CLASS}`);
+    const resizeObserver = new ResizeObserver(() => {
       if (isFloating) clampToScreenOnResize();
       if (collectionSidebarId || !isFloating) handleResize();
-    }
+    });
 
-    window.addEventListener('resize', onWindowResize);
-    if (!isFloating && !isMobile) onFullscreenChange(window, 'add', handleResize);
+    if (element) resizeObserver.observe(element);
 
     return () => {
-      window.removeEventListener('resize', onWindowResize);
-      if (!isFloating && !isMobile) onFullscreenChange(window, 'remove', handleResize);
+      resizeObserver.disconnect();
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Fixes
Issue Number: #3406 

## What is the current behavior?
When theater mode is enabled on a livestream it works, but if it is disabled the video and the livestream chat overlap

## What is the new behavior?
This PR uses resize observer to dynamically report on changes

## Other information

## PR Checklist
<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the floating video player to respond more accurately and reliably when the window or container size changes, ensuring it maintains proper positioning and dimensions during all viewport changes.

* **Performance**  
  * Optimized the resize detection mechanism to reduce resource consumption and provide faster, more responsive behavior during resizing operations and viewport adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->