### PR TITLE
Allow clearing old LBC comment limits from Odysee

### DIFF
--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/creatorSettingsTab/view.jsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/tabs/creatorSettingsTab/view.jsx
@@ -401,7 +401,7 @@ export default function CreatorSettingsTab(props: Props) {
                       className="form-field--price-amount"
                       type="number"
                       placeholder="0"
-                      value={minUSDTip || (minTip ? 0.01 : '')} // Default to 0.01 if LBC limit is used, so user has way to clear it on Odysee
+                      value={minUSDTip || (minTip ? 0.01 : minUSDTip)} // Default to 0.01 if LBC limit is used, so user has way to clear it on Odysee
                       onChange={(e) => {
                         const newMinUSDTip = parseFloat(e.target.value);
                         setMinUSDTip(newMinUSDTip);
@@ -447,7 +447,7 @@ export default function CreatorSettingsTab(props: Props) {
                       step="any"
                       type="number"
                       placeholder="0"
-                      value={minUSDSuper || (minSuper ? 0.01 : '')} // Default to 0.01 if LBC limit is used, so user has way to clear it on Odysee
+                      value={minUSDSuper || (minSuper ? 0.01 : minUSDSuper)} // Default to 0.01 if LBC limit is used, so user has way to clear it on Odysee
                       disabled={!!minTip || !!minUSDTip}
                       onChange={(e) => {
                         const newMinUSDSuper = parseFloat(e.target.value);


### PR DESCRIPTION
If user has set LBC comment limits in the past, we show $0.01 limit on UI. 
There wasn't a way to clear that from settings, so updated settings to match the other UI. 

-If user has LBC min tip set, it shows as the $0.01 in settings too. 
-Changing the minUSD tip/hyperchat, will set both LBC limits to 0. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creator settings for minimum tip amounts: added debounced updates, cross-field clearing between LBC and USD tip fields, and safer initialization during full sync. Fields now respect focus to avoid overwriting active input, and USD tip displays a sensible fallback when an LBC limit is present. Overall stability of multi-currency tip handling was improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->