### PR TITLE
Update link for 'How to use' button

### DIFF
--- a/ui/component/youtubeTransferStatus/view.jsx
+++ b/ui/component/youtubeTransferStatus/view.jsx
@@ -380,7 +380,7 @@ export default function YoutubeTransferStatus(props: Props) {
                     <Button
                       button="link"
                       label={__('How to use')}
-                      href="https://help.odysee.tv/category-syncprogram/"
+                      href="https://help.odysee.tv/category-syncprogram/synctool/"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Update link for 'How to use' button

## Fixes

Issue Number:

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?
How to use link repeated youtube sync which is already in the learn more.

## What is the new behavior?
Link now points to how to use self sync
## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?
references how to use


Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [ ] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Help/How-to links in the YouTube transfer feature to provide more accurate navigation. Users clicking for guidance are now directed to the synctool documentation resource, which offers more specific and targeted assistance. This improves the user experience by ensuring help resources are properly aligned with feature functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->