### PR TITLE
Fix .docx file crash

### DIFF
--- a/ui/redux/selectors/content.js
+++ b/ui/redux/selectors/content.js
@@ -228,9 +228,11 @@ export const makeSelectFileRenderModeForUri = (uri: string) =>
       if (['text', 'document', 'script'].includes(mediaType)) {
         return RENDER_MODES.DOCUMENT;
       }
+      // @if TARGET='app'
       if (extension === 'docx') {
         return RENDER_MODES.DOCX;
       }
+      // @endif
 
       // when writing this my local copy of Lbry.getMediaType had '3D-file', but I was receiving model...'
       if (['3D-file', 'model'].includes(mediaType)) {
@@ -291,9 +293,11 @@ export const selectFileRenderModeForUri = createSelector(
     if (['text', 'document', 'script'].includes(mediaType)) {
       return RENDER_MODES.DOCUMENT;
     }
+    // @if TARGET='app'
     if (extension === 'docx') {
       return RENDER_MODES.DOCX;
     }
+    // @endif
 
     // when writing this my local copy of Lbry.getMediaType had '3D-file', but I was receiving model...'
     if (['3D-file', 'model'].includes(mediaType)) {


### PR DESCRIPTION
This was crashing, due to DocxViewer only being imported on the desktop App.
But importing it on web doesn't seem to work. 
This change defaults .docx to render in the Download only view

 https://odysee.com/@Dimitar:6/On-raw-Milk:6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * DOCX file handling/rendering is now limited to the app build only. This reduces unnecessary docx-related logic in non-app distributions, streamlines builds, and can help reduce bundle size and potential edge-case behavior outside the app. No public APIs or exported signatures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->