### PR TITLE
Show file info without desc in shorts comment view

### DIFF
--- a/ui/component/fileTitleSection/view.jsx
+++ b/ui/component/fileTitleSection/view.jsx
@@ -22,6 +22,7 @@ type Props = {
   nsfw: boolean,
   isNsfwBlocked: boolean,
   livestream?: boolean,
+  hideDescription?: boolean,
   // redux
   channelClaimId?: string,
   title?: string,
@@ -36,6 +37,7 @@ export default function FileTitleSection(props: Props) {
     nsfw,
     isNsfwBlocked,
     livestream = false,
+    hideDescription,
     subCount,
     channelClaimId,
     title,
@@ -106,7 +108,7 @@ export default function FileTitleSection(props: Props) {
         ) : (
           <>
             <ClaimAuthor channelSubCount={subCount} uri={uri} />
-            <FileDescription expandOverride={isMobile && livestream} uri={uri} />
+            {!hideDescription && <FileDescription expandOverride={isMobile && livestream} uri={uri} />}
           </>
         )
       }

--- a/ui/component/shortsSidePanel/view.jsx
+++ b/ui/component/shortsSidePanel/view.jsx
@@ -49,6 +49,7 @@ const ShortsSidePanel = React.memo<Props>(
             <FileTitleSection uri={uri} accessStatus={accessStatus} />
           ) : (
             <>
+              <FileTitleSection uri={uri} accessStatus={accessStatus} hideDescription />
               {contentUnlocked &&
                 (commentsDisabled ? (
                   <Empty padded text={__('The creator of this content has disabled comments.')} />


### PR DESCRIPTION
Fixes: If clicking shorts comment notification(or shorts comments in general), it's unclear what video you are on. Now shows the details also in comment view.  

![2026-02-11_15-37](https://github.com/user-attachments/assets/a6fffdf7-68a7-40d4-bbe5-1bf925f2f3fe)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display logic to conditionally hide file descriptions in certain contexts, providing a cleaner user interface when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->