### PR TITLE
Fix shorts sidepanel not showing all claim detail options in edit mode

### DIFF
--- a/ui/scss/component/_shorts.scss
+++ b/ui/scss/component/_shorts.scss
@@ -83,8 +83,8 @@ body:has(.main--shorts-page):not(:has(.navigation__overlay--active)) {
 .shorts-page__side-panel {
   position: fixed;
   top: 0;
-  right: -600px;
-  width: 600px;
+  right: -720px;
+  width: 720px;
   height: 100vh;
   background: var(--color-card-background);
   border-left: 1px solid var(--color-border);
@@ -393,7 +393,8 @@ body:has(.main--shorts-page):not(:has(.navigation__overlay--active)) {
 
 @media (max-width: 1180px) and (min-width: $breakpoint-small) {
   .shorts-page__side-panel {
-    width: 400px;
+    width: 440px;
+    right: -440px;
     .claim-preview__text {
       flex-direction: column !important;
     }


### PR DESCRIPTION
## Fixes


## What is the current behavior?

Claim details for shots doesn'ts show all claim options without scrolling when you are the owner.

## What is the new behavior?
Claim details now shows all options for owners without scroll or overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the shorts side panel width and positioning for improved layout and responsive design across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->