### PR TITLE
Fixed VideoJS incorrectly displaying some VOD's as live

### DIFF
--- a/ui/component/viewers/videoViewer/internal/videojs.jsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.jsx
@@ -277,6 +277,8 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     autoPlayNextShort,
   });
 
+  const isLivestreamUi = Boolean(isLivestreamClaim && userClaimId);
+
   const videoJsOptions = {
     preload: 'auto',
     playbackRates: VIDEO_PLAYBACK_RATES,
@@ -291,10 +293,12 @@ export default React.memo<Props>(function VideoJs(props: Props) {
         useDtsForTimestampOffset: true,
       },
     },
-    liveTracker: {
-      trackingThreshold: 0,
-      liveTolerance: 10,
-    },
+    liveTracker: isLivestreamUi
+      ? {
+          trackingThreshold: 0,
+          liveTolerance: 10,
+        }
+      : false,
     inactivityTimeout: 2000,
     muted: startMuted,
     plugins: { eventTracking: true, overlay: OVERLAY.OVERLAY_DATA },
@@ -310,7 +314,7 @@ export default React.memo<Props>(function VideoJs(props: Props) {
     techOrder: ['chromecast', 'html5'],
     ...Chromecast.getOptions(),
     suppressNotSupportedError: true,
-    liveui: true,
+    liveui: isLivestreamUi,
   };
 
   // TODO: would be nice to pull this out into functions file


### PR DESCRIPTION
## Fixes

Issue Number:

<!-- Tip: 
 - Add keywords to directly close the Issue when the PR is merged. 
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

VideoJS on some uploads containing HLS in their name / file will display live player controls for VOD's and not allow scrubbing. 

## What is the new behavior?

Only live videos have live player controls. 

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video player livestream detection to selectively enable live tracking features and interface elements only during livestream playback, providing a better viewing experience for live content while maintaining standard playback for on-demand videos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->