### PR TITLE
Skip upload size limit when editing existing "too big" upload

### DIFF
--- a/ui/component/publish/shared/publishFormErrors/index.js
+++ b/ui/component/publish/shared/publishFormErrors/index.js
@@ -1,5 +1,10 @@
 import { connect } from 'react-redux';
-import { selectPublishFormValue, selectIsStillEditing, selectMemberRestrictionStatus } from 'redux/selectors/publish';
+import {
+  selectPublishFormValue,
+  selectIsStillEditing,
+  selectMemberRestrictionStatus,
+  selectPrevFileSizeTooBig,
+} from 'redux/selectors/publish';
 import PublishFormErrors from './view';
 
 const select = (state) => ({
@@ -16,6 +21,7 @@ const select = (state) => ({
   releaseTimeError: selectPublishFormValue(state, 'releaseTimeError'),
   memberRestrictionStatus: selectMemberRestrictionStatus(state),
   isStillEditing: selectIsStillEditing(state),
+  prevFileSizeTooBig: selectPrevFileSizeTooBig(state),
 });
 
 export default connect(select)(PublishFormErrors);

--- a/ui/component/publish/shared/publishFormErrors/view.jsx
+++ b/ui/component/publish/shared/publishFormErrors/view.jsx
@@ -18,6 +18,7 @@ type Props = {
   fileBitrate: number,
   fileSizeTooBig: boolean,
   isStillEditing: boolean,
+  prevFileSizeTooBig: boolean,
   uploadThumbnailStatus: string,
   thumbnail: string,
   thumbnailError: boolean,
@@ -42,6 +43,7 @@ function PublishFormErrors(props: Props) {
     waitForFile,
     fileBitrate,
     fileSizeTooBig,
+    prevFileSizeTooBig,
   } = props;
   // These are extra help
   // If there is an error it will be presented as an inline error as well
@@ -59,9 +61,7 @@ function PublishFormErrors(props: Props) {
     <div className="error__text">
       {waitForFile && <div>{__('Choose a replay file, or select None')}</div>}
       {missingTiers && <div>{__(HELP.NO_TIERS_SELECTED)}</div>}
-      {fileSizeTooBig && (
-        <div>{UPLOAD_SIZE_MESSAGE}</div>
-      )}
+      {fileSizeTooBig && !(isStillEditing && prevFileSizeTooBig) && <div>{UPLOAD_SIZE_MESSAGE}</div>}
       {fileBitrate > BITRATE.MAX && (
         <div>{__('Bitrate is over the max, please transcode or choose another file.')}</div>
       )}

--- a/ui/component/publish/upload/publishFile/index.js
+++ b/ui/component/publish/upload/publishFile/index.js
@@ -1,6 +1,11 @@
 import { connect } from 'react-redux';
 import { selectBalance } from 'redux/selectors/wallet';
-import { selectIsStillEditing, selectPublishFormValue, selectMyClaimForUri } from 'redux/selectors/publish';
+import {
+  selectIsStillEditing,
+  selectPublishFormValue,
+  selectMyClaimForUri,
+  selectPrevFileSizeTooBig,
+} from 'redux/selectors/publish';
 import { doUpdateFile, doUpdatePublishForm, doUpdateTitle } from 'redux/actions/publish';
 import { selectActiveChannelClaim } from 'redux/selectors/app';
 import PublishFile from './view';
@@ -16,6 +21,7 @@ const select = (state, props) => ({
   duration: selectPublishFormValue(state, 'fileDur'),
   isVid: selectPublishFormValue(state, 'fileVid'),
   myClaimForUri: selectMyClaimForUri(state),
+  prevFileSizeTooBig: selectPrevFileSizeTooBig(state),
   activeChannelClaim: selectActiveChannelClaim(state),
 });
 

--- a/ui/component/publish/upload/publishFile/view.jsx
+++ b/ui/component/publish/upload/publishFile/view.jsx
@@ -29,6 +29,7 @@ type Props = {
   fileBitrate: number,
   fileSizeTooBig: boolean,
   isStillEditing: boolean,
+  prevFileSizeTooBig: boolean,
   balance: number,
   duration: number,
   isVid: boolean,
@@ -49,6 +50,7 @@ function PublishFile(props: Props) {
     fileBitrate,
     fileSizeTooBig,
     isStillEditing,
+    prevFileSizeTooBig,
     doUpdateTitle,
     doUpdateFile,
     disabled,
@@ -179,7 +181,7 @@ function PublishFile(props: Props) {
 
   function getUploadMessage() {
     // @if TARGET='web'
-    if (fileSizeTooBig) {
+    if (fileSizeTooBig && !(isStillEditing && prevFileSizeTooBig)) {
       return (
         <p className="help--warning">
           {UPLOAD_SIZE_MESSAGE}{' '}

--- a/ui/component/publish/upload/uploadForm/index.js
+++ b/ui/component/publish/upload/uploadForm/index.js
@@ -7,6 +7,7 @@ import {
   selectMemberRestrictionStatus,
   selectPublishFormValue,
   selectMyClaimForUri,
+  selectPrevFileSizeTooBig,
 } from 'redux/selectors/publish';
 import { selectIsStreamPlaceholderForUri } from 'redux/selectors/claims';
 import * as RENDER_MODES from 'constants/file_render_modes';
@@ -40,6 +41,7 @@ const select = (state) => {
     isStillEditing: selectIsStillEditing(state),
     filePath: selectPublishFormValue(state, 'filePath'),
     fileSizeTooBig: selectPublishFormValue(state, 'fileSizeTooBig'),
+    prevFileSizeTooBig: selectPrevFileSizeTooBig(state),
     remoteUrl: selectPublishFormValue(state, 'remoteFileUrl'),
     publishSuccess: selectPublishFormValue(state, 'publishSuccess'),
     memberRestrictionStatus: selectMemberRestrictionStatus(state),

--- a/ui/component/publish/upload/uploadForm/view.jsx
+++ b/ui/component/publish/upload/uploadForm/view.jsx
@@ -47,6 +47,7 @@ type Props = {
   publish: DoPublishDesktop,
   filePath: string | File,
   fileSizeTooBig: boolean,
+  prevFileSizeTooBig: boolean,
   fileText: string,
   fileBitrate: number,
   bid: ?number,
@@ -111,6 +112,7 @@ function UploadForm(props: Props) {
     enablePublishPreview,
     filePath,
     fileSizeTooBig,
+    prevFileSizeTooBig,
     fileText,
     fileBitrate,
     hasClaimedInitialRewards,
@@ -187,7 +189,7 @@ function UploadForm(props: Props) {
   const isOverwritingExistingClaim = !editingURI && myClaimForUri;
 
   const formValid =
-    !fileSizeTooBig &&
+    !(fileSizeTooBig && !(isStillEditing && prevFileSizeTooBig)) &&
     (!memberRestrictionStatus.isApplicable || memberRestrictionStatus.isSelectionValid) &&
     (isOverwritingExistingClaim
       ? false

--- a/ui/redux/selectors/publish.js
+++ b/ui/redux/selectors/publish.js
@@ -9,6 +9,7 @@ import {
   selectClaimsByUri,
   selectCollectionClaimPublishUpdateMetadataForId,
 } from 'redux/selectors/claims';
+import { WEB_PUBLISH_SIZE_LIMIT_GB } from 'config';
 import { CHANNEL_ANONYMOUS } from 'constants/claim';
 import { SCHEDULED_LIVESTREAM_TAG } from 'constants/tags';
 import {
@@ -107,6 +108,11 @@ export const selectMyClaimForUri = createCachedSelector(
     }
   }
 )((state, caseSensitive = true) => `selectMyClaimForUri-${caseSensitive ? '1' : '0'}`);
+
+export const selectPrevFileSizeTooBig = createSelector(selectMyClaimForUri, (claim) => {
+  const size = claim && claim.value && claim.value.source && claim.value.source.size;
+  return size ? Number(size) > WEB_PUBLISH_SIZE_LIMIT_GB * 1073741824 : false;
+});
 
 export const selectIsResolvingPublishUris = createSelector(
   selectState,


### PR DESCRIPTION
If previous file on publication was "too big", skip the file size check on edit. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file size validation warnings when editing existing publications with oversized files. The size limit message is now properly suppressed during editing if the previously published file exceeded the size limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->