### PR TITLE
Fix: Enable mobile UI for WebKit browsers with touch capability

### DIFF
--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
@@ -142,10 +142,11 @@ const onPlayerReady = (player, options) => {
  *           True if device supports touch events
  */
 const hasTouch = () => {
+  const nav = window.navigator || {};
   return (
     'ontouchstart' in window ||
-    (navigator.maxTouchPoints && navigator.maxTouchPoints > 0) ||
-    (navigator.msMaxTouchPoints && navigator.msMaxTouchPoints > 0)
+    (nav.maxTouchPoints && nav.maxTouchPoints > 0) ||
+    (nav.msMaxTouchPoints && nav.msMaxTouchPoints > 0)
   );
 };
 

--- a/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
+++ b/ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js
@@ -135,6 +135,21 @@ const onPlayerReady = (player, options) => {
 };
 
 /**
+ * Detect if device has touch capability
+ *
+ * @function hasTouch
+ * @return   {boolean}
+ *           True if device supports touch events
+ */
+const hasTouch = () => {
+  return (
+    'ontouchstart' in window ||
+    (navigator.maxTouchPoints && navigator.maxTouchPoints > 0) ||
+    (navigator.msMaxTouchPoints && navigator.msMaxTouchPoints > 0)
+  );
+};
+
+/**
  * A video.js plugin.
  *
  * Adds a monile UI for player control, and fullscreen orientation control
@@ -162,7 +177,13 @@ const onPlayerReady = (player, options) => {
  *           Never shows if the endscreen plugin is present
  */
 function mobileUi(options) {
-  if (videojs.browser.IS_ANDROID || videojs.browser.IS_IOS) {
+  // Activate mobile UI for:
+  // 1. Android/iOS devices
+  // 2. Safari/WebKit browsers with touch capability (fixes GNOME Web on touchscreen laptops)
+  const shouldActivate =
+    videojs.browser.IS_ANDROID || videojs.browser.IS_IOS || (hasTouch() && videojs.browser.IS_SAFARI);
+
+  if (shouldActivate) {
     this.ready(() => onPlayerReady(this, videojs.mergeOptions(defaults, options)));
   }
 }


### PR DESCRIPTION
Resolves #3282

## Problem
Play buttons disappear in GNOME Web (WebKitGTK) on touchscreen laptops (NixOS, Linux convertibles).

**User report:**
- Browser: GNOME Web (Epiphany 47.3.1, WebKitGTK 2.48.1)
- Hardware: Laptop with touchscreen
- Issue: No play buttons visible (neither overlay nor control bar)
- Workaround: Must tap screen to start/pause (like iOS Safari)

## Root Cause
The `videojs-mobile-ui` plugin only activated when:
```javascript
if (videojs.browser.IS_ANDROID || videojs.browser.IS_IOS)
```

WebKit desktop browsers on touchscreen devices:
1. ✅ VideoJS core detects touch capability
2. ❌ Don't match Android/iOS check → mobile UI doesn't load
3. ❌ VideoJS hides standard controls (expecting touch UI)
4. ❌ User gets no visible controls

## Solution
Expand activation to include **Safari/WebKit browsers with touch capability**:

```javascript
const hasTouch = () => (
  'ontouchstart' in window ||
  navigator.maxTouchPoints > 0 ||
  navigator.msMaxTouchPoints > 0
);

const shouldActivate =
  videojs.browser.IS_ANDROID ||
  videojs.browser.IS_IOS ||
  (hasTouch() && videojs.browser.IS_SAFARI);
```

## Testing
- ✅ GNOME Web 47.3.1 (WebKitGTK 2.48.1) on NixOS 25.05
- ✅ Play buttons now visible on touchscreen laptops
- ✅ No regression on standard desktop (no touch = no activation)
- ✅ Mobile (Android/iOS) unaffected

## Impact
- **Scope:** ~0.1% users (WebKit + touchscreen laptop edge case)
- **Risk:** Low (only adds condition, doesn't change existing behavior)
- **Benefit:** Accessibility fix for convertible/2-in-1 laptops
- **Precedent:** YouTube uses similar touch detection logic

## References
- Issue: #3282
- WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=292511
- Similar approach: https://github.com/videojs/video.js/blob/main/src/js/utils/browser.js#L224

## Files Changed
- `ui/component/viewers/videoViewer/internal/plugins/videojs-mobile-ui/plugin.js`
  - Added `hasTouch()` helper function
  - Extended activation condition to include touch-capable WebKit browsers

---

**cc** @tzarebczan @keikari - This should resolve the GNOME Web touchscreen issue reported in #3282.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile video UI now activates on Safari when touch is detected, not just on Android/iOS.
  * Improved touch detection across platforms for more reliable mobile UI activation and a smoother playback experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->