### PR TITLE
Preserve livestream replay edit metadata

### DIFF
--- a/ui/component/publish/shared/publishName/view.tsx
+++ b/ui/component/publish/shared/publishName/view.tsx
@@ -26,6 +26,9 @@ function PublishName(props: Props) {
   const dispatch = useAppDispatch();
   const publishFormName = useAppSelector((state) => selectPublishFormValue(state, 'name'));
   const uri = useAppSelector((state) => selectPublishFormValue(state, 'uri'));
+  const editingURI = useAppSelector((state) => selectPublishFormValue(state, 'editingURI'));
+  const publishType = useAppSelector((state) => selectPublishFormValue(state, 'type'));
+  const liveCreateType = useAppSelector((state) => selectPublishFormValue(state, 'liveCreateType'));
   const isStillEditing = useAppSelector((state) => selectIsStillEditing(state));
   const myClaimForUri = useAppSelector((state) => (selectMyClaimForUri as any)(state, true));
   const myClaimForUriCaseInsensitive = useAppSelector((state) => (selectMyClaimForUri as any)(state, false));
@@ -41,6 +44,8 @@ function PublishName(props: Props) {
   const [blurred, setBlurred] = React.useState(false);
   const activeChannelName = activeChannelClaim && activeChannelClaim.name;
   const isMobile = useIsMobile();
+  const shouldLockName =
+    isStillEditing || (publishType === 'livestream' && Boolean(editingURI) && liveCreateType === 'edit_placeholder');
   let prefix = IS_WEB ? (isMobile ? '' : `${DOMAIN}/`) : 'lbry://';
 
   if (activeChannelName && !incognito) {
@@ -102,7 +107,7 @@ function PublishName(props: Props) {
           name="content_name"
           value={name}
           error={nameError}
-          disabled={isStillEditing}
+          disabled={shouldLockName}
           onChange={handleChange}
           onBlur={() => setBlurred(true)}
           autoComplete="off"
@@ -111,7 +116,7 @@ function PublishName(props: Props) {
       <div className="form-field__help">
         <NameHelpText
           uri={uri}
-          isStillEditing={isStillEditing}
+          isStillEditing={shouldLockName}
           myClaimForUri={myClaimForUri}
           myClaimForUriCaseInsensitive={myClaimForUriCaseInsensitive}
           currentUploads={currentUploads}

--- a/ui/redux/actions/publish.ts
+++ b/ui/redux/actions/publish.ts
@@ -405,8 +405,13 @@ function extractMetadataViaVideoElement(blob: Blob, dispatch: Dispatch, shouldAp
 export const doUpdateFile = (file: WebFile, clearName: boolean = true) => {
   return (dispatch: Dispatch, getState: GetState) => {
     const state = getState();
-    const { name, title } = state.publish;
+    const { name, title, type, liveCreateType, liveEditType, editingURI } = state.publish;
     const isStillEditing = selectIsStillEditing(state);
+    const preserveLivestreamReplayEditMetadata =
+      type === 'livestream' &&
+      Boolean(editingURI) &&
+      liveCreateType === 'edit_placeholder' &&
+      liveEditType === 'upload_replay';
 
     if (!file) {
       // This also handles the case of trying to select another file but canceling half way.
@@ -582,13 +587,13 @@ export const doUpdateFile = (file: WebFile, clearName: boolean = true) => {
     const newFileName = (file.name && file.name.substr(0, file.name.lastIndexOf('.'))) || '';
     const fileName = clearName ? newFileName : name || newFileName;
 
-    if (clearName || !title) {
+    if (!preserveLivestreamReplayEditMetadata && (clearName || !title)) {
       formUpdates.title = newFileName || fileName;
     }
 
-    if (!isStillEditing && clearName) {
+    if (!preserveLivestreamReplayEditMetadata && !isStillEditing && clearName) {
       formUpdates.name = sanitizeName(newFileName || fileName);
-    } else if (!isStillEditing && !name) {
+    } else if (!preserveLivestreamReplayEditMetadata && !isStillEditing && !name) {
       formUpdates.name = sanitizeName(fileName);
     }
 
@@ -1468,7 +1473,10 @@ export const doPublishWithEarlyUpload =
 
       dispatch({
         type: ACTIONS.UPDATE_PENDING_CLAIMS,
-        data: { claims: [fakePendingClaim], options: { overrideTags: true, overrideSigningChannel: true } },
+        data: {
+          claims: [fakePendingClaim],
+          options: { overrideTags: true, overrideSigningChannel: true },
+        },
       } as UpdatePendingClaimsAction);
       dispatch({ type: ACTIONS.PUBLISH_SET_ACTIVE_FORM, data: { id: null } });
       dispatch({ type: ACTIONS.PUBLISH_SUCCESS, data: {} });
@@ -1479,13 +1487,20 @@ export const doPublishWithEarlyUpload =
           dispatch({ type: ACTIONS.REMOVE_PENDING_CLAIM_BY_ID, data: { claimId: pendingClaimId } });
           dispatch({
             type: ACTIONS.UPDATE_PENDING_CLAIMS,
-            data: { claims: [pendingClaim], options: { overrideTags: true, overrideSigningChannel: true } },
+            data: {
+              claims: [pendingClaim],
+              options: { overrideTags: true, overrideSigningChannel: true },
+            },
           } as UpdatePendingClaimsAction);
           dispatch({
             type: ACTIONS.PUBLISH_PIPELINE_UPDATE,
             data: {
               id: guid,
-              updates: { stage: 'published', progress: 100, uri: pendingClaim.permanent_url || publishedUri },
+              updates: {
+                stage: 'published',
+                progress: 100,
+                uri: pendingClaim.permanent_url || publishedUri,
+              },
             },
           });
           dispatch(doCheckPendingClaims(undefined));


### PR DESCRIPTION
## Fixes

## What is the current behavior?
When editing a livestream and choosing `Upload Replay`, selecting a new replay file can overwrite existing livestream metadata with the uploaded file name. This is incorrect for livestream edits, where the existing title/URL should be preserved.

## What is the new behavior?
When editing a livestream with `Upload Replay`, selecting a replay file no longer overwrites the existing livestream title.

## PR Checklist

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the name input field during livestream placeholder editing; field now correctly locks during specific edit operations to prevent unintended modifications.
  * Enhanced metadata preservation for livestream replays; title and name information are now properly retained when updating other publish form fields during livestream replay edit operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->