### PR TITLE
Fix purchase confirmation and purchased state updates

### DIFF
--- a/ui/modal/modalPreorderAndPurchaseContent/internal/preorderAndPurchaseContentCard/view.tsx
+++ b/ui/modal/modalPreorderAndPurchaseContent/internal/preorderAndPurchaseContentCard/view.tsx
@@ -5,6 +5,7 @@ import BusyIndicator from 'component/common/busy-indicator';
 import { Form } from 'component/common/form';
 import * as ICONS from 'constants/icons';
 import * as STRIPE from 'constants/stripe';
+import * as MODALS from 'constants/modal_types';
 import Button from 'component/button';
 import Card from 'component/common/card';
 import WalletStatus from 'component/walletStatus';
@@ -30,7 +31,7 @@ import {
 } from 'redux/selectors/claims';
 import { selectUserVerifiedEmail } from 'redux/selectors/user';
 import { doPlayUri } from 'redux/actions/content';
-import { doHideModal } from 'redux/actions/app';
+import { doHideModal, doOpenModal } from 'redux/actions/app';
 import { doCheckIfPurchasedClaimId } from 'redux/actions/payments';
 import { doPurchaseClaimForUri } from 'redux/actions/wallet';
 import { selectPreferredCurrency } from 'redux/selectors/settings';
@@ -150,6 +151,11 @@ export default function PreorderAndPurchaseContentCard(props: Props) {
     ).then(checkIfFinished);
   }
 
+  const handleSdkPurchase = React.useCallback(() => {
+    dispatch(doHideModal());
+    dispatch(doOpenModal(MODALS.AFFIRM_PURCHASE, { uri }));
+  }, [dispatch, uri]);
+
   React.useEffect(() => {
     // -- fetch for modal url param --
     if (isUrlParamModal && isAuthenticated && claimId && fiatRequired && isFetchingPurchases === undefined) {
@@ -212,10 +218,7 @@ export default function PreorderAndPurchaseContentCard(props: Props) {
                 rentDisabled={cantAffordRent}
                 purchaseDisabled={cantAffordPurchase}
                 preorderDisabled={cantAffordPreorder}
-                uri={uri}
-                setWaitingForBackend={setWaitingForBackend}
-                doPlayUri={(u, s, o, cb) => dispatch(doPlayUri(u, s, o, cb))}
-                doHideModal={() => dispatch(doHideModal())}
+                onSdkPurchaseClick={handleSdkPurchase}
               />
             )}
             <p className="help">
@@ -273,10 +276,7 @@ const SubmitArea = (props: any) => (
       <Button
         button="primary"
         requiresAuth
-        onClick={() => {
-          props.setWaitingForBackend(true);
-          props.doPlayUri(props.uri, true, undefined, props.doHideModal);
-        }}
+        onClick={props.onSdkPurchaseClick}
         label={
           <I18nMessage
             tokens={{

--- a/ui/redux/reducers/claims.ts
+++ b/ui/redux/reducers/claims.ts
@@ -1057,8 +1057,14 @@ reducers[ACTIONS.PURCHASE_URI_COMPLETED] = (state: ClaimsState, action: any): Cl
   const claimId = byUri[uri];
 
   if (claimId) {
-    let claim = byId[claimId];
-    claim.purchase_receipt = purchaseReceipt;
+    const claim = byId[claimId];
+
+    if (claim) {
+      byId[claimId] = {
+        ...claim,
+        purchase_receipt: purchaseReceipt,
+      };
+    }
   }
 
   myPurchases.push(uri);


### PR DESCRIPTION
## Fixes

  ## What is the current behavior?

 Some paid content purchase flows can bypass the expected confirmation path, and successful purchases may not immediately update the UI until the page is refreshed.

  ## What is the new behavior?

Content purchase from the mixed purchase modal now routes through the confirmation modal, and purchased state  updates immediately after a successful purchase without requiring a page refresh.

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved purchase flow modal routing and callback handling for better separation of concerns.
  * Enhanced state management in purchase claim tracking to prevent unintended data mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->