### PR TITLE
Fix publish preview media metadata

### DIFF
--- a/ui/component/publish/shared/publishSummary/view.tsx
+++ b/ui/component/publish/shared/publishSummary/view.tsx
@@ -69,6 +69,8 @@ export default function PublishSummary() {
     memberRestrictionTierIds,
     thumbnail,
     filePath,
+    fileMime,
+    fileVid,
     fileDur,
     type,
   } = pf;
@@ -101,6 +103,18 @@ export default function PublishSummary() {
 
   React.useEffect(() => {
     if (!pf.name || !isNameValid(pf.name) || !previewUri) return;
+
+    const isPost = type === 'post';
+    const isAudio = !isPost && !!fileMime && fileMime.startsWith('audio/');
+    const sourceMediaType = isPost ? 'text/markdown' : fileMime || (fileVid ? 'video/mp4' : undefined);
+    const streamMetadata = isPost
+      ? {}
+      : fileVid && fileDur
+        ? { video: { duration: fileDur } }
+        : isAudio && fileDur
+          ? { audio: { duration: fileDur } }
+          : {};
+
     const fakeClaim: any = {
       claim_id: previewClaimId,
       name: pf.name,
@@ -117,8 +131,8 @@ export default function PublishSummary() {
         thumbnail: { url: thumbnail },
         languages: language ? [language] : [],
         tags: tags.map((t: any) => t.name),
-        source: { media_type: type === 'post' ? 'text/markdown' : 'video/mp4' },
-        ...(type !== 'post' ? { video: { duration: fileDur || 60 } } : {}),
+        source: sourceMediaType ? { media_type: sourceMediaType } : undefined,
+        ...streamMetadata,
       },
       signing_channel: channelClaim
         ? {
@@ -151,7 +165,21 @@ export default function PublishSummary() {
         },
       });
     }
-  }, [title, description, thumbnail, channel, pf.name, language, tags, channelClaim, previewBlobUrl]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [
+    title,
+    description,
+    thumbnail,
+    channel,
+    pf.name,
+    language,
+    tags,
+    channelClaim,
+    previewBlobUrl,
+    fileMime,
+    fileVid,
+    fileDur,
+    type,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function getPriceValue() {
     switch (paywall) {

--- a/ui/component/publish/upload/publishFilePicker/view.tsx
+++ b/ui/component/publish/upload/publishFilePicker/view.tsx
@@ -99,7 +99,7 @@ export default function PublishFilePicker(props: Props) {
         type="file"
         style={{ display: 'none' }}
         onChange={handleInputChange}
-        accept="video/*,audio/*,image/*,application/*,text/*,.md,.pdf,.html,.epub,.docx,.odt,.txt,.csv,.json,.xml,.lbry,.stl,.obj,.fbx,.gcode,.cbr,.cbz,.cbt"
+        accept="video/*,audio/*,image/*,application/*,text/*,.zip,.md,.pdf,.html,.epub,.docx,.odt,.txt,.csv,.json,.xml,.lbry,.stl,.obj,.fbx,.gcode,.cbr,.cbz,.cbt"
       />
 
       {!hasFile ? (

--- a/ui/redux/actions/publish.ts
+++ b/ui/redux/actions/publish.ts
@@ -1438,6 +1438,15 @@ export const doPublishWithEarlyUpload =
       const publishedUri = channelBaseUrl
         ? `${channelBaseUrl}/${publishData.name}`
         : buildURI({ streamName: publishData.name, channelName: publishData.channel } as LbryUrlObj, true);
+      const isAudio = !!publishData.fileMime && publishData.fileMime.startsWith('audio/');
+      const sourceMediaType = publishData.fileMime || (publishData.fileVid ? 'video/mp4' : undefined);
+      const streamMetadata = publishData.fileVid
+        ? publishData.fileDur
+          ? { video: { duration: publishData.fileDur } }
+          : {}
+        : isAudio && publishData.fileDur
+          ? { audio: { duration: publishData.fileDur } }
+          : {};
       const pendingClaimId = `pending-${guid}`;
       const fakePendingClaim: any = {
         claim_id: pendingClaimId,
@@ -1454,7 +1463,8 @@ export const doPublishWithEarlyUpload =
           description: publishData.description,
           thumbnail: { url: publishData.thumbnail },
           tags: publishData.tags?.map((t: any) => t.name) || [],
-          source: { media_type: 'video/mp4' },
+          source: sourceMediaType ? { media_type: sourceMediaType } : undefined,
+          ...streamMetadata,
         },
         signing_channel: signingChannel
           ? {


### PR DESCRIPTION
 ## Fixes

  Issue Number:

  ## What is the current behavior?

During publish preview, non-video uploads such as zip files, PDFs, and images can be shown as if they were videos 

  ## What is the new behavior?

Publish preview now uses the actual uploaded file metadata, so non-video files no longer render with video duration badges. The early pending-preview path also uses the correct media type.

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added .zip file upload support in the file picker.

* **Bug Fixes**
  * Fixed media type detection to properly distinguish between posts, audio files, and video files based on file information.
  * Corrected metadata assignment to use appropriate duration information for each media type instead of defaulting values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->