### PR TITLE
Fix livestream schedule time picker alignment

### DIFF
--- a/ui/scss/component/_form-field.scss
+++ b/ui/scss/component/_form-field.scss
@@ -873,6 +873,8 @@ fieldset-section {
   }
 
   .react-datepicker__time-list-item {
+    margin-left: 0;
+
     &:hover {
       background-color: var(--color-button-alt-bg-hover) !important;
     }


### PR DESCRIPTION
 ## Fixes

## What is the current behavior?

In the livestream scheduling flow, the time options in the date picker are shifted and the `AM/PM` suffix can appear clipped.

  ## What is the new behavior?
  The livestream schedule date picker now aligns its time options correctly, and the full `AM/PM` text is visible.

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal alignment of time picker options in the DatePicker component for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->