### PR TITLE
Fix membership tier editor UX

### DIFF
--- a/ui/page/creatorMemberships/creatorArea/internal/tiersTab/internal/editingTier/view.tsx
+++ b/ui/page/creatorMemberships/creatorArea/internal/tiersTab/internal/editingTier/view.tsx
@@ -37,14 +37,10 @@ function MembershipEditTier(props: Props) {
   const doMembershipUpdateTier = (params: MembershipUpdateTierParams) => dispatch(doMembershipUpdateTierAction(params));
   const doMembershipList = (params: MembershipListParams, forceUpdate?: boolean | null) =>
     dispatch(doMembershipListAction(params, forceUpdate));
-  console.log('perk props', props);
-  console.log('membershipOdyseePerks', membershipOdyseePerks);
   const isCreatingAMembership = typeof membership.membership_id === 'string';
   const isMobile = useIsMobile();
   const roughHeaderHeight = (isMobile ? 56 : 60) + 10; // @see: --header-height
 
-  const nameRef = React.useRef<any>(null);
-  const contributionRef = React.useRef<any>(null);
   // no guarantee MEMBERSHIP_CONSTS._PERKS is the same as api get perks result. this is dumb.
   const defaultPerkIds: Array<number | string> = [...MEMBERSHIP_CONSTS.DEFAULT_TIER_PERKS];
   const currentPerkIds: Array<number | string> = membership.perks.map((perk) => perk.id);
@@ -55,7 +51,7 @@ function MembershipEditTier(props: Props) {
   const initialState = React.useRef({
     name: membership.name || '',
     description: membership.description || '',
-    price: Number(membership.prices[0].amount) / 100,
+    price: String(Number(membership.prices[0].amount) / 100),
     // currently a single price
     perks: isCreatingAMembership ? defaultPerkIds : currentPerkIds,
     frequency: 'monthly',
@@ -69,12 +65,13 @@ function MembershipEditTier(props: Props) {
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [selectedPerkIds, setSelectedPerkIds] = React.useState<Array<number | string>>(initialState.current.perks);
   const [saveError, setSaveError] = React.useState('');
-  console.log('selectedPerkIds', selectedPerkIds);
   const nameError = getIsInputEmpty(editTierParams.editTierName);
   const descriptionError = getIsInputEmpty(editTierParams.editTierDescription);
-  const priceLowerThanMin = Number(editTierParams.editTierPrice) < MIN_PRICE;
-  const priceHigherThanMax = Number(editTierParams.editTierPrice) > MAX_PRICE;
-  const priceError = !editTierParams.editTierPrice || priceLowerThanMin || priceHigherThanMax;
+  const parsedPrice = Number(editTierParams.editTierPrice);
+  const hasPriceValue = String(editTierParams.editTierPrice).trim() !== '' && !Number.isNaN(parsedPrice);
+  const priceLowerThanMin = hasPriceValue && parsedPrice < MIN_PRICE;
+  const priceHigherThanMax = hasPriceValue && parsedPrice > MAX_PRICE;
+  const priceError = !hasPriceValue || priceLowerThanMin || priceHigherThanMax;
 
   /**
    * When someone hits the 'Save' button from the edit functionality
@@ -98,7 +95,7 @@ function MembershipEditTier(props: Props) {
     }
 
     setIsSubmitting(true);
-    const newTierMonthlyContribution = contributionRef.current?.input?.current?.value || 0;
+    const newTierMonthlyContribution = parsedPrice;
     const selectedPerksAsArray = selectedPerkIds.toString();
 
     if (activeChannelClaim) {
@@ -231,16 +228,13 @@ function MembershipEditTier(props: Props) {
   return (
     <div className="membership-tier__wrapper-edit" ref={editTierWrapperRef}>
       <FormField
-        ref={nameRef}
         max={30}
         type="text"
         name="tier_name"
         label={__('Tier Name')}
         placeholder={membership.name}
         autoFocus
-        onChange={(e) =>
-          setEditTierParams((prev) => ({ ...prev, editTierName: nameRef.current?.input?.current?.value || '' }))
-        }
+        onChange={(e) => setEditTierParams((prev) => ({ ...prev, editTierName: e.target.value || '' }))}
         value={editTierParams.editTierName}
       />
 
@@ -251,6 +245,7 @@ function MembershipEditTier(props: Props) {
         name="tier_description"
         label={__('Tier Description')}
         placeholder={__('Description of your tier')}
+        hideSuggestions
         value={editTierParams.editTierDescription}
         onChange={(e) => setEditTierParams((prev) => ({ ...prev, editTierDescription: e.target.value }))}
       />
@@ -331,19 +326,15 @@ function MembershipEditTier(props: Props) {
       </div>
 
       <FormField
-        ref={contributionRef}
         className="form-field--price-amount"
         type="number"
         name="tier_contribution"
-        step="1"
+        step="0.01"
         min={MIN_PRICE}
         max={MAX_PRICE}
         label={__('Monthly Contribution ($/Month)')}
         value={editTierParams.editTierPrice}
-        onChange={(e) => {
-          const value = contributionRef.current?.input?.current?.value;
-          setEditTierParams((prev) => ({ ...prev, editTierPrice: parseFloat(value) }));
-        }}
+        onChange={(e) => setEditTierParams((prev) => ({ ...prev, editTierPrice: e.target.value }))}
         disabled={hasSubscribers}
       />
 

--- a/ui/page/creatorMemberships/creatorArea/internal/tiersTab/internal/membershipTier/view.tsx
+++ b/ui/page/creatorMemberships/creatorArea/internal/tiersTab/internal/membershipTier/view.tsx
@@ -91,6 +91,7 @@ function MembershipTier(props: Props) {
       </div>
 
       <div className="membership-tier__infos">
+        {membership.description && <span className="membership-tier__infos-description">{membership.description}</span>}
         <label>{__('Pledge')}</label>
         <span>
           ${(Number(membership?.prices[0].amount) / 100).toFixed(2)} (
@@ -101,8 +102,6 @@ function MembershipTier(props: Props) {
           )
         </span>{' '}
         {/* the ui basically supports monthly right now */}
-        <label>{__('Description ')}</label>
-        <span className="membership-tier__description">{membership.description}</span>
         <div className="membership-tier__perks">
           <div className="membership-tier__perks-content">
             <label>{__('Odysee Perks')}</label>

--- a/ui/page/creatorMemberships/creatorArea/view.tsx
+++ b/ui/page/creatorMemberships/creatorArea/view.tsx
@@ -117,6 +117,13 @@ const CreatorArea = (props: Props) => {
     navigate(url);
   }
 
+  React.useEffect(() => {
+    if (myChannelClaims) {
+      doListAllMyMembershipTiers();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only fetch after channel claims resolve.
+  }, [myChannelClaims]);
+
   const onChannelOverviewSelect = () => {
     setAllSelected(false);
     onTabChange(1);

--- a/ui/page/creatorMemberships/creatorArea/view.tsx
+++ b/ui/page/creatorMemberships/creatorArea/view.tsx
@@ -75,6 +75,7 @@ const CreatorArea = (props: Props) => {
   const disabledMessage = __('Monetization is not enabled. Please set up your wallet first.');
 
   const channelsToList = allSelected ? myChannelClaims : activeChannelClaim ? [activeChannelClaim] : null;
+  const previewChannelClaim = activeChannelClaim || myChannelClaims?.[0];
   const { search } = useLocation();
   const urlParams = new URLSearchParams(search);
   // if tiers are saved, then go to balance, otherwise go to tiers
@@ -258,7 +259,7 @@ const CreatorArea = (props: Props) => {
                       <span className="section__subtitle ">{__('Preview your tiers')}</span>
                       <br />
                       <Button
-                        navigate={`${formatLbryUrlForWeb(activeChannelClaim?.canonical_url)}?view=membership`}
+                        navigate={`${formatLbryUrlForWeb(previewChannelClaim?.canonical_url)}?view=membership`}
                         label={__('See Your Memberships')}
                         icon={ICONS.BACK}
                         button="secondary"

--- a/ui/scss/component/_membership.scss
+++ b/ui/scss/component/_membership.scss
@@ -1067,6 +1067,17 @@
     border: 2px solid var(--color-border);
     overflow: auto !important;
   }
+  textarea {
+    min-height: 8rem;
+    border-radius: var(--border-radius);
+    padding: var(--spacing-s);
+    resize: vertical;
+    white-space: pre-wrap;
+  }
+  .form-field__help {
+    margin-top: var(--spacing-xxs);
+    margin-bottom: var(--spacing-s);
+  }
   fieldset-section {
     margin-top: var(--spacing-m);
     &:first-of-type {
@@ -1184,8 +1195,8 @@ svg.icon--Upgrade {
 
 .membership-tier__infos-description {
   display: block;
-  max-height: 144px;
-  overflow-y: scroll;
+  margin-bottom: var(--spacing-s);
+  overflow-wrap: anywhere;
   white-space: pre-line;
 }
 


### PR DESCRIPTION
Issue Number:

## What is the current behavior?

In the creator memberships portal, tier editing has a few UX issues:
  - deleting the default tier name can make the title field hard to continue editing
  - the amount field can be difficult to clear and re-enter
  - the tier description UI looks rough and inconsistent with other description fields

  ## What is the new behavior?

 Tier editing in the creator memberships portal is now smoother:
  - the tier name field can be cleared and retyped normally
  - the amount field can be edited and re-entered reliably
  - the tier description field and description display use a cleaner, more appropriate UI

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tier price validation and initialization logic for more reliable handling.
  * Fixed membership description display to render only when content exists.

* **New Features**
  * Added decimal input support (0.01 step) for tier contribution amounts.

* **Style**
  * Enhanced textarea styling in tier editing with improved padding, sizing, and constraints.
  * Improved description text wrapping and spacing for better readability.

* **Chores**
  * Removed debug logging statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->