### PR TITLE
Load creator membership supporters on portal open

### DIFF
--- a/ui/page/creatorMemberships/creatorArea/view.tsx
+++ b/ui/page/creatorMemberships/creatorArea/view.tsx
@@ -124,6 +124,13 @@ const CreatorArea = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only fetch after channel claims resolve.
   }, [myChannelClaims]);
 
+  React.useEffect(() => {
+    if (supportersList === undefined) {
+      doGetMembershipSupportersList();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only fetch when supporters have not resolved.
+  }, [supportersList]);
+
   const onChannelOverviewSelect = () => {
     setAllSelected(false);
     onTabChange(1);


### PR DESCRIPTION
## Fixes

  Issue Number:

## What is the current behavior?

Creator Portal Overview and My Supporters can remain stuck loading because the supporters list is required before those tabs render, but the creator portal does not fetch it on initial load.

## What is the new behavior?

The creator portal fetches the membership supporters list when it has not resolved yet, allowing Overview and My Supporters to load normally.

## Other information

## PR Checklist
  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below
  </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed membership supporters list not loading properly on initial page load in the creator area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->