### PR TITLE
Fix/creator memberships tab highlight

### DIFF
--- a/ui/page/creatorMemberships/creatorArea/style.scss
+++ b/ui/page/creatorMemberships/creatorArea/style.scss
@@ -59,6 +59,10 @@
     border-bottom: 1px solid var(--color-header-button);
   }
 
+  .tab__divider {
+    display: none;
+  }
+
   .tab__panel {
     position: relative;
     width: calc(100% - 2 * var(--spacing-l));

--- a/ui/page/creatorMemberships/creatorArea/view.tsx
+++ b/ui/page/creatorMemberships/creatorArea/view.tsx
@@ -124,6 +124,13 @@ const CreatorArea = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only fetch after channel claims resolve.
   }, [myChannelClaims]);
 
+  React.useEffect(() => {
+    if (supportersList === undefined) {
+      doGetMembershipSupportersList();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only fetch when supporters have not resolved.
+  }, [supportersList]);
+
   const onChannelOverviewSelect = () => {
     setAllSelected(false);
     onTabChange(1);


### PR DESCRIPTION
## Fixes

## What is the current behavior?

Creator Memberships tabs show a duplicate active-tab highlight because the page renders both the shared tab divider and its own selected-tab underline.

## What is the new behavior?

Creator Memberships hides the extra shared tab divider so only the intended selected-tab underline is shown.

## PR Checklist
 <details><summary>Toggle...</summary>

 What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below
  </details>
