### PR TITLE
Polish creator memberships overview

### DIFF
--- a/ui/page/creatorMemberships/creatorArea/internal/overviewTab/internal/channelOverview/view.tsx
+++ b/ui/page/creatorMemberships/creatorArea/internal/overviewTab/internal/channelOverview/view.tsx
@@ -10,42 +10,47 @@ import { useAppSelector } from 'redux/hooks';
 import { selectSupportersAmountForChannelId, selectMonthlyIncomeForChannelId } from 'redux/selectors/memberships';
 type Props = {
   channelClaim: ChannelClaim;
+  onSelect: () => void;
 };
 
 const ChannelOverview = (props: Props) => {
-  const { channelClaim } = props;
+  const { channelClaim, onSelect } = props;
   const supportersAmount = useAppSelector((state) => selectSupportersAmountForChannelId(state, channelClaim.claim_id));
   const monthlyIncome = useAppSelector((state) => selectMonthlyIncomeForChannelId(state, channelClaim.claim_id));
   return (
     <>
-      <td className="channelThumbnail">
-        <ChannelThumbnail xsmall uri={channelClaim.canonical_url} />
-      </td>
+      <button type="button" className="membership-overview-channel__select" onClick={onSelect}>
+        <span className="membership-overview-channel__identity">
+          <ChannelThumbnail xsmall uri={channelClaim.canonical_url} />
+          <TruncatedText text={channelClaim.value.title || channelClaim.name} lines={1} />
+        </span>
 
-      <td>
-        <TruncatedText text={channelClaim.value.title || channelClaim.name} lines={1} />
-      </td>
+        <span className="membership-overview-channel__metric">
+          <span>{__('Supporters')}</span>
+          {supportersAmount}
+        </span>
+        <span className="membership-overview-channel__metric">
+          <span>{__('Estimated Monthly Income')}</span>${(monthlyIncome / 100).toFixed(2)}
+        </span>
+      </button>
 
-      <td>{supportersAmount}</td>
-      <td>${(monthlyIncome / 100).toFixed(2)}</td>
-
-      <td>
+      <div className="membership-overview-channel__action">
         <ButtonNavigateChannelId
           button="alt"
           channelId={channelClaim.claim_id}
           icon={ICONS.MEMBERSHIP}
           navigate={`${formatLbryUrlForWeb(channelClaim.canonical_url)}?view=membership`}
         />
-      </td>
+      </div>
 
-      <td className="membership-table__url">
+      <div className="membership-overview-channel__action">
         <CopyableText // onlyCopy
           hideValue // primaryButton
           // linkTo={`${URL}${formatLbryUrlForWeb(channelClaim.canonical_url)}?view=membership`}
           copyable={`${URL}${formatLbryUrlForWeb(channelClaim.canonical_url)}?view=membership`}
           snackMessage={__('Page location copied')}
         />
-      </td>
+      </div>
     </>
   );
 };

--- a/ui/page/creatorMemberships/creatorArea/internal/overviewTab/style.scss
+++ b/ui/page/creatorMemberships/creatorArea/internal/overviewTab/style.scss
@@ -53,27 +53,171 @@
   }
 }
 
-.table-total {
-  margin-bottom: var(--spacing-m);
-  background-color: var(--color-header-background);
-  border-radius: var(--border-radius);
+.membership-overview-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--spacing-m);
+  margin-bottom: var(--spacing-l);
 
-  td {
-    font-weight: var(--font-weight-bold);
-    width: 33.3%;
-    &:nth-child(1) {
-      padding-right: 0.25rem;
-    }
+  @media (max-width: $breakpoint-small) {
+    grid-template-columns: 1fr;
   }
+}
+
+.membership-overview-stat {
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background-color: var(--color-header-background);
+  padding: var(--spacing-m) var(--spacing-l);
+
   span {
     display: block;
-    background-color: var(--color-header-background);
-    padding: var(--spacing-xxs);
-    padding-bottom: 4px;
-    width: auto;
+    margin-bottom: var(--spacing-s);
+    color: var(--color-text-subtitle);
+    font-size: var(--font-small);
+    font-weight: var(--font-weight-bold);
+  }
+
+  strong {
     color: var(--color-primary);
-    border: 2px solid var(--color-border);
-    border-radius: var(--border-radius);
+    font-size: var(--font-large);
+    line-height: 1.1;
+  }
+}
+
+.membership-overview-list {
+  display: grid;
+  gap: var(--spacing-s);
+  margin-bottom: 28px;
+}
+
+.membership-overview-list__header,
+.membership-overview-channel {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(90px, 0.35fr) minmax(150px, 0.5fr) 56px 48px;
+  align-items: center;
+  gap: var(--spacing-s);
+}
+
+.membership-overview-list__header {
+  padding: 0 var(--spacing-l) var(--spacing-xs);
+  color: var(--color-text-subtitle);
+  font-size: var(--font-xsmall);
+  font-weight: var(--font-weight-bold);
+
+  span:nth-child(2),
+  span:nth-child(3) {
+    text-align: right;
+  }
+}
+
+.membership-overview-channel {
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background-color: var(--color-header-background);
+  padding: var(--spacing-m) var(--spacing-l);
+  transition:
+    background-color var(--animation-duration) var(--animation-style),
+    border-color var(--animation-duration) var(--animation-style);
+
+  &:focus-within,
+  &:hover {
+    background-color: rgba(var(--color-header-background-base), 0.55);
+    border-color: var(--color-link);
+  }
+
+  .button--alt {
+    background-image: linear-gradient(147deg, var(--color-primary), rgb(247, 121, 55));
+    color: white;
+
+    &:hover {
+      color: white;
+    }
+  }
+}
+
+.membership-overview-channel__select {
+  display: grid;
+  grid-column: span 3;
+  grid-template-columns: minmax(220px, 1fr) minmax(90px, 0.35fr) minmax(150px, 0.5fr);
+  align-items: center;
+  gap: var(--spacing-s);
+  min-width: 0;
+  border: 0;
+  background: none;
+  padding: 0;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.membership-overview-channel__identity {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-s);
+  min-width: 0;
+  font-weight: var(--font-weight-bold);
+
+  .channel-thumbnail {
+    flex: 0 0 auto;
+    margin-right: 0;
+  }
+}
+
+.membership-overview-channel__metric {
+  color: var(--color-text);
+  font-weight: var(--font-weight-bold);
+  text-align: right;
+
+  span {
+    display: none;
+  }
+}
+
+.membership-overview-channel__action {
+  display: flex;
+  justify-content: flex-end;
+
+  .button {
+    min-width: 36px;
+    height: 36px;
+    margin: 0;
+  }
+}
+
+@media (max-width: $breakpoint-small) {
+  .membership-overview-list__header {
+    display: none;
+  }
+
+  .membership-overview-channel {
+    grid-template-columns: 1fr auto auto;
+    gap: var(--spacing-xs) var(--spacing-s);
+  }
+
+  .membership-overview-channel__select {
+    grid-column: 1 / -1;
+    grid-template-columns: 1fr auto auto;
+  }
+
+  .membership-overview-channel__metric {
+    display: grid;
+    gap: var(--spacing-xxs);
+    text-align: left;
+
+    span {
+      display: block;
+      color: var(--color-text-subtitle);
+      font-size: var(--font-xsmall);
+    }
+  }
+
+  .membership-overview-channel__identity {
+    grid-column: 1 / -1;
   }
 }
 

--- a/ui/page/creatorMemberships/creatorArea/internal/overviewTab/view.tsx
+++ b/ui/page/creatorMemberships/creatorArea/internal/overviewTab/view.tsx
@@ -29,45 +29,35 @@ function OverviewTab(props: Props) {
 
   return (
     <>
-      <table className="table table-total">
-        <tr>
-          {/* todo: allow sorting */}
-          <td>
-            {/* todo: make this a link to the supporters tab with all channel set to on */}
-            {/* so they can see all their supporters */}
-            {__('Total Supporters')} <span>{totalSupportersAmount}</span>
-          </td>
-          <td>
-            {__('Income Last Month')} <span>${(previousMonthlyIncome / 100).toFixed(2)}</span>
-          </td>
-          <td>
-            {__('Projected Monthly Income')} <span>${(totalMonthlyIncome / 100).toFixed(2)}</span>
-          </td>
-        </tr>
-      </table>
+      <div className="membership-overview-stats">
+        <div className="membership-overview-stat">
+          <span>{__('Total Supporters')}</span>
+          <strong>{totalSupportersAmount}</strong>
+        </div>
+        <div className="membership-overview-stat">
+          <span>{__('Income Last Month')}</span>
+          <strong>${(previousMonthlyIncome / 100).toFixed(2)}</strong>
+        </div>
+        <div className="membership-overview-stat">
+          <span>{__('Projected Monthly Income')}</span>
+          <strong>${(totalMonthlyIncome / 100).toFixed(2)}</strong>
+        </div>
+      </div>
 
-      <div className="membership-table__wrapper">
-        <table className="table">
-          <thead>
-            <tr>
-              <th className="channelName-header" colSpan={2}>
-                {__('Channel Name')}
-              </th>
-              <th>{__('Supporters')}</th>
-              <th>{__('Estimated Monthly Income')}</th>
-              <th className="membership-table__page">{__('Page')}</th>
-              <th className="membership-table__url">{__('URL')}</th>
-            </tr>
-          </thead>
+      <div className="membership-overview-list">
+        <div className="membership-overview-list__header">
+          <span>{__('Channel Name')}</span>
+          <span>{__('Supporters')}</span>
+          <span>{__('Estimated Monthly Income')}</span>
+          <span>{__('Page')}</span>
+          <span>{__('URL')}</span>
+        </div>
 
-          <tbody>
-            {myChannelClaims.map((channelClaim: ChannelClaim) => (
-              <tr key={channelClaim.claim_id} onClick={() => selectChannel(channelClaim)}>
-                <ChannelOverview channelClaim={channelClaim} />
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        {myChannelClaims.map((channelClaim: ChannelClaim) => (
+          <div key={channelClaim.claim_id} className="membership-overview-channel">
+            <ChannelOverview channelClaim={channelClaim} onSelect={() => selectChannel(channelClaim)} />
+          </div>
+        ))}
       </div>
 
       <HelpHub


### PR DESCRIPTION
## Fixes


## What is the current behavior?

Creator Memberships Overview uses a plain table layout for summary metrics and channel membership rows, making the page feel less polished than the rest of the creator portal.

## What is the new behavior?

Creator Memberships Overview now shows summary metrics as compact cards and channels as cleaner, better-spaced rows.

## Other information

## PR Checklist
 <details><summary>Toggle...</summary>

What kind of change does this PR introduce?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [x] Other - Please describe: UI polish

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below
  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the membership overview layout with a modern grid-based system for improved organization and visual clarity
  * Enhanced channel selection with clickable interactive elements
  * Improved responsive design for better display on mobile and tablet screens
  * Updated stat card presentation with emphasized values for better visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->