### PR TITLE
Fix membership subscribe params

### DIFF
--- a/ui/redux/actions/memberships.ts
+++ b/ui/redux/actions/memberships.ts
@@ -174,7 +174,6 @@ export const doMembershipBuy =
     } = membershipParams;
     const source_payment_address = selectAPIArweaveDefaultAddress(state);
     const subscribeApiParams: MembershipSubscribeParams = {
-      membership_id: membershipId,
       subscriber_channel_claim_id: subscriberChannelId,
       price_id: String(priceId),
       source_payment_address: source_payment_address || '',

--- a/ui/types/membership.d.ts
+++ b/ui/types/membership.d.ts
@@ -103,7 +103,6 @@ type MembershipContentResponseItem = {
 };
 
 type MembershipSubscribeParams = {
-  membership_id: string;
   price_id: string;
   [key: string]: any;
 };


### PR DESCRIPTION
## Fixes

## What is the current behavior?

  Attempting to subscribe to a creator membership can fail because the frontend sends `membership_id` to `membership_v2.subscribe`, which the backend rejects as an extraneous parameter.

## What is the new behavior?

The subscribe request now only sends the parameters accepted by the backend subscribe endpoint. 

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>
