### PR TITLE
Fix memberships landing card routes

### DIFF
--- a/ui/page/creatorMemberships/index.tsx
+++ b/ui/page/creatorMemberships/index.tsx
@@ -12,7 +12,7 @@ const MembershipsLandingPage = () => {
   const navigate = useNavigate();
 
   function handleNavigateToPage(page: string) {
-    navigate(page);
+    navigate(`/$/${page}`);
   }
 
   return (


### PR DESCRIPTION
## Fixes

  Issue Number:

  ## What is the current behavior?

  Clicking the Donor Portal or Creator Portal image on the memberships landing page routes to a nested path like `/memberships/memberships/supporter` or `/memberships/memberships/creator`, which shows the not found page.

  ## What is the new behavior?

  The portal image clicks now route to the correct absolute memberships paths: `/memberships/supporter` and `/memberships/creator`.

  ## Other information

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation routing behavior in the Creator Memberships section to ensure proper page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->