### PR TITLE
Show wallet address in use error

### DIFF
--- a/ui/modal/modalArweaveConnect/view.tsx
+++ b/ui/modal/modalArweaveConnect/view.tsx
@@ -20,6 +20,7 @@ import {
   doUpdateArweaveAddressDefault,
 } from 'redux/actions/payments';
 import { selectArweaveConnecting } from 'redux/selectors/arwallet';
+import { LocalStorage } from 'util/storage';
 
 type Props = {
   previousModal?: {
@@ -60,11 +61,7 @@ export default function ModalAnnouncements(props: Props) {
         .then(() => {
           dispatch(doHideModal());
         })
-        .catch((e) => {
-          if (e?.message === 'address already exists for another user') {
-            dispatch(doHideModal());
-          }
-        });
+        .catch(() => {});
     }
   }, [walletAddress, dispatch, hasArweaveEntry, apiEntryWithAddress]);
 
@@ -110,6 +107,7 @@ export default function ModalAnnouncements(props: Props) {
   };
 
   const handleDisconnect = () => {
+    LocalStorage.setItem('WANDER_DISCONNECT', 'true');
     dispatch(doArDisconnect());
 
     if (previousModal) {
@@ -186,6 +184,44 @@ export default function ModalAnnouncements(props: Props) {
     );
   };
 
+  const AddressInUseCard = () => {
+    return (
+      <Card
+        className="announcement"
+        title={__('Wallet Connect Error')}
+        body={
+          <div className="section">
+            <p>
+              {__(
+                'The currently active Wander wallet is already connected to another Odysee account. Please switch to a different wallet.'
+              )}
+            </p>
+          </div>
+        }
+        actions={
+          <div className="section__actions">
+            <Button
+              button="primary"
+              label={__('Change login')}
+              onClick={() => {
+                dispatch(doRegisterArweaveAddressClear());
+                LocalStorage.setItem('AR_ADDRESS_IN_USE', 'true');
+                dispatch(doHideModal());
+                window.wanderInstance.open();
+              }}
+            />
+            <Button
+              button="alt"
+              label={__('Disconnect')}
+              disabled={isArAccountRegistering}
+              onClick={handleDisconnect}
+            />
+          </div>
+        }
+      />
+    );
+  };
+
   const handleCloseModal = () => {
     if (previousModal) {
       dispatch(doOpenModal(previousModal.id, previousModal.modalProps));
@@ -202,11 +238,10 @@ export default function ModalAnnouncements(props: Props) {
     !showConnecting &&
     !!arAccountRegisteringError &&
     arAccountRegisteringError !== 'address already exists for another user';
+  const showAddressInUseError =
+    !showConnecting && arAccountRegisteringError === 'address already exists for another user';
 
-  if (
-    (apiEntryWithAddress && !showConnecting && !showRegister && !showMakeDefault) ||
-    arAccountRegisteringError === 'address already exists for another user'
-  ) {
+  if (apiEntryWithAddress && !showConnecting && !showRegister && !showMakeDefault && !showAddressInUseError) {
     handleCloseModal();
     return null;
   }
@@ -217,6 +252,7 @@ export default function ModalAnnouncements(props: Props) {
       {showConnecting && <ConnectingCard />}
       {/* don't bother showing register unless you're showing a 2nd+ address */}
       {showRegister && <RegisterCard />}
+      {showAddressInUseError && <AddressInUseCard />}
       {showErrorCard && <ErrorCard />}
       {showMakeDefault && <MakeDefaultCard />}
       {/* {apiEntryWithAddress && defaultApiAddress === walletAddress && <TopUpCard />} */}


### PR DESCRIPTION
## Fixes

Issue Number:

## What is the current behavior?

When connecting a Wander wallet that is already connected to another Odysee account, the API returns `address already exists for another user`, but the wallet connect UI does not clearly surface the error. In this state, disconnecting or changing login can also reopen the connect flow or leave the page overlay active.

## What is the new behavior?

The wallet connect modal now shows a clear Wallet Connect Error for wallets already connected to another account. The user can change login or disconnect without getting stuck in a reconnect loop or blocked overlay state.

## Other information



  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wallet address registration now displays a notification when an address is already in use, allowing you to change your login instead of automatically closing the modal
  * Enhanced state management during wallet disconnection and reconnection workflows

* **Bug Fixes**
  * Improved handling of duplicate wallet address detection during registration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->