### PR TITLE
Improve upload thumbnail validation feedback

### DIFF
--- a/ui/component/publish/shared/publishWizard/style.scss
+++ b/ui/component/publish/shared/publishWizard/style.scss
@@ -239,6 +239,39 @@
   color: var(--color-text);
 }
 
+.publish-details__thumbnail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+  border: 1px solid transparent;
+  border-radius: var(--border-radius);
+  margin: calc(var(--spacing-s) * -1);
+  padding: var(--spacing-s);
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.publish-details__thumbnail--needs-attention {
+  border-color: var(--color-border);
+  background-color: var(--color-card-background);
+}
+
+.publish-details__thumbnail-feedback {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-xs);
+  color: var(--color-text-error);
+  font-size: var(--font-small);
+  font-weight: var(--font-weight-bold);
+  line-height: 1.4;
+
+  .icon {
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+}
+
 .publish-details .form-field__help:empty {
   display: none;
 }

--- a/ui/component/publish/shared/publishWizard/view.tsx
+++ b/ui/component/publish/shared/publishWizard/view.tsx
@@ -9,6 +9,7 @@ import './style.scss';
 type Step = {
   label: string;
   validate?: () => boolean;
+  onInvalid?: () => void;
 };
 
 type StepChangeSource = 'next' | 'back' | 'step';
@@ -46,7 +47,10 @@ export default function PublishWizard(props: Props) {
   function handleNext() {
     if (isLastStep) return;
     const step = steps[activeStep];
-    if (step.validate && !step.validate()) return;
+    if (step.validate && !step.validate()) {
+      step.onInvalid?.();
+      return;
+    }
     onStepChange(activeStep + 1, 'next');
   }
 
@@ -63,7 +67,10 @@ export default function PublishWizard(props: Props) {
     }
     for (let i = activeStep; i < index; i++) {
       const step = steps[i];
-      if (step.validate && !step.validate()) return;
+      if (step.validate && !step.validate()) {
+        step.onInvalid?.();
+        return;
+      }
     }
     onStepChange(index, 'step');
   }

--- a/ui/component/publish/upload/uploadForm/view.tsx
+++ b/ui/component/publish/upload/uploadForm/view.tsx
@@ -152,6 +152,8 @@ function UploadForm(props: Props) {
   const [waitForFile, setWaitForFile] = useState(false);
   const activeStep = useAppSelector((state) => state.publish.activeStep ?? 0);
   const setActiveStep = (step: number) => updatePublishForm({ activeStep: step } as any);
+  const [detailsNextAttempted, setDetailsNextAttempted] = React.useState(false);
+  const thumbnailSectionRef = React.useRef<HTMLDivElement | null>(null);
   const TAGS_LIMIT = 5;
   const missingRequiredFile = mode === PUBLISH_MODES.FILE && !editingURI && !filePath && !remoteUrl;
   const emptyPostError = mode === PUBLISH_MODES.POST && (!fileText || fileText.trim() === '');
@@ -689,6 +691,28 @@ function UploadForm(props: Props) {
 
   // -- Wizard steps --
   const isMkvFormat = fileFormat && fileFormat.toLowerCase() === 'mkv';
+  const isThumbnailStep = activeStep === 1;
+  const isThumbnailUploading = uploadThumbnailStatus === THUMBNAIL_STATUSES.IN_PROGRESS;
+  const showThumbnailRequiredError = detailsNextAttempted && isThumbnailStep && !thumbnail;
+  const showThumbnailUploadError = detailsNextAttempted && isThumbnailStep && isThumbnailUploading;
+  const showThumbnailInvalidError =
+    detailsNextAttempted && isThumbnailStep && !!thumbnail && thumbnailError && !thumbnailUploaded;
+  const showThumbnailFeedback = showThumbnailRequiredError || showThumbnailUploadError || showThumbnailInvalidError;
+  const thumbnailFeedbackMessage = showThumbnailUploadError
+    ? __('Your thumbnail is still uploading. Wait for it to finish before continuing.')
+    : showThumbnailRequiredError
+      ? __('Choose a thumbnail before continuing. Upload an image or paste an image URL.')
+      : __('This thumbnail could not be loaded. Choose another image or paste a valid image URL.');
+
+  function handleDetailsInvalid() {
+    setDetailsNextAttempted(true);
+
+    if (!thumbnail || isThumbnailUploading || (thumbnailError && !thumbnailUploaded)) {
+      window.setTimeout(() => {
+        thumbnailSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }, 0);
+    }
+  }
 
   const wizardSteps = [
     {
@@ -697,6 +721,7 @@ function UploadForm(props: Props) {
     },
     {
       label: 'Details',
+      onInvalid: handleDetailsInvalid,
       validate: () =>
         !!title &&
         !!name &&
@@ -820,8 +845,20 @@ function UploadForm(props: Props) {
                   <h3 className="publish-details__title">{__('Description')}</h3>
                   <PublishDescription disabled={disabled || publishing} />
                 </div>
-                <div>
+                <div
+                  ref={thumbnailSectionRef}
+                  className={classnames({
+                    'publish-details__thumbnail': showThumbnailFeedback,
+                    'publish-details__thumbnail--needs-attention': showThumbnailFeedback,
+                  })}
+                >
                   <h3 className="publish-details__title">{__('Thumbnail')}</h3>
+                  {showThumbnailFeedback && (
+                    <div className="publish-details__thumbnail-feedback" role="alert">
+                      <Icon icon={ICONS.ALERT} size={18} />
+                      <span>{thumbnailFeedbackMessage}</span>
+                    </div>
+                  )}
                   <SelectThumbnail />
                 </div>
                 <div>


### PR DESCRIPTION
## Fixes

## What is the current behavior?

When clicking Next on the upload Details step without a thumbnail, the form is blocked but the user does not get clear, focused feedback explaining that a thumbnail must be selected before continuing.

 ## What is the new behavior?

The Details step now shows focused thumbnail validation feedback after the user tries to continue.

## Other information

## PR Checklist

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced publish wizard with improved validation feedback for thumbnails.
  * Added visual alerts and automatic scrolling to invalid fields during the publish process for better error visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->