### PR TITLE
Autolink pasted URLs in comments

### DIFF
--- a/ui/component/markdownLink/view.tsx
+++ b/ui/component/markdownLink/view.tsx
@@ -71,7 +71,9 @@ function MarkdownLink(props: Props) {
 
   if (linkUrlObject && !href.startsWith('mailto:')) {
     const linkDomain = linkUrlObject.hostname;
-    const isKnownAppDomainLink = KNOWN_APP_DOMAINS.includes(linkDomain);
+    const normalizedLinkDomain = linkDomain.replace(/^www\./, '');
+    const isKnownAppDomainLink =
+      KNOWN_APP_DOMAINS.includes(linkDomain) || KNOWN_APP_DOMAINS.includes(normalizedLinkDomain);
 
     if (isKnownAppDomainLink) {
       let linkPathname;
@@ -133,11 +135,12 @@ function MarkdownLink(props: Props) {
         </Menu>
       );
     } else {
+      const allowKnownAppPreview = Boolean((parentCommentId || isComment) && lbryUrlFromLink);
       element = (
         <ClaimLink
           uri={lbryUrlFromLink || decodedUri}
           parentCommentId={parentCommentId}
-          allowPreview={embed || allowPreview}
+          allowPreview={embed || allowPreview || allowKnownAppPreview}
         >
           {children}
         </ClaimLink>

--- a/ui/util/remark-lbry.ts
+++ b/ui/util/remark-lbry.ts
@@ -43,7 +43,10 @@ const BARE_LINK_DOMAINS = [
   'odysee.com',
 ];
 const bareDomainPattern = BARE_LINK_DOMAINS.map((d) => d.replace(/\./g, '\\.')).join('|');
-const bareLinkRegex = new RegExp(`(?:^|(?<=\\s))((?:https?://)?(?:${bareDomainPattern})(?:/[^\\s]*)?)`, 'i');
+const bareLinkRegex = new RegExp(
+  `(?:^|(?<=\\s))((?:(?:https?://|www\\.)[^\\s<>"']+|(?:https?://)?(?:${bareDomainPattern})(?:/[^\\s<>"']*)?))`,
+  'i'
+);
 export const punctuationMarks = [',', '.', '!', '?', ':', ';', '-', ']', ')', '}'];
 const mentionToken = '@';
 const invalidRegex = /[-_.+=?!@#$%^&*:;,{}<>\w/\\]/;


### PR DESCRIPTION
## Fixes

Issue Number:

## What is the current behavior?

Pasted links in comments can appear as plain text instead of clickable links, especially for regular `http://`, `https://`, or `www.` 

  ## What is the new behavior?

Comments now auto-link pasted `http://`, `https://`, and `www.` URLs so they render as clickable links through the existing markdown/comment link renderer.

## Other information

## PR Checklist

  <details><summary>Toggle...</summary>

What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>