### PR TITLE
Omit invalid Arweave purchase validity

### DIFF
--- a/ui/redux/actions/wallet.ts
+++ b/ui/redux/actions/wallet.ts
@@ -955,6 +955,8 @@ export const doPurchaseClaimForUri =
 
     const amountToUse = itsARental ? rentTipAmount : tipAmount;
     const expirationTime = itsARental ? tags.rentalTag.expirationTimeInSeconds : undefined;
+    const validityParams =
+      Number.isInteger(expirationTime) && expirationTime >= 0 ? { validity_seconds: expirationTime } : {};
     // if ()
     const isV2 = true;
 
@@ -982,7 +984,7 @@ export const doPurchaseClaimForUri =
             source_claim_id: claim.claim_id,
             target_claim_id: claim.claim_id,
             type: transactionType,
-            validity_seconds: expirationTime,
+            ...validityParams,
             receiver_address: arweaveTipData.address,
             sender_address: source_payment_address,
             v2: true,
@@ -1019,7 +1021,7 @@ export const doPurchaseClaimForUri =
             source_claim_id: claim.claim_id,
             target_claim_id: claim.claim_id,
             type: transactionType,
-            validity_seconds: expirationTime,
+            ...validityParams,
             receiver_address: arweaveTipData.address,
             sender_address: source_payment_address,
             token: reference_token,
@@ -1083,7 +1085,7 @@ export const doPurchaseClaimForUri =
         source_claim_id: claim.claim_id,
         target_claim_id: claim.claim_id,
         type: transactionType,
-        validity_seconds: expirationTime,
+        ...validityParams,
       },
       'post'
     )


### PR DESCRIPTION
## Fixes

## What is the current behavior?

Arweave paid-content purchases can fail with `validity_seconds: must be an unsigned integer` because purchase/preorder requests include `validity_seconds` even when there is no rental duration.

## What is the new behavior?

`validity_seconds` is only sent when the content purchase is a rental and the rental duration is a valid unsigned integer. Purchase and preorder requests omit the field.

## Other information

This keeps rental behavior intact while preventing invalid `validity_seconds` values from being sent for non-rental Arweave purchases.

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved purchase claim transaction processing with refined expiration time parameter validation, ensuring transaction requests accurately include relevant expiration information only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->