### PR TITLE
Fix wallet password sync redirect

### DIFF
--- a/ui/component/app/view.tsx
+++ b/ui/component/app/view.tsx
@@ -36,8 +36,8 @@ import { useIsMobile } from 'effects/use-screensize';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from 'redux/hooks';
 import {
-  selectGetSyncErrorMessage,
   selectPrefsReady,
+  selectSyncApplyPasswordError,
   selectSyncFatalError,
   selectSyncIsLocked,
 } from 'redux/selectors/sync';
@@ -209,7 +209,7 @@ function App() {
   const languages = useAppSelector(selectLoadedLanguages);
   const reloadRequired = useAppSelector((state) => state.app.reloadRequired);
   const prefsReady = useAppSelector(selectPrefsReady);
-  const syncError = useAppSelector(selectGetSyncErrorMessage);
+  const syncApplyPasswordError = useAppSelector(selectSyncApplyPasswordError);
   const syncIsLocked = useAppSelector(selectSyncIsLocked);
   const uploadCount = useAppSelector(selectUploadCount);
   const isAuthenticated = useAppSelector(selectUserVerifiedEmail);
@@ -642,10 +642,10 @@ function App() {
   }, [dispatch, hasSignedIn, hasVerifiedEmail]);
   useEffect(() => {
     if (embedPath) return;
-    if (syncError && isAuthenticated && !pathname.includes(PAGES.AUTH_WALLET_PASSWORD) && !currentModal) {
+    if (syncApplyPasswordError && isAuthenticated && !pathname.includes(PAGES.AUTH_WALLET_PASSWORD) && !currentModal) {
       navigate(`/$/${PAGES.AUTH_WALLET_PASSWORD}?redirect=${pathname}`);
     } // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [syncError, pathname, isAuthenticated, navigate]);
+  }, [syncApplyPasswordError, pathname, isAuthenticated, navigate]);
   useEffect(() => {
     if (embedPath) return;
     if (prefsReady && isAuthenticated && (pathname === '/' || pathname === `/$/${PAGES.HELP}`) && announcement !== '') {

--- a/ui/redux/reducers/sync.ts
+++ b/ui/redux/reducers/sync.ts
@@ -40,6 +40,7 @@ reducers[ACTIONS.GET_SYNC_STARTED] = (state: SyncState) =>
   Object.assign({}, state, {
     getSyncIsPending: true,
     getSyncErrorMessage: null,
+    syncApplyPasswordError: false,
   });
 
 reducers[ACTIONS.SET_SYNC_LOCK] = (state: SyncState, action: any) =>


### PR DESCRIPTION
## Fixes

## What is the current behavior?

Signed-in users can be redirected to the wallet password screen after a generic wallet sync error, even when the error is not actually a wallet-password failure. Users without a wallet password can get stuck because no password works.

## What is the new behavior?

The wallet password screen is only shown when sync reports the specific wallet password error state. Generic sync errors no longer force signed-in users into the wallet password route.

## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated wallet password redirect flow to improve error detection accuracy when prompting for password re-entry during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->