### PR TITLE
Security: Arbitrary local file read via tempfile endpoint path traversal

### DIFF
--- a/web/src/tempfile.js
+++ b/web/src/tempfile.js
@@ -4,7 +4,31 @@ const path = require('path');
 
 async function getTempFile(ctx) {
   const filename = ctx.params.filename;
-  return fs.readFileSync(path.join(__dirname, `/../dist/${filename}`), 'utf8');
+  let decodedFilename;
+
+  if (typeof filename !== 'string') {
+    ctx.throw(400, 'Invalid filename');
+  }
+
+  try {
+    decodedFilename = decodeURIComponent(filename);
+  } catch (error) {
+    ctx.throw(400, 'Invalid filename');
+  }
+
+  const distPath = path.resolve(__dirname, '../dist');
+  const filePath = path.resolve(distPath, decodedFilename);
+
+  if (
+    decodedFilename.includes('..') ||
+    decodedFilename.includes('/') ||
+    decodedFilename.includes('\\') ||
+    !filePath.startsWith(`${distPath}${path.sep}`)
+  ) {
+    ctx.throw(400, 'Invalid filename');
+  }
+
+  return fs.readFileSync(filePath, 'utf8');
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

Security: Arbitrary local file read via tempfile endpoint path traversal

## Problem

**Severity**: `Critical` | **File**: `web/src/tempfile.js:L5`

The `getTempFile` handler reads a file from `../dist/${filename}` using user-controlled `ctx.params.filename` without normalization or validation. Attackers may be able to supply path traversal sequences (for example `../../...`) to read arbitrary files accessible to the process, depending on routing and platform path resolution.

## Solution

Reject any filename containing path separators, `..`, or encoded traversal sequences. Resolve the final path with `path.resolve`, verify it stays within the intended directory, and use a fixed allowlist of generated artifact filenames when possible.

## Changes

- `web/src/tempfile.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file retrieval security by adding strict filename validation and sanitization.
  * Enhanced error handling for invalid or malformed input parameters.
  * Implemented protections against path traversal attacks to ensure secure file access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->