### PR TITLE
Preserve audio during upload optimization

### DIFF
--- a/ui/workers/upload-conversion-worker.ts
+++ b/ui/workers/upload-conversion-worker.ts
@@ -181,6 +181,45 @@ function assembleOutputBlob(writes: OutputWrite[]) {
   return new Blob(blobParts, { type: 'video/mp4' });
 }
 
+async function validateAudioPreserved(inputAudioTrackCount: number, outputFile: File) {
+  if (inputAudioTrackCount === 0) return;
+
+  let outputInput;
+
+  try {
+    outputInput = new Input({
+      formats: ALL_FORMATS,
+      source: new BlobSource(outputFile),
+    });
+
+    const outputAudioTrack = await outputInput.getPrimaryAudioTrack();
+    if (!outputAudioTrack) {
+      throw new Error('Audio track was lost during video conversion.');
+    }
+  } finally {
+    if (outputInput) {
+      outputInput.dispose();
+    }
+  }
+}
+
+async function getOptimizationAudioOptions(track: any, audioBitrate: number) {
+  const codec = track.codec;
+
+  if (codec === 'aac') {
+    return { forceTranscode: false };
+  }
+
+  if (await track.canDecode()) {
+    return {
+      codec: 'aac',
+      bitrate: audioBitrate,
+    };
+  }
+
+  throw new Error(`Audio track codec ${codec || 'unknown'} cannot be decoded for AAC optimization.`);
+}
+
 async function runManualPacketCopy(input: Input, output: Output, tracks: any[], _fileSize: number) {
   const startTimestamp = Math.max(await input.getFirstTimestamp(), 0);
   const trackProgress = new Map<number, number>();
@@ -496,14 +535,12 @@ self.addEventListener('message', async (e: MessageEvent) => {
         bitrate: options?.videoBitrate || 5_000_000,
         keyFrameInterval: 2,
       };
-      conversionOptions.audio = {
-        codec: 'aac',
-        bitrate: options?.audioBitrate || 128_000,
-      };
+      conversionOptions.audio = (track: any) => getOptimizationAudioOptions(track, options?.audioBitrate || 128_000);
     }
 
     const tracks = await input.getTracks();
     const avTracks = tracks.filter((track) => track.isVideoTrack() || track.isAudioTrack());
+    const inputAudioTrackCount = avTracks.filter((track) => track.isAudioTrack()).length;
 
     const canUseManualPacketCopy = type === 'convert' && avTracks.length > 0;
 
@@ -523,6 +560,7 @@ self.addEventListener('message', async (e: MessageEvent) => {
 
     const blob = assembleOutputBlob(writes);
     const outputFile = new File([blob], file.name.replace(/\.[^.]+$/, '.mp4'), { type: 'video/mp4' });
+    await validateAudioPreserved(inputAudioTrackCount, outputFile);
 
     self.postMessage({ type: 'done', file: outputFile }); // eslint-disable-line unicorn/require-post-message-target-origin
   } catch (err: any) {


### PR DESCRIPTION
## Fixes

  Issue Number:

  ## What is the current behavior?

  Upload optimization can drop the audio track from a video while still allowing the optimized file to continue through publish. This was reproduced with an MP4 whose source
  audio was already AAC, resulting in a published video with no audio.

  ## What is the new behavior?

  The optimization worker now preserves existing AAC audio without forcing an unnecessary audio transcode. For non-AAC audio, it only transcodes when the browser can decode
  the source track.

  The worker also validates the optimized output and fails conversion if an input with audio produces an output without audio.

  ## Other information

  Tested locally by uploading the affected video with optimization enabled. The newly uploaded video plays correctly with audio.

  Validation:
  - `corepack pnpm check`

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented audio preservation validation during file conversion to detect and prevent unintended audio track loss.

* **Improvements**
  * Optimized audio format conversion by intelligently handling already-optimized audio, reducing unnecessary processing and conversion time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->