### PR TITLE
fix rotated shorts detection

### DIFF
--- a/ui/component/shortsVideoPlayer/view.tsx
+++ b/ui/component/shortsVideoPlayer/view.tsx
@@ -75,6 +75,7 @@ const ShortsVideoPlayer = React.memo<Props>(
         <div className={`${SHORTS_PLAYER_WRAPPER_CLASS} ${primaryPlayerWrapperClass}`}>
           <VideoClaimInitiator
             uri={uri}
+            isShortsContext
             onSwipeNext={onSwipeNext}
             onSwipePrevious={onSwipePrevious}
             enableSwipe={enableSwipe}

--- a/ui/component/videoClaimInitiator/view.tsx
+++ b/ui/component/videoClaimInitiator/view.tsx
@@ -13,10 +13,11 @@ type Props = {
   uri: string;
   children?: any;
   streamClaim: () => void;
+  isShortsContext?: boolean;
 };
 
 const VideoClaimInitiator = (props: Props) => {
-  const { uri, children, streamClaim } = props;
+  const { uri, children, streamClaim, isShortsContext } = props;
   const dispatch = useAppDispatch();
   const mainPlayerDimensions = useAppSelector(selectMainPlayerDimensions);
   const playerRef = React.useCallback(
@@ -36,7 +37,7 @@ const VideoClaimInitiator = (props: Props) => {
     [dispatch, mainPlayerDimensions]
   );
   return (
-    <ClaimCoverRender uri={uri} onClick={streamClaim} passedRef={playerRef}>
+    <ClaimCoverRender uri={uri} onClick={streamClaim} passedRef={playerRef} isShortsContext={isShortsContext}>
       <Button className="button--icon button--play" onClick={streamClaim} iconSize={30} title={__('Play')} />
       {children}
     </ClaimCoverRender>

--- a/ui/hocs/withStreamClaimRender/view.tsx
+++ b/ui/hocs/withStreamClaimRender/view.tsx
@@ -342,6 +342,7 @@ const withStreamClaimRender = (StreamClaimComponent: FunctionalComponentParam) =
         source: undefined,
         sourceId: claimLinkId,
         commentId: undefined,
+        isShort: isShortsContext ? true : undefined,
       };
       let check = playingOptions.uri === currentStreamingUri;
 

--- a/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/view.tsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/view.tsx
@@ -24,7 +24,6 @@ import {
   doSetContentHistoryItem as doSetContentHistoryItemAction,
   doSetPrimaryUri as doSetPrimaryUriAction,
 } from 'redux/actions/content';
-import { doFileGetForUri as doFileGetForUriAction } from 'redux/actions/file';
 import {
   selectClaimIsNsfwForUri,
   selectClaimForUri,
@@ -36,7 +35,6 @@ import {
 } from 'redux/selectors/claims';
 import { selectBlackListedDataForUri, selectFilteredDataForUri } from 'lbryinc';
 import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
-import { makeSelectFileInfoForUri } from 'redux/selectors/file_info';
 import { selectCommentsListTitleForUri, selectCommentsDisabledSettingForChannelId } from 'redux/selectors/comments';
 import { doToggleAppDrawer as doToggleAppDrawerAction } from 'redux/actions/app';
 import { selectClientSetting } from 'redux/selectors/settings';
@@ -125,25 +123,6 @@ function filteredInfo() {
   );
 }
 
-function isShortVideoMetadata(video: { duration?: number; height?: number; width?: number } | null | undefined) {
-  if (!video) return false;
-
-  const duration = Number(video.duration);
-  const width = Number(video.width);
-  const height = Number(video.height);
-
-  return (
-    Number.isFinite(duration) &&
-    duration > 0 &&
-    duration <= SETTINGS.SHORTS_DURATION_LTE &&
-    Number.isFinite(width) &&
-    width > 0 &&
-    Number.isFinite(height) &&
-    height > 0 &&
-    width / height <= SETTINGS.SHORTS_ASPECT_RATIO_LTE
-  );
-}
-
 function DeferredRecommendedContent({ uri, skipWait }: { uri: string; skipWait?: boolean }) {
   const content = (
     <React.Suspense fallback={null}>
@@ -176,7 +155,6 @@ const StreamClaimPage = (props: Props) => {
   const thumbnail = useAppSelector((state) => selectThumbnailForUri(state, uri));
   const isMature = useAppSelector((state) => selectClaimIsNsfwForUri(state, uri));
   const renderMode = useAppSelector((state) => makeSelectFileRenderModeForUri(uri)(state));
-  const fileInfo = useAppSelector((state) => makeSelectFileInfoForUri(uri)(state));
   const commentsDisabledTag = useAppSelector((state) =>
     makeSelectTagInClaimOrChannelForUri(uri, TAGS.DISABLE_COMMENTS_TAG)(state)
   );
@@ -207,78 +185,7 @@ const StreamClaimPage = (props: Props) => {
   const collectionSidebarId = urlParams.get(COLLECTIONS_CONSTS.COLLECTION_ID);
   const disableShortsView = !!collectionSidebarId || disableShortsViewSetting;
   const shortsView = urlParams.get('view') === 'shorts';
-  const claimVideo = claim?.value?.video;
-  const shouldProbeShortVideo =
-    !isClaimShortValue &&
-    !disableShortsView &&
-    Boolean(claimVideo?.duration && claimVideo.duration <= SETTINGS.SHORTS_DURATION_LTE);
-  const [probedShortVideo, setProbedShortVideo] = React.useState<boolean | null>(null);
-  const isShortVideo = Boolean((isClaimShortValue || probedShortVideo) && !disableShortsView);
-
-  React.useEffect(() => {
-    setProbedShortVideo(null);
-  }, [uri]);
-
-  React.useEffect(() => {
-    if (!shouldProbeShortVideo) {
-      setProbedShortVideo(null);
-      return;
-    }
-
-    const fileInfoVideo = fileInfo?.metadata?.video;
-    if (isShortVideoMetadata(fileInfoVideo)) {
-      setProbedShortVideo(true);
-      return;
-    }
-
-    const streamingUrl = fileInfo?.streaming_url;
-    if (!streamingUrl) {
-      dispatch(doFileGetForUriAction(uri));
-      return;
-    }
-
-    let cancelled = false;
-    const video = document.createElement('video');
-
-    const cleanup = () => {
-      video.removeAttribute('src');
-      video.load();
-    };
-
-    const onLoadedMetadata = () => {
-      if (cancelled) return;
-
-      setProbedShortVideo(
-        isShortVideoMetadata({
-          duration: video.duration,
-          width: video.videoWidth,
-          height: video.videoHeight,
-        })
-      );
-      cleanup();
-    };
-
-    const onError = () => {
-      if (cancelled) return;
-      setProbedShortVideo(false);
-      cleanup();
-    };
-
-    video.preload = 'metadata';
-    video.muted = true;
-    video.playsInline = true;
-    video.addEventListener('loadedmetadata', onLoadedMetadata, { once: true });
-    video.addEventListener('error', onError, { once: true });
-    video.src = streamingUrl;
-
-    return () => {
-      cancelled = true;
-      video.removeEventListener('loadedmetadata', onLoadedMetadata);
-      video.removeEventListener('error', onError);
-      cleanup();
-    };
-  }, [dispatch, fileInfo, shouldProbeShortVideo, uri]);
-
+  const isShortVideo = isClaimShortValue && !disableShortsView;
   React.useEffect(() => {
     if ((linkedCommentId || threadCommentId) && isMobile) {
       doToggleAppDrawer(DRAWERS.CHAT);
@@ -287,7 +194,7 @@ const StreamClaimPage = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   React.useEffect(() => {
-    if (!isShortVideo && !shouldProbeShortVideo && shortsView) {
+    if (!isClaimShortValue && shortsView) {
       const urlParams = new URLSearchParams(search);
       urlParams.delete('view');
       const newSearch = urlParams.toString();
@@ -296,7 +203,7 @@ const StreamClaimPage = (props: Props) => {
       window.history.replaceState({}, '', newUrl);
       window.location.reload();
     }
-  }, [isShortVideo, shouldProbeShortVideo, shortsView, search]);
+  }, [isClaimShortValue, shortsView, search]);
   React.useEffect(() => {
     const urlParams = new URLSearchParams(search);
 
@@ -335,10 +242,6 @@ const StreamClaimPage = (props: Props) => {
           <LivestreamPage uri={uri} accessStatus={accessStatus} />
         </React.Suspense>
       );
-    }
-
-    if (shouldProbeShortVideo && probedShortVideo === null) {
-      return null;
     }
 
     if (isShortVideo) {

--- a/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/view.tsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/view.tsx
@@ -24,6 +24,7 @@ import {
   doSetContentHistoryItem as doSetContentHistoryItemAction,
   doSetPrimaryUri as doSetPrimaryUriAction,
 } from 'redux/actions/content';
+import { doFileGetForUri as doFileGetForUriAction } from 'redux/actions/file';
 import {
   selectClaimIsNsfwForUri,
   selectClaimForUri,
@@ -35,6 +36,7 @@ import {
 } from 'redux/selectors/claims';
 import { selectBlackListedDataForUri, selectFilteredDataForUri } from 'lbryinc';
 import { makeSelectFileRenderModeForUri } from 'redux/selectors/content';
+import { makeSelectFileInfoForUri } from 'redux/selectors/file_info';
 import { selectCommentsListTitleForUri, selectCommentsDisabledSettingForChannelId } from 'redux/selectors/comments';
 import { doToggleAppDrawer as doToggleAppDrawerAction } from 'redux/actions/app';
 import { selectClientSetting } from 'redux/selectors/settings';
@@ -123,6 +125,25 @@ function filteredInfo() {
   );
 }
 
+function isShortVideoMetadata(video: { duration?: number; height?: number; width?: number } | null | undefined) {
+  if (!video) return false;
+
+  const duration = Number(video.duration);
+  const width = Number(video.width);
+  const height = Number(video.height);
+
+  return (
+    Number.isFinite(duration) &&
+    duration > 0 &&
+    duration <= SETTINGS.SHORTS_DURATION_LTE &&
+    Number.isFinite(width) &&
+    width > 0 &&
+    Number.isFinite(height) &&
+    height > 0 &&
+    width / height <= SETTINGS.SHORTS_ASPECT_RATIO_LTE
+  );
+}
+
 function DeferredRecommendedContent({ uri, skipWait }: { uri: string; skipWait?: boolean }) {
   const content = (
     <React.Suspense fallback={null}>
@@ -155,6 +176,7 @@ const StreamClaimPage = (props: Props) => {
   const thumbnail = useAppSelector((state) => selectThumbnailForUri(state, uri));
   const isMature = useAppSelector((state) => selectClaimIsNsfwForUri(state, uri));
   const renderMode = useAppSelector((state) => makeSelectFileRenderModeForUri(uri)(state));
+  const fileInfo = useAppSelector((state) => makeSelectFileInfoForUri(uri)(state));
   const commentsDisabledTag = useAppSelector((state) =>
     makeSelectTagInClaimOrChannelForUri(uri, TAGS.DISABLE_COMMENTS_TAG)(state)
   );
@@ -185,7 +207,78 @@ const StreamClaimPage = (props: Props) => {
   const collectionSidebarId = urlParams.get(COLLECTIONS_CONSTS.COLLECTION_ID);
   const disableShortsView = !!collectionSidebarId || disableShortsViewSetting;
   const shortsView = urlParams.get('view') === 'shorts';
-  const isShortVideo = isClaimShortValue && !disableShortsView;
+  const claimVideo = claim?.value?.video;
+  const shouldProbeShortVideo =
+    !isClaimShortValue &&
+    !disableShortsView &&
+    Boolean(claimVideo?.duration && claimVideo.duration <= SETTINGS.SHORTS_DURATION_LTE);
+  const [probedShortVideo, setProbedShortVideo] = React.useState<boolean | null>(null);
+  const isShortVideo = Boolean((isClaimShortValue || probedShortVideo) && !disableShortsView);
+
+  React.useEffect(() => {
+    setProbedShortVideo(null);
+  }, [uri]);
+
+  React.useEffect(() => {
+    if (!shouldProbeShortVideo) {
+      setProbedShortVideo(null);
+      return;
+    }
+
+    const fileInfoVideo = fileInfo?.metadata?.video;
+    if (isShortVideoMetadata(fileInfoVideo)) {
+      setProbedShortVideo(true);
+      return;
+    }
+
+    const streamingUrl = fileInfo?.streaming_url;
+    if (!streamingUrl) {
+      dispatch(doFileGetForUriAction(uri));
+      return;
+    }
+
+    let cancelled = false;
+    const video = document.createElement('video');
+
+    const cleanup = () => {
+      video.removeAttribute('src');
+      video.load();
+    };
+
+    const onLoadedMetadata = () => {
+      if (cancelled) return;
+
+      setProbedShortVideo(
+        isShortVideoMetadata({
+          duration: video.duration,
+          width: video.videoWidth,
+          height: video.videoHeight,
+        })
+      );
+      cleanup();
+    };
+
+    const onError = () => {
+      if (cancelled) return;
+      setProbedShortVideo(false);
+      cleanup();
+    };
+
+    video.preload = 'metadata';
+    video.muted = true;
+    video.playsInline = true;
+    video.addEventListener('loadedmetadata', onLoadedMetadata, { once: true });
+    video.addEventListener('error', onError, { once: true });
+    video.src = streamingUrl;
+
+    return () => {
+      cancelled = true;
+      video.removeEventListener('loadedmetadata', onLoadedMetadata);
+      video.removeEventListener('error', onError);
+      cleanup();
+    };
+  }, [dispatch, fileInfo, shouldProbeShortVideo, uri]);
+
   React.useEffect(() => {
     if ((linkedCommentId || threadCommentId) && isMobile) {
       doToggleAppDrawer(DRAWERS.CHAT);
@@ -194,7 +287,7 @@ const StreamClaimPage = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   React.useEffect(() => {
-    if (!isClaimShortValue && shortsView) {
+    if (!isShortVideo && !shouldProbeShortVideo && shortsView) {
       const urlParams = new URLSearchParams(search);
       urlParams.delete('view');
       const newSearch = urlParams.toString();
@@ -203,7 +296,7 @@ const StreamClaimPage = (props: Props) => {
       window.history.replaceState({}, '', newUrl);
       window.location.reload();
     }
-  }, [isClaimShortValue, shortsView, search]);
+  }, [isShortVideo, shouldProbeShortVideo, shortsView, search]);
   React.useEffect(() => {
     const urlParams = new URLSearchParams(search);
 
@@ -242,6 +335,10 @@ const StreamClaimPage = (props: Props) => {
           <LivestreamPage uri={uri} accessStatus={accessStatus} />
         </React.Suspense>
       );
+    }
+
+    if (shouldProbeShortVideo && probedShortVideo === null) {
+      return null;
     }
 
     if (isShortVideo) {

--- a/ui/redux/actions/content.ts
+++ b/ui/redux/actions/content.ts
@@ -188,7 +188,7 @@ export const doStartFloatingPlayingUri =
     const canStartloatingPlayer = !isMature && isPlayable && (!isLivestreamClaim || isLive);
     const shortData = claim
       ? {
-          isShort: isClaimShort(claim),
+          isShort: typeof playingOptions.isShort === 'boolean' ? playingOptions.isShort : isClaimShort(claim),
         }
       : {};
     if (!canStartloatingPlayer) return;


### PR DESCRIPTION
## Fixes

## What is the current behavior?

  Some short portrait videos open in the standard video page instead of Shorts. This can happen when stored claim     metadata is missing display dimensions or reports encoded rotated dimensions, causing `isClaimShort` to return false.

  ## What is the new behavior?

  For short-duration video claims that fail the stored metadata Shorts check, the stream page fetches file info and probes the actual playback metadata from the streaming URL.

  If the playback dimensions are vertical, the claim is rendered with `ShortsPage`. Shorts context is also preserved when starting playback so the player uses the Shorts layout instead of falling back to the claim’s landscape metadata.

  ## Other information

  Tested locally with a 39s phone video encoded as `1920x1080` with rotation metadata but displayed as `1080x1920`; the page now opens and plays correctly in Shorts view.

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Shorts-specific handling so short videos can be detected more reliably and shown in the correct viewing experience.
  * Added support for passing Shorts context through video playback and claim rendering flows.

* **Bug Fixes**
  * Playback state now preserves explicit short-video settings when available, instead of always deriving them from the claim alone.
  * Short-video rendering now waits for metadata checks before choosing between Shorts and standard video playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->