### PR TITLE
Fix Odysee comment links

### DIFF
--- a/ui/component/claimLink/view.tsx
+++ b/ui/component/claimLink/view.tsx
@@ -49,7 +49,9 @@ const ClaimLink = (props: Props) => {
     return <span>{children}</span>;
   }
 
-  if (!claim) return null;
+  if (!claim) {
+    return <Button button="link" label={children} className="button--external-link" navigate={uri} />;
+  }
   const { value_type: valueType } = claim;
   const isChannel = valueType === 'channel';
 

--- a/ui/component/comment/view.tsx
+++ b/ui/component/comment/view.tsx
@@ -530,6 +530,7 @@ function CommentView(props: Props) {
                         parentCommentId={commentId}
                         stakedLevel={stakedLevel}
                         hasMembership={Boolean(odyseeMembership)}
+                        isComment
                       />
                     </Expandable>
                   )}

--- a/ui/component/common/markdown-preview.tsx
+++ b/ui/component/common/markdown-preview.tsx
@@ -23,6 +23,8 @@ import ZoomableImage from 'component/zoomableImage';
 const RE_EMOTE = /:\+1:|:-1:|:[\w-]+:/;
 const RE_STANDALONE_HTML_BREAK = /^\s*<br\s*\/?>\s*$/i;
 const RE_FENCED_CODE = /^\s*(```|~~~)/;
+const RE_BARE_HTTP_LINK = /(^|[\s([])((?:https?:\/\/|www\.)[^\s<>"]+)/gi;
+const TRAILING_LINK_PUNCTUATION = ".,;:!?'";
 
 function isEmote(title, src) {
   return (
@@ -67,6 +69,35 @@ function normalizeStandaloneHtmlBreaks(content: string) {
   });
 
   return normalizedLines.join('\n');
+}
+
+function stripTrailingLinkPunctuation(url: string) {
+  let end = url.length;
+
+  while (end > 0 && TRAILING_LINK_PUNCTUATION.includes(url.charAt(end - 1))) {
+    end--;
+  }
+
+  return {
+    link: url.slice(0, end),
+    trailing: url.slice(end),
+  };
+}
+
+function protectBareHttpLinks(content: string) {
+  return content.replace(RE_BARE_HTTP_LINK, (match, prefix, rawUrl) => {
+    if (prefix === '<') {
+      return match;
+    }
+
+    const { link, trailing } = stripTrailingLinkPunctuation(rawUrl);
+
+    if (!link) {
+      return match;
+    }
+
+    return `${prefix}<${link}>${trailing}`;
+  });
 }
 
 type SimpleTextProps = {
@@ -248,8 +279,9 @@ export default React.memo<MarkdownProps>(function MarkdownPreview(props: Markdow
   }
 
   const normalizedContent = typeof content === 'string' ? normalizeStandaloneHtmlBreaks(content) : content;
-  const strippedContent = normalizedContent
-    ? normalizedContent.replace(REPLACE_REGEX, (iframeHtml, iframeUrl) => {
+  const linkProtectedContent = typeof normalizedContent === 'string' ? protectBareHttpLinks(normalizedContent) : '';
+  const strippedContent = linkProtectedContent
+    ? linkProtectedContent.replace(REPLACE_REGEX, (iframeHtml, iframeUrl) => {
         if (platform.isSafari()) {
           return iframeUrl;
         }

--- a/ui/component/markdownLink/view.tsx
+++ b/ui/component/markdownLink/view.tsx
@@ -26,6 +26,20 @@ function isMe(claim, title) {
   return claim && title && claim.replace('#', ':') === title;
 }
 
+function getLbryUrlFromKnownAppLink(linkPathPlusHash: string, search: string = ''): string | undefined {
+  const candidate = `lbry://${linkPathPlusHash}${search}`;
+
+  if (isURIValid(candidate)) {
+    return candidate;
+  }
+
+  const legacyCandidate = `lbry://${linkPathPlusHash.replace(/:/g, '#')}${search}`;
+
+  if (legacyCandidate !== candidate && isURIValid(legacyCandidate)) {
+    return legacyCandidate;
+  }
+}
+
 function MarkdownLink(props: Props) {
   const {
     children,
@@ -87,13 +101,12 @@ function MarkdownLink(props: Props) {
 
       const linkPathPlusHash = linkPathname ? `${linkPathname}${linkUrlObject.hash}` : undefined;
       const possibleLbryUrl = linkPathPlusHash
-        ? `lbry://${linkPathPlusHash.replace(/:/g, '#')}${linkUrlObject.search}`
+        ? getLbryUrlFromKnownAppLink(linkPathPlusHash, linkUrlObject.search)
         : undefined;
-      const lbryLinkIsValid = possibleLbryUrl && isURIValid(possibleLbryUrl);
       const isMarkdownLinkWithLabel =
         children && Array.isArray(children) && React.Children.count(children) === 1 && children.toString() !== href;
 
-      if (lbryLinkIsValid && !isMarkdownLinkWithLabel) {
+      if (possibleLbryUrl && !isMarkdownLinkWithLabel && !isComment) {
         lbryUrlFromLink = possibleLbryUrl;
       }
     }

--- a/ui/util/remark-lbry.ts
+++ b/ui/util/remark-lbry.ts
@@ -44,7 +44,7 @@ const BARE_LINK_DOMAINS = [
 ];
 const bareDomainPattern = BARE_LINK_DOMAINS.map((d) => d.replace(/\./g, '\\.')).join('|');
 const bareLinkRegex = new RegExp(
-  `(?:^|(?<=\\s))((?:(?:https?://|www\\.)[^\\s<>"']+|(?:https?://)?(?:${bareDomainPattern})(?:/[^\\s<>"']*)?))`,
+  `(?:^|(?<=\\s))((?:(?:https?://|www\\.)[^\\s<>"]+|(?:https?://)?(?:${bareDomainPattern})(?:/[^\\s<>"]*)?))`,
   'i'
 );
 export const punctuationMarks = [',', '.', '!', '?', ':', ';', '-', ']', ')', '}'];
@@ -91,7 +91,7 @@ const TRAILING_PAIRS: Array<[string, string]> = [
   ['[', ']'],
   ['{', '}'],
 ];
-const TRAILING_PUNCTUATION = '.,;:!?';
+const TRAILING_PUNCTUATION = ".,;:!?'";
 
 // Strip trailing punctuation from a bare URL, but keep paired brackets balanced
 // so links like https://en.wikipedia.org/wiki/Mark_Levine_(disambiguation) survive.


### PR DESCRIPTION
 ## Fixes

  Issue Number:

  ## What is the current behavior?

  Some bare Odysee links in comments are not rendered correctly. URLs containing apostrophes, underscores, or `:` claim modifiers can be truncated, parsed as markdown emphasis, fail to become links, or cause later comment text to disappear when converted into inline claim previews.

  ## What is the new behavior?

  Bare HTTP Odysee links in comments are preserved as full clickable links. The markdown parser now protects bare HTTP links before parsing so underscores inside URLs are not treated as emphasis, and Odysee app-link conversion preserves valid `:` claim modifiers.

  ## Other information

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External links now remain clickable in more cases, even when a claim isn’t yet available.
  * Markdown previews handle plain web links more reliably, including links followed by punctuation or apostrophes.

* **Bug Fixes**
  * Improved conversion of known app links into valid app URLs.
  * Comment content now uses updated markdown handling for more consistent rendering.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->