### PR TITLE
Fix membership tier rename

### DIFF
--- a/ui/page/creatorMemberships/creatorArea/internal/tiersTab/internal/editingTier/view.tsx
+++ b/ui/page/creatorMemberships/creatorArea/internal/tiersTab/internal/editingTier/view.tsx
@@ -158,7 +158,6 @@ function MembershipEditTier(props: Props) {
       } else {
         // is edit
         const params: MembershipUpdateTierParams = {
-          id: membership.id,
           new_name: editTierParams.editTierName,
           new_description: editTierParams.editTierDescription,
           new_amount: price,

--- a/ui/redux/actions/memberships.ts
+++ b/ui/redux/actions/memberships.ts
@@ -26,6 +26,23 @@ import { doChannelsHavePremium } from './user';
 const stripeEnvironment = getStripeEnvironment();
 const USD_TO_USDC = 1000000;
 const CONVERT_DOLLARS_TO_PENNIES = 100;
+function getMembershipTierError(error) {
+  const message = error?.message || error;
+
+  if (
+    typeof message === 'string' &&
+    (message.match(/membership already exists for this channel/i) ||
+      message.match(/prior \(even deleted memberships\)/i) ||
+      message.match(/Duplicate entry.*membership_v2\.idx_user_publish_name_unique/i))
+  ) {
+    return __(
+      'This tier name has already been used for this channel. Deleted tier names cannot currently be reused, so please choose a different tier name.'
+    );
+  }
+
+  return message;
+}
+
 export const doFetchChannelMembershipsForChannelIds =
   (channelId: string, channelIds: ClaimIds) => async (dispatch: Dispatch, getState: GetState) => {
     if (!channelIds || channelIds.length === 0) return;
@@ -387,7 +404,7 @@ export const doMembershipAddTier = (params: MembershipAddTierParams) => async (d
     }))
     .catch((e) => {
       return {
-        error: e?.message || e,
+        error: getMembershipTierError(e),
       };
     });
 export const doMembershipUpdateTier = (params: MembershipUpdateTierParams) => async (dispatch: Dispatch) =>
@@ -397,7 +414,7 @@ export const doMembershipUpdateTier = (params: MembershipUpdateTierParams) => as
     }))
     .catch((e) => {
       return {
-        error: e?.message || e,
+        error: getMembershipTierError(e),
       };
     });
 export const doGetMembershipPerks = (params: MembershipListParams) => async (dispatch: Dispatch) =>

--- a/ui/types/membership.d.ts
+++ b/ui/types/membership.d.ts
@@ -57,16 +57,23 @@ type MembershipCreateResponse = {
 };
 
 type MembershipUpdateTierParams = {
-  id: string;
-  name?: string;
-  description?: string;
-  price?: { amount: number; currency: string };
-  perks?: Array<string>;
+  membership_id: string;
+  new_name?: string;
+  new_description?: string;
+  new_amount?: number;
+  new_members_only_chat_enabled?: boolean;
   [key: string]: any;
 };
 
-type MembershipAddTierParams = Omit<MembershipUpdateTierParams, 'id'> & {
+type MembershipAddTierParams = {
   channel_id: string;
+  name: string;
+  description: string;
+  amount: number;
+  currency: string;
+  perks: string;
+  frequency: string;
+  payment_address?: string;
 };
 
 type MembershipBuyParams = {


### PR DESCRIPTION
## Fixes

  Issue Number:

  ## What is the current behavior?

  Editing an existing membership tier can fail with `Extraneous params: id` because the frontend sends an unsupported `id` field to `membership_v2/update`.

  When a creator tries to recreate a deleted tier name, the backend rejects it, but the error message does not clearly explain that deleted tier names cannot currently be
  reused.

  ## What is the new behavior?

  Membership tier updates no longer send the unsupported `id` parameter.

  Duplicate tier-name failures now show a clearer message explaining that the tier name has already been used for the channel and deleted tier names cannot currently be
  reused.

  ## Other information

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>