### PR TITLE
fix markdown link punctuation

### DIFF
--- a/ui/component/common/markdown-preview.tsx
+++ b/ui/component/common/markdown-preview.tsx
@@ -23,8 +23,13 @@ import ZoomableImage from 'component/zoomableImage';
 const RE_EMOTE = /:\+1:|:-1:|:[\w-]+:/;
 const RE_STANDALONE_HTML_BREAK = /^\s*<br\s*\/?>\s*$/i;
 const RE_FENCED_CODE = /^\s*(```|~~~)/;
-const RE_BARE_HTTP_LINK = /(^|[\s([])((?:https?:\/\/|www\.)[^\s<>"]+)/gi;
+const RE_BARE_HTTP_LINK = /(^|[\s([])((?:https?:\/\/)[^\s<>"]+)/gi;
 const TRAILING_LINK_PUNCTUATION = ".,;:!?'";
+const TRAILING_LINK_PAIRS: Array<[string, string]> = [
+  ['(', ')'],
+  ['[', ']'],
+  ['{', '}'],
+];
 
 function isEmote(title, src) {
   return (
@@ -74,8 +79,32 @@ function normalizeStandaloneHtmlBreaks(content: string) {
 function stripTrailingLinkPunctuation(url: string) {
   let end = url.length;
 
-  while (end > 0 && TRAILING_LINK_PUNCTUATION.includes(url.charAt(end - 1))) {
-    end--;
+  while (end > 0) {
+    const last = url.charAt(end - 1);
+
+    if (TRAILING_LINK_PUNCTUATION.includes(last)) {
+      end--;
+      continue;
+    }
+
+    const pair = TRAILING_LINK_PAIRS.find(([, close]) => close === last);
+    if (pair) {
+      const slice = url.slice(0, end);
+      let opens = 0;
+      let closes = 0;
+
+      for (let i = 0; i < slice.length; i++) {
+        if (slice[i] === pair[0]) opens++;
+        else if (slice[i] === pair[1]) closes++;
+      }
+
+      if (closes > opens) {
+        end--;
+        continue;
+      }
+    }
+
+    break;
   }
 
   return {


### PR DESCRIPTION
## Fixes

  ## What is the current behavior?

  Bare HTTP link protection can interfere with existing Markdown links. Links like `[Title](https://...)` or `[Title](\nhttps://...)` may render incorrectly when the URL is
  wrapped as an autolink and the closing Markdown delimiter is included in the href. Scheme-less `www.` links can also be wrapped as invalid CommonMark autolinks and render as
  plain text.

  ## What is the new behavior?

  Bare HTTP links preserve surrounding punctuation correctly, so Markdown links, image destinations, and parenthesized URLs render with the expected href. Scheme-less `www.`
  links are left for the existing link formatter instead of being wrapped as invalid autolinks.

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown link handling so auto-link detection is more accurate.
  * URLs now require `http://` or `https://` to be matched, reducing unintended linkification.
  * Trailing punctuation is now trimmed more reliably, including cases with nested or unmatched closing brackets and parentheses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->