### PR TITLE
Fix rotated shorts channel listing

### DIFF
--- a/ui/component/claimPreviewTile/view.tsx
+++ b/ui/component/claimPreviewTile/view.tsx
@@ -43,6 +43,7 @@ import {
 } from 'redux/selectors/claims';
 import { doFileGetForUri } from 'redux/actions/file';
 import { selectViewCountForUri, selectBanStateForUri } from 'lbryinc';
+import Lbry from 'lbry';
 import { selectStreamingUrlForUri } from 'redux/selectors/file_info';
 import { selectIsActiveLivestreamForUri } from 'redux/selectors/livestream';
 import { selectShowMatureContent, selectClientSetting } from 'redux/selectors/settings';
@@ -62,6 +63,61 @@ type Props = {
   isShortFromChannelPage?: boolean;
   sectionTitle?: HomepageTitles;
 };
+
+function isShortVideoMetadata(video: { duration?: number; height?: number; width?: number } | null | undefined) {
+  if (!video) return false;
+
+  const duration = Number(video.duration);
+  const width = Number(video.width);
+  const height = Number(video.height);
+
+  return (
+    Number.isFinite(duration) &&
+    duration > 0 &&
+    duration <= SETTINGS.SHORTS_DURATION_LTE &&
+    Number.isFinite(width) &&
+    width > 0 &&
+    Number.isFinite(height) &&
+    height > 0 &&
+    width / height <= SETTINGS.SHORTS_ASPECT_RATIO_LTE
+  );
+}
+
+function probeShortVideoFromUrl(streamingUrl: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const video = document.createElement('video');
+
+    const cleanup = () => {
+      video.removeAttribute('src');
+      video.load();
+    };
+
+    const finish = (isShortVideo: boolean) => {
+      cleanup();
+      resolve(isShortVideo);
+    };
+
+    video.preload = 'metadata';
+    video.playsInline = true;
+    video.muted = true;
+    video.addEventListener(
+      'loadedmetadata',
+      () => {
+        finish(
+          isShortVideoMetadata({
+            duration: video.duration,
+            width: video.videoWidth,
+            height: video.videoHeight,
+          })
+        );
+      },
+      { once: true }
+    );
+    video.addEventListener('error', () => finish(true), { once: true });
+    video.src = streamingUrl;
+    video.load();
+  });
+}
 
 // preview image cards used in related video functionality, channel overview page and homepage
 function ClaimPreviewTile(props: Props) {
@@ -126,7 +182,15 @@ function ClaimPreviewTile(props: Props) {
   const repostedContentUri = claim && (claim.reposted_claim ? claim.reposted_claim.permanent_url : claim.permanent_url);
   const listId = collectionId || collectionClaimId || '';
   const isClaimShortValue = Boolean(claim && isClaimShort(claim));
-  const isShortsSection = Boolean(isShortFromChannelPage || sectionTitle === 'Shorts');
+  const claimVideo = claim?.value?.video;
+  const shouldProbeChannelShort =
+    Boolean(isShortFromChannelPage && isStream && !isClaimShortValue) &&
+    Boolean(claimVideo?.duration && claimVideo.duration <= SETTINGS.SHORTS_DURATION_LTE);
+  const [probedChannelShort, setProbedChannelShort] = React.useState<boolean | null>(null);
+  const isProbedChannelShort = shouldProbeChannelShort && probedChannelShort === true;
+  const isShortsSection = Boolean(
+    isProbedChannelShort || (!shouldProbeChannelShort && isShortFromChannelPage) || sectionTitle === 'Shorts'
+  );
   const shouldUseShortsView = !disableShortsView && (isClaimShortValue || isShortsSection);
   const hasListSearchParams = Boolean(listId);
   const shortsViewParam = shouldUseShortsView ? `${hasListSearchParams ? '&' : '?'}view=shorts` : '';
@@ -167,6 +231,55 @@ function ClaimPreviewTile(props: Props) {
   const useShortsThumb = isShortsSection || queryParams.get('view') === 'shortsTab';
   let shouldHide = false;
 
+  React.useEffect(() => {
+    setProbedChannelShort(null);
+  }, [uri]);
+
+  React.useEffect(() => {
+    if (!shouldProbeChannelShort || !uri) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const probe = async () => {
+      if (cancelled) return;
+
+      let url = streamingUrl;
+
+      if (!url) {
+        dispatch(doFileGetForUri(uri));
+
+        try {
+          const fileInfo = await Lbry.get({ uri });
+          url = fileInfo?.streaming_url;
+        } catch {
+          setProbedChannelShort(true);
+          return;
+        }
+      }
+
+      if (cancelled) return;
+
+      if (!url) {
+        setProbedChannelShort(true);
+        return;
+      }
+
+      const isShortVideo = await probeShortVideoFromUrl(url);
+
+      if (!cancelled) {
+        setProbedChannelShort(isShortVideo);
+      }
+    };
+
+    probe();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dispatch, shouldProbeChannelShort, streamingUrl, uri]);
+
   if (isMature && !showMature) {
     // Unfortunately needed until this is resolved
     // https://github.com/lbryio/lbry-sdk/issues/2785
@@ -183,6 +296,10 @@ function ClaimPreviewTile(props: Props) {
       banState.filtered ||
       (!showHiddenByUser && (banState.muted || banState.blocked)) ||
       (isAbandoned && !showUnresolvedClaims);
+  }
+
+  if (!shouldHide && shouldProbeChannelShort && !isProbedChannelShort) {
+    shouldHide = true;
   }
 
   // Filter empty reposts

--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/view.tsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/view.tsx
@@ -82,6 +82,61 @@ type Props = {
   };
 };
 
+function isShortVideoMetadata(video: { duration?: number; height?: number; width?: number } | null | undefined) {
+  if (!video) return false;
+
+  const duration = Number(video.duration);
+  const width = Number(video.width);
+  const height = Number(video.height);
+
+  return (
+    Number.isFinite(duration) &&
+    duration > 0 &&
+    duration <= SETTINGS.SHORTS_DURATION_LTE &&
+    Number.isFinite(width) &&
+    width > 0 &&
+    Number.isFinite(height) &&
+    height > 0 &&
+    width / height <= SETTINGS.SHORTS_ASPECT_RATIO_LTE
+  );
+}
+
+function probeShortVideoFromUrl(streamingUrl: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const video = document.createElement('video');
+
+    const cleanup = () => {
+      video.removeAttribute('src');
+      video.load();
+    };
+
+    const finish = (isShort: boolean) => {
+      cleanup();
+      resolve(isShort);
+    };
+
+    video.preload = 'metadata';
+    video.playsInline = true;
+    video.muted = true;
+    video.addEventListener(
+      'loadedmetadata',
+      () => {
+        finish(
+          isShortVideoMetadata({
+            duration: video.duration,
+            width: video.videoWidth,
+            height: video.videoHeight,
+          })
+        );
+      },
+      { once: true }
+    );
+    video.addEventListener('error', () => finish(true), { once: true });
+    video.src = streamingUrl;
+    video.load();
+  });
+}
+
 function ChannelPage(props: Props) {
   const navigate = useNavigate();
   const { search, pathname } = useLocation();
@@ -206,20 +261,47 @@ function ChannelPage(props: Props) {
       setHasShorts(true);
     }
 
-    // Use claim_search instead of lighthouse to detect shorts
     Lbry.claim_search({
       channel_ids: [claimId],
-      page_size: 1,
+      page_size: 20,
       stream_types: ['video'],
       duration: `<=${SETTINGS.SHORTS_DURATION_LTE}`,
-      content_aspect_ratio: `<=${SETTINGS.SHORTS_ASPECT_RATIO_LTE}`,
       order_by: ['release_time'],
       no_totals: true,
     })
-      .then((result: any) => {
+      .then(async (result: any) => {
         if (!cancelled) {
           const items = result?.items || [];
-          setHasShorts(items.length > 0);
+          const hasIndexedShort = items.some((item: Claim) => isShortVideoMetadata((item?.value as any)?.video));
+
+          if (hasIndexedShort) {
+            setHasShorts(true);
+            return;
+          }
+
+          for (const item of items) {
+            if (cancelled) return;
+
+            try {
+              const fileInfo = await Lbry.get({
+                uri: item.canonical_url || item.permanent_url,
+              });
+
+              if (cancelled) return;
+
+              if (!fileInfo?.streaming_url || (await probeShortVideoFromUrl(fileInfo.streaming_url))) {
+                setHasShorts(true);
+                return;
+              }
+            } catch {
+              if (!cancelled) {
+                setHasShorts(true);
+              }
+              return;
+            }
+          }
+
+          setHasShorts(false);
         }
       })
       .catch(() => {


### PR DESCRIPTION
## Summary

- Detect channel Shorts tabs from short-duration video candidates instead of relying only on indexed aspect ratio.
- Probe candidate media metadata in the browser so rotated vertical uploads can appear in the channel Shorts tab.
- Hide channel Shorts tiles that are positively confirmed to be landscape, so short landscape videos do not leak into the Shorts tab.

## Root Cause

Some rotated/mobile Shorts are indexed with landscape dimensions such as `1920x1080`, while the browser reports the playable video as vertical. The channel Shorts tab detector used `content_aspect_ratio <= 0.8`, which excluded those rotated Shorts before the tab/list could render. Removing that filter alone let true short landscape videos leak into the Shorts tab.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Shorts on channel pages, including videos whose metadata is not immediately available.
  * Shorts sections now more reliably display eligible short-form videos and avoid showing unrelated content.
  * Improved handling of video loading errors during Shorts detection to provide more consistent channel page results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->