### PR TITLE
Fix shorts player transition state

### DIFF
--- a/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/internal/shorts/view.tsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/streamClaimPage/internal/shorts/view.tsx
@@ -42,6 +42,7 @@ import {
   selectPlayingCollectionId,
   selectIsUriCurrentlyPlaying,
   selectIsAutoplayCountdownForUri,
+  selectPlayingUri,
 } from 'redux/selectors/content';
 import { selectCommentsDisabledSettingForChannelId } from 'redux/selectors/comments';
 import { selectNoRestrictionOrUserIsMemberForContentClaimId } from 'redux/selectors/memberships';
@@ -149,6 +150,7 @@ export default function ShortsPage(props: Props) {
   const previousThumbnail = prevShortClaimValue?.value?.thumbnail?.url || null;
   const isMature = useAppSelector((state) => selectClaimIsNsfwForUri(state, uri));
   const isUriPlaying = useAppSelector((state) => selectIsUriCurrentlyPlaying(state, uri));
+  const playingUri = useAppSelector(selectPlayingUri);
   const playingCollectionId = useAppSelector(selectPlayingCollectionId);
   const position = useAppSelector((state) => selectContentPositionForUri(state, uri));
   const commentsDisabledTag = useAppSelector((state) =>
@@ -218,6 +220,15 @@ export default function ShortsPage(props: Props) {
   const isTransitioningRef = React.useRef(false);
   const processNextTransitionRef = React.useRef<any>(() => {});
   const finishTransitionRef = React.useRef<any>(() => {});
+
+  React.useEffect(() => {
+    const playingUrlParams = new URLSearchParams(playingUri.location?.search || '');
+    const playingFromShortsView = playingUrlParams.get('view') === 'shorts';
+
+    if (playingUri.uri && (!isUriPlaying || !playingFromShortsView)) {
+      dispatch(doClearPlayingUriAction());
+    }
+  }, [dispatch, isUriPlaying, playingUri.location?.search, playingUri.uri]);
   const hasPlaylist = shortsRecommendedUris && shortsRecommendedUris.length > 0;
   const isAtStart = currentIndex <= 0;
   const isAtEnd = currentIndex >= (shortsRecommendedUris?.length || 1) - 1;


### PR DESCRIPTION

  Issue Number:

  ## What is the current behavior?

  Opening a Shorts URL after playing a normal video can reuse stale normal-player state, causing the short to play inside the normal wide video player layout.

  ## What is the new behavior?

  Shorts pages clear stale playback state when the active player was not started from `?view=shorts`, so the short mounts in the correct Shorts player layout.


  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Shorts playback state handling by clearing stale playback selections when content is no longer playing or playback switches to another view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->