### PR TITLE
Add markdown Odysee embed opt out

### DIFF
--- a/ui/component/markdownLink/view.tsx
+++ b/ui/component/markdownLink/view.tsx
@@ -2,6 +2,7 @@ import { KNOWN_APP_DOMAINS } from 'config';
 import * as ICONS from 'constants/icons';
 import * as React from 'react';
 import { isURIValid } from 'util/lbryURI';
+import { isEmbedOptIn, isEmbedOptOut } from 'util/remark-lbry';
 import Button from 'component/button';
 import CommentMenuList from 'component/commentMenuList';
 import ChannelTitle from 'component/channelTitle';
@@ -65,6 +66,8 @@ function MarkdownLink(props: Props) {
   // Regex for url protocol
   const protocolRegex = new RegExp('^(https?|lbry|mailto)+:', 'i');
   const protocol = href ? protocolRegex.exec(href) : null;
+  const embedOptOut = isEmbedOptOut(href, title);
+  const embedOptIn = isEmbedOptIn(href, title);
   const isMention = href && href.startsWith('lbry://@');
   const mentionedMyChannel =
     isMention &&
@@ -106,7 +109,7 @@ function MarkdownLink(props: Props) {
       const isMarkdownLinkWithLabel =
         children && Array.isArray(children) && React.Children.count(children) === 1 && children.toString() !== href;
 
-      if (possibleLbryUrl && !isMarkdownLinkWithLabel && !isComment) {
+      if (possibleLbryUrl && !embedOptOut && (embedOptIn || (!isMarkdownLinkWithLabel && !isComment))) {
         lbryUrlFromLink = possibleLbryUrl;
       }
     }
@@ -155,7 +158,7 @@ function MarkdownLink(props: Props) {
         <ClaimLink
           uri={lbryUrlFromLink || decodedUri}
           parentCommentId={parentCommentId}
-          allowPreview={embed || allowPreview || allowKnownAppPreview}
+          allowPreview={!embedOptOut && (embed || embedOptIn || allowPreview || allowKnownAppPreview)}
         >
           {children}
         </ClaimLink>

--- a/ui/util/remark-lbry.ts
+++ b/ui/util/remark-lbry.ts
@@ -92,6 +92,55 @@ const TRAILING_PAIRS: Array<[string, string]> = [
   ['{', '}'],
 ];
 const TRAILING_PUNCTUATION = ".,;:!?'";
+const EMBED_OPT_OUT_VALUES = new Set(['0', 'false', 'no']);
+const EMBED_OPT_IN_VALUES = new Set(['1', 'true', 'yes']);
+
+function getLinkSearchParams(url: string): URLSearchParams | null {
+  const queryIndex = url.indexOf('?');
+  if (queryIndex < 0) {
+    return null;
+  }
+
+  const hashIndex = url.indexOf('#', queryIndex);
+  const query = url.slice(queryIndex + 1, hashIndex >= 0 ? hashIndex : undefined);
+  return new URLSearchParams(query);
+}
+
+export function isEmbedOptOut(url: string, title?: string | null): boolean {
+  const normalizedTitle = title?.trim().toLowerCase();
+  if (normalizedTitle === 'noembed' || normalizedTitle === 'no-embed') {
+    return true;
+  }
+
+  const params = getLinkSearchParams(url);
+  if (!params) {
+    return false;
+  }
+
+  const embed = params.get('embed');
+  const noEmbed = params.get('noembed');
+
+  return (
+    (embed !== null && EMBED_OPT_OUT_VALUES.has(embed.toLowerCase())) ||
+    (noEmbed !== null && !EMBED_OPT_OUT_VALUES.has(noEmbed.toLowerCase()))
+  );
+}
+
+export function isEmbedOptIn(url: string, title?: string | null): boolean {
+  const normalizedTitle = title?.trim().toLowerCase();
+  if (normalizedTitle === 'embed') {
+    return true;
+  }
+
+  const params = getLinkSearchParams(url);
+  if (!params) {
+    return false;
+  }
+
+  const embed = params.get('embed');
+
+  return embed !== null && EMBED_OPT_IN_VALUES.has(embed.toLowerCase());
+}
 
 // Strip trailing punctuation from a bare URL, but keep paired brackets balanced
 // so links like https://en.wikipedia.org/wiki/Mark_Levine_(disambiguation) survive.
@@ -318,7 +367,7 @@ function splitTextNode(value: string): MdastNode[] {
 }
 
 function setAutoEmbed(node: MdastNode) {
-  if (!node.url) {
+  if (!node.url || isEmbedOptOut(node.url, node.title)) {
     return;
   }
 


### PR DESCRIPTION
## Fixes

  Issue Number:

  ## What is the current behavior?

  Odysee links in markdown do not give authors a reliable way to choose between an embed/preview and a plain link. Community/comment markdown can also fail to embed Odysee
  links even when embedding is intended.

  ## What is the new behavior?

  Odysee markdown links now support explicit per-link embed controls:

  - `"embed"` or `?embed=true` forces an embed/preview.
  - `"noembed"`, `"no-embed"`, `?noembed=1`, or `?embed=false` renders the link without an embed/preview.

  Default markdown post behavior is preserved: bare Odysee claim links still auto-embed unless the author opts out.

  ## Other information


  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opting links in or out of automatic embeds using link titles or query parameters.
  * Supports common boolean-style values for embed preferences.
  * Claim previews now respect embed preferences.
  * Known-app links remain as regular links when embedding is explicitly disabled.
  * Links without an explicit preference continue to follow the default embedding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->