### PR TITLE
Add markdown Odysee embed opt out

### DIFF
--- a/ui/component/common/markdown-preview.tsx
+++ b/ui/component/common/markdown-preview.tsx
@@ -1,7 +1,7 @@
 import { CHANNEL_STAKED_LEVEL_VIDEO_COMMENTS, MISSING_THUMB_DEFAULT } from 'config';
 import { platform } from 'util/platform';
 import { formattedEmote } from 'util/remark-emote';
-import { formattedLinks } from 'util/remark-lbry';
+import { formattedLinks, isEmbedOptIn, isEmbedOptOut } from 'util/remark-lbry';
 import { formattedTimestamp } from 'util/remark-timestamp';
 import { getThumbnailCdnUrl } from 'util/thumbnail';
 import * as React from 'react';
@@ -214,11 +214,9 @@ const SimpleLink = (props: SimpleLinkProps) => {
     );
   }
 
-  const [uri, search] = href.split('?');
-  const urlParams = new URLSearchParams(search);
-  const embedParam = urlParams.get('embed');
+  const [uri] = href.split('?');
 
-  if (embed || embedParam) {
+  if (!isEmbedOptOut(href, title) && (embed || isEmbedOptIn(href, title))) {
     // Decode this since users might just copy it from the url bar
     const decodedUri = decodeURI(uri);
     return (

--- a/ui/component/markdownLink/view.tsx
+++ b/ui/component/markdownLink/view.tsx
@@ -2,6 +2,7 @@ import { KNOWN_APP_DOMAINS } from 'config';
 import * as ICONS from 'constants/icons';
 import * as React from 'react';
 import { isURIValid } from 'util/lbryURI';
+import { isEmbedOptIn, isEmbedOptOut } from 'util/remark-lbry';
 import Button from 'component/button';
 import CommentMenuList from 'component/commentMenuList';
 import ChannelTitle from 'component/channelTitle';
@@ -65,6 +66,8 @@ function MarkdownLink(props: Props) {
   // Regex for url protocol
   const protocolRegex = new RegExp('^(https?|lbry|mailto)+:', 'i');
   const protocol = href ? protocolRegex.exec(href) : null;
+  const embedOptOut = isEmbedOptOut(href, title);
+  const embedOptIn = isEmbedOptIn(href, title);
   const isMention = href && href.startsWith('lbry://@');
   const mentionedMyChannel =
     isMention &&
@@ -105,8 +108,9 @@ function MarkdownLink(props: Props) {
         : undefined;
       const isMarkdownLinkWithLabel =
         children && Array.isArray(children) && React.Children.count(children) === 1 && children.toString() !== href;
+      const shouldAutoEmbedKnownAppLink = !isMarkdownLinkWithLabel && (!isComment || Boolean(parentCommentId));
 
-      if (possibleLbryUrl && !isMarkdownLinkWithLabel && !isComment) {
+      if (possibleLbryUrl && !embedOptOut && (embedOptIn || shouldAutoEmbedKnownAppLink)) {
         lbryUrlFromLink = possibleLbryUrl;
       }
     }
@@ -155,7 +159,7 @@ function MarkdownLink(props: Props) {
         <ClaimLink
           uri={lbryUrlFromLink || decodedUri}
           parentCommentId={parentCommentId}
-          allowPreview={embed || allowPreview || allowKnownAppPreview}
+          allowPreview={!embedOptOut && (embed || embedOptIn || allowPreview || allowKnownAppPreview)}
         >
           {children}
         </ClaimLink>

--- a/ui/component/markdownLink/view.tsx
+++ b/ui/component/markdownLink/view.tsx
@@ -109,8 +109,8 @@ function MarkdownLink(props: Props) {
       const isMarkdownLinkWithLabel =
         children && Array.isArray(children) && React.Children.count(children) === 1 && children.toString() !== href;
       const shouldAutoEmbedKnownAppLink = !isMarkdownLinkWithLabel && (!isComment || Boolean(parentCommentId));
-      if (possibleLbryUrl && !embedOptOut && (embedOptIn || (!isMarkdownLinkWithLabel && !isComment))) {
 
+      if (possibleLbryUrl && !embedOptOut && (embedOptIn || shouldAutoEmbedKnownAppLink)) {
         lbryUrlFromLink = possibleLbryUrl;
       }
     }

--- a/ui/util/remark-lbry.ts
+++ b/ui/util/remark-lbry.ts
@@ -92,6 +92,55 @@ const TRAILING_PAIRS: Array<[string, string]> = [
   ['{', '}'],
 ];
 const TRAILING_PUNCTUATION = ".,;:!?'";
+const EMBED_OPT_OUT_VALUES = new Set(['0', 'false', 'no']);
+const EMBED_OPT_IN_VALUES = new Set(['1', 'true', 'yes']);
+
+function getLinkSearchParams(url: string): URLSearchParams | null {
+  const queryIndex = url.indexOf('?');
+  if (queryIndex < 0) {
+    return null;
+  }
+
+  const hashIndex = url.indexOf('#', queryIndex);
+  const query = url.slice(queryIndex + 1, hashIndex >= 0 ? hashIndex : undefined);
+  return new URLSearchParams(query);
+}
+
+export function isEmbedOptOut(url: string, title?: string | null): boolean {
+  const normalizedTitle = title?.trim().toLowerCase();
+  if (normalizedTitle === 'noembed' || normalizedTitle === 'no-embed') {
+    return true;
+  }
+
+  const params = getLinkSearchParams(url);
+  if (!params) {
+    return false;
+  }
+
+  const embed = params.get('embed');
+  const noEmbed = params.get('noembed');
+
+  return (
+    (embed !== null && EMBED_OPT_OUT_VALUES.has(embed.toLowerCase())) ||
+    (noEmbed !== null && !EMBED_OPT_OUT_VALUES.has(noEmbed.toLowerCase()))
+  );
+}
+
+export function isEmbedOptIn(url: string, title?: string | null): boolean {
+  const normalizedTitle = title?.trim().toLowerCase();
+  if (normalizedTitle === 'embed') {
+    return true;
+  }
+
+  const params = getLinkSearchParams(url);
+  if (!params) {
+    return false;
+  }
+
+  const embed = params.get('embed');
+
+  return embed !== null && EMBED_OPT_IN_VALUES.has(embed.toLowerCase());
+}
 
 // Strip trailing punctuation from a bare URL, but keep paired brackets balanced
 // so links like https://en.wikipedia.org/wiki/Mark_Levine_(disambiguation) survive.
@@ -318,7 +367,7 @@ function splitTextNode(value: string): MdastNode[] {
 }
 
 function setAutoEmbed(node: MdastNode) {
-  if (!node.url) {
+  if (!node.url || isEmbedOptOut(node.url, node.title)) {
     return;
   }
 

--- a/ui/util/remark-lbry.ts
+++ b/ui/util/remark-lbry.ts
@@ -292,7 +292,7 @@ function createLinkNode(rawText: string): { node?: MdastNode; consumedText: stri
       }
 
       return {
-        node: createURI(consumedText, consumedText, true),
+        node: createURI(consumedText, consumedText, !isEmbedOptOut(consumedText)),
         consumedText,
       };
     }


### PR DESCRIPTION
## Fixes

  Issue Number:

  ## What is the current behavior?

  After adding explicit Odysee embed controls, bare Odysee links in regular community comments no longer auto-embed as expected.

  ## What is the new behavior?

  Regular community comments can auto-embed bare Odysee links again, while explicit per-link embed controls remain supported:

  - `"embed"` or `?embed=true` forces an embed/preview.
  - `"noembed"`, `"no-embed"`, `?noembed=1`, or `?embed=false` renders the link without an embed/preview.

  Live chat comments still require explicit embed opt-in, and markdown post behavior remains unchanged.

  ## Other information

  Follow-up to #3545.

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Known application links now automatically embed in more comment and non-comment contexts when appropriate.
  * LBRY link previews now support explicit embed opt-in and opt-out controls.
* **Bug Fixes**
  * Improved LBRY preview handling by correctly processing links with query parameters.
  * Prevented previews from appearing when embedding has been explicitly disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->