### PR TITLE
Fix pinned comment replies

### DIFF
--- a/ui/redux/reducers/comments.ts
+++ b/ui/redux/reducers/comments.ts
@@ -594,48 +594,38 @@ export default handleActions(
       const pinnedCommentsById = Object.assign({}, state.pinnedCommentsById);
 
       if (pinnedComment) {
-        if (topLevelCommentsById[claimId]) {
-          const index = topLevelCommentsById[claimId].indexOf(pinnedComment.comment_id);
-
-          if (index > -1) {
-            topLevelCommentsById[claimId].splice(index, 1);
-          }
-        } else {
-          topLevelCommentsById[claimId] = [];
-        }
-
-        if (pinnedCommentsById[claimId]) {
-          const index = pinnedCommentsById[claimId].indexOf(pinnedComment.comment_id);
-
-          if (index > -1) {
-            pinnedCommentsById[claimId].splice(index, 1);
-          }
-        } else {
-          pinnedCommentsById[claimId] = [];
-        }
+        const existingComment = commentById[pinnedComment.comment_id];
+        topLevelCommentsById[claimId] = (topLevelCommentsById[claimId] || []).filter(
+          (commentId) => commentId !== pinnedComment.comment_id
+        );
+        pinnedCommentsById[claimId] = (pinnedCommentsById[claimId] || []).filter(
+          (commentId) => commentId !== pinnedComment.comment_id
+        );
 
         if (unpin) {
           // Without the sort score, I have no idea where to put it. Just
           // dump it at the top. Users can refresh if they want it back to
           // the correct sorted position.
-          topLevelCommentsById[claimId].unshift(pinnedComment.comment_id);
+          topLevelCommentsById[claimId] = [pinnedComment.comment_id, ...topLevelCommentsById[claimId]];
         } else {
-          pinnedCommentsById[claimId].unshift(pinnedComment.comment_id);
+          pinnedCommentsById[claimId] = [pinnedComment.comment_id, ...pinnedCommentsById[claimId]];
         }
 
-        if (commentById[pinnedComment.comment_id]) {
+        if (existingComment) {
           // Commentron's `comment.Pin` response places the creator's credentials
           // in the 'channel_*' fields, which doesn't make sense. Maybe it is to
           // show who signed/pinned it, but even if so, it shouldn't overload
           // these variables which are already used by existing comment data structure.
-          // Ensure we don't override the existing/correct values, but fallback
-          // to whatever was given.
-          const { channel_id, channel_name, channel_url } = commentById[pinnedComment.comment_id];
+          // Ensure we don't override the existing/correct values, but fallback to whatever was given.
+          const { channel_id, channel_name, channel_url, parent_id, replies } = existingComment;
           commentById[pinnedComment.comment_id] = {
+            ...existingComment,
             ...pinnedComment,
             channel_id: channel_id || pinnedComment.channel_id,
             channel_name: channel_name || pinnedComment.channel_name,
             channel_url: channel_url || pinnedComment.channel_url,
+            parent_id: pinnedComment.parent_id || parent_id,
+            replies: pinnedComment.replies ?? replies,
           };
         } else {
           commentById[pinnedComment.comment_id] = pinnedComment;


### PR DESCRIPTION
Issue Number:

  ## What is the current behavior?

  After pinning a comment, replies for the newly pinned comment may not be visible until another state update occurs, such as changing the comment sort order.

  ## What is the new behavior?

  Pinning or unpinning a comment now preserves the existing full comment data, including the reply count, when applying the pin API response.

  The reducer also updates pinned and top-level comment ID lists immutably so selectors refresh immediately.

  ## Other information

  Validated locally with `npm run check`. The check completed with existing unrelated livestream lint warnings and no errors.

  ## PR Checklist

  <details><summary>Toggle...</summary>

  What kind of change does this PR introduce?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting)
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation changes
  - [ ] Other - Please describe:

  Please check all that apply to this PR using "x":

  - [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
  - [x] I have checked that this PR does not introduce a breaking change
  - [ ] This PR introduces breaking changes and I have provided a detailed explanation below

  </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment pinning so comments are consistently removed from previous locations before appearing in the pinned list.
  * Preserved existing comment details, including channel information and parent or reply context, when updating pinned comments.
  * Prevented duplicate comment entries and reduced missing or incorrect metadata after pinning.
  * Improved comment list consistency when moving comments between pinned and top-level views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->