### PR TITLE
Fix large tag: split comma-separated tags and limit to 5

### DIFF
--- a/ui/component/claimTags/view.tsx
+++ b/ui/component/claimTags/view.tsx
@@ -6,7 +6,7 @@ import { selectTagsForUri } from 'redux/selectors/claims';
 import { selectFollowedTags } from 'redux/selectors/tags';
 const SLIM_TAGS = 1;
 const NORMAL_TAGS = 3;
-const LARGE_TAGS = 6;
+const LARGE_TAGS = 5;
 type Props = {
   uri: string;
   type: string;

--- a/ui/util/tags.ts
+++ b/ui/util/tags.ts
@@ -1,7 +1,17 @@
 import { INTERNAL_TAGS, PURCHASE_TAG, PURCHASE_TAG_OLD, RENTAL_TAG, RENTAL_TAG_OLD } from 'constants/tags';
 
 export function removeInternalStringTags(tags: Array<string>): Array<string> {
-  return tags.filter((tag: string) => {
+  const expandedTags = tags.flatMap((tag: string) => {
+    if (tag.includes(',')) {
+      return tag
+        .split(',')
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+    }
+    return [tag];
+  });
+
+  return expandedTags.filter((tag: string) => {
     return (
       !INTERNAL_TAGS.includes(tag) &&
       !tag.startsWith(PURCHASE_TAG) &&
@@ -13,7 +23,19 @@ export function removeInternalStringTags(tags: Array<string>): Array<string> {
 }
 
 export function removeInternalTags(tags: Array<Tag>): Array<Tag> {
-  return tags.filter((tag: Tag) => {
+  const expandedTags = tags.flatMap((tag: Tag) => {
+    if (!tag?.name) return [];
+    if (tag.name.includes(',')) {
+      return tag.name
+        .split(',')
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0)
+        .map((name) => ({ ...tag, name }));
+    }
+    return [tag];
+  });
+
+  return expandedTags.filter((tag: Tag) => {
     if (!tag?.name) return false;
     return (
       !INTERNAL_TAGS.includes(tag.name) &&


### PR DESCRIPTION
Bug in posts using large tags: they were displayed as a single tag with all tags concatenated by commas, instead of as individual tags limited to 5.

<img width="1837" height="72" alt="imagen" src="https://github.com/user-attachments/assets/8a9f0a02-115f-4b6f-825d-bfa0f7b582a1" />

The `metadata.tags` array contained tags as a single comma-separated string (e.g., [“tag1, tag2, tag3, ...”]) instead of an array of individual strings. ClaimTags treated the entire string as a single tag, ignoring the limit.

A fix was applied in ui/util/tags.ts: `flatMap` was added to `removeInternalStringTags` and `removeInternalTags` to split comma-separated tags into individual tags before filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tag handling by supporting comma-separated tag values and removing empty entries.
  * Internal tags are now filtered more consistently across tag formats.

* **Bug Fixes**
  * Adjusted large-tag display to show up to five tags.
  * Excluded unnamed tags from displayed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->