### PR TITLE
Fix sticker name hover preview

### DIFF
--- a/ui/component/commentCreate/internal/comment-selectors.tsx
+++ b/ui/component/commentCreate/internal/comment-selectors.tsx
@@ -275,7 +275,7 @@ const StickerCategory = (rowProps: RowProps) => {
                 button="alt"
                 className="button--file-action"
                 onClick={() => handleSelect(sticker)}
-                onMouseEnter={() => handleHover(sticker)}
+                onMouseEnter={() => handleHover(name)}
                 onMouseLeave={() => handleHover('')}
               >
                 <StickerWrapper price={price}>


### PR DESCRIPTION
## Fixes

Fix: Preview for stickers in comment shows [object Object]

<img width="1968" height="796" alt="image" src="https://github.com/user-attachments/assets/1bdbd728-6b0c-4c00-a7e6-e5b18eda04af" />

---

Didn't test as I don't have a dev environment set up for frontend, hope this fixes it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sticker hover previews by displaying the sticker’s name correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->