### PR TITLE
Fix Tap to unmute doing nothing

### DIFF
--- a/ui/component/viewers/videoViewer/index.ts
+++ b/ui/component/viewers/videoViewer/index.ts
@@ -123,7 +123,11 @@ function VideoViewerWithRedux(props: any) {
     collectionId,
     nextPlaylistUri,
     isMarkdownOrComment,
-    autoplayIfEmbedded: Boolean(autoplay),
+    // Only embeds have to start muted -- browsers require it to autoplay there.
+    // The shorts feed puts `autoplay=1` on every in-feed url too (to force
+    // playback in withStreamClaimRender), and treating that as "start muted"
+    // re-muted every short after the first, discarding the viewer's unmute.
+    autoplayIfEmbedded: Boolean(autoplay) && isEmbeddedPlayback,
     autoplayNext,
     volume: volume ?? 1,
     muted: muted ?? false,

--- a/ui/component/viewers/videoViewer/internal/videojs.tsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.tsx
@@ -589,18 +589,21 @@ function VideoJsInner(props: Props) {
     if (!media || readyCalledRef.current) return;
     readyCalledRef.current = true;
 
-    // Set initial state
-    const state = store.state;
+    // Set initial state. `toggleMuted()` flips whatever the current value is, so
+    // it cannot express "start muted" — assign the element instead. The store
+    // picks this up through its own 'volumechange' listener.
     if (startMuted) {
-      try {
-        state.toggleMuted();
-      } catch {
-        // Store target not yet attached — fall back to muting the element directly
-        media.muted = true;
-      }
+      media.muted = true;
     }
 
-    // Call onPlayerReady with a compatible API object
+    // Call onPlayerReady with a compatible API object.
+    //
+    // Every accessor below reads the media element rather than a captured
+    // `store.state`. The store hands out a new frozen object on each update, so
+    // a reference captured here (this effect runs once per media element) is
+    // stale from the next state change onwards — which silently turned the
+    // muted() setter into a no-op, since its guard compared against a value
+    // that never changed.
     const playerApi = {
       currentTime: (val) => {
         if (val !== undefined) {
@@ -611,24 +614,24 @@ function VideoJsInner(props: Props) {
       },
       muted: (val) => {
         if (val !== undefined) {
-          if (val !== state.muted) state.toggleMuted();
+          if (val !== media.muted) store.state.toggleMuted();
           return val;
         }
-        return state.muted;
+        return media.muted;
       },
       volume: (val) => {
         if (val !== undefined) {
-          state.setVolume(val);
+          store.state.setVolume(val);
           return val;
         }
-        return state.volume;
+        return media.volume;
       },
       playbackRate: (val) => {
         if (val !== undefined) {
-          state.setPlaybackRate(val);
+          store.state.setPlaybackRate(val);
           return val;
         }
-        return state.playbackRate;
+        return media.playbackRate;
       },
       on: (event, fn) => media.addEventListener(event, fn),
       off: (event, fn) => media.removeEventListener(event, fn),
@@ -1155,15 +1158,11 @@ function VideoJsInner(props: Props) {
 
   const unmuteAndHideHint = useCallback(() => {
     if (media) {
-      if (window.player?.muted) {
-        try {
-          window.player.muted(false);
-        } catch {
-          media.muted = false;
-        }
-      } else {
-        media.muted = false;
-      }
+      // Unmute the element directly. Routing this through `window.player` added
+      // nothing (the old `window.player?.muted` test read a method reference, so
+      // it was always truthy regardless of mute state) and the store stays in
+      // sync either way through its 'volumechange' listener.
+      media.muted = false;
 
       if (media.volume === 0) media.volume = 1.0;
 


### PR DESCRIPTION
## Fixes

## What is the current behavior?

A muted autoplaying video shows a "Tap to unmute" hint in the middle of the player, but tapping it does not unmute anything. The hint disappears and the video stays silent, so viewers have to reach for the volume control in the control bar instead. The hint ends up being an obstruction rather than a shortcut.

## What is the new behavior?

 Tapping the hint now unmutes the element directly. The store stays in sync either way, because its volume feature already listens for `volumechange` and syncs itself:

## Other information


## PR Checklist

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved video playback state handling for mute status, volume, playback speed, and current playback time.
- Fixed unmute behavior so videos reliably resume with audio when requested.
- Improved initial muted playback setup for more consistent media behavior.
- Fixed autoplay handling so embedded videos respect autoplay settings without incorrectly muting other short-form videos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->