### PR TITLE
Remove the alt. edit button when viewing your channel page

### DIFF
--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/view.tsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/view.tsx
@@ -600,22 +600,7 @@ function ChannelPage(props: Props) {
               </Tooltip>
             </div>
             <div className="channel__edit">
-              {channelIsMine && (
-                <>
-                  {pending ? (
-                    <span>{__('Your changes will be live in a few minutes')}</span>
-                  ) : (
-                    <Button
-                      button="alt"
-                      title={__('Edit')}
-                      onClick={() => navigate(`?${CHANNEL_PAGE.QUERIES.VIEW}=${CHANNEL_PAGE.VIEWS.EDIT}`)}
-                      icon={ICONS.EDIT}
-                      iconSize={18}
-                      disabled={pending}
-                    />
-                  )}
-                </>
-              )}
+              {channelIsMine && pending && <span>{__('Your changes will be live in a few minutes')}</span>}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Fixes

Issue Number: -

<!-- Tip:
 - Add keywords to directly close the Issue when the PR is merged.
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

<img width="437" height="401" alt="image" src="https://github.com/user-attachments/assets/fd8809a0-14cf-454e-8f9f-053597fd0b65" />

(don't judge, it's a new wallet)

## What is the new behavior?

<img width="281" height="360" alt="image" src="https://github.com/user-attachments/assets/0d86b7e8-0403-4e75-abf2-f1298af97f55" />

## Other information

I'm not sure stills if users would want the simple alt button and remove the edit option from the dropdown?? still—one has to go, there's duplicate buttons around the same spot of the page.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
