### PR TITLE
Migrate the uploads button to one central place

### DIFF
--- a/ui/component/header/view.tsx
+++ b/ui/component/header/view.tsx
@@ -211,6 +211,7 @@ const Header = (props: Props) => {
 
           {!hideProfile && (
             <React.Suspense fallback={null}>
+              <HeaderMenuButtons authRedirect={authRedirect} />
               <HeaderProfileMenuButton />
             </React.Suspense>
           )}
@@ -331,9 +332,6 @@ const Header = (props: Props) => {
             {!authHeader && !isMobile && (
               <div className="header__center">
                 <WunderBar />
-                <React.Suspense fallback={null}>
-                  <HeaderMenuButtons authRedirect={authRedirect} />
-                </React.Suspense>
               </div>
             )}
 

--- a/ui/component/headerMenuButtons/view.tsx
+++ b/ui/component/headerMenuButtons/view.tsx
@@ -9,6 +9,7 @@ import Icon from 'component/common/icon';
 import React from 'react';
 import Tooltip from 'component/common/tooltip';
 import UploadManagerMenu from 'component/header/uploadManagerMenu';
+import { Menu, MenuButton, MenuList, MenuItem } from 'component/common/menu';
 import { useAppSelector, useAppDispatch } from 'redux/hooks';
 import { selectUserVerifiedEmail, selectUser } from 'redux/selectors/user';
 import { selectActivePipelineItems, selectCurrentUploads } from 'redux/selectors/publish';
@@ -18,29 +19,6 @@ type HeaderMenuButtonProps = {
   authRedirect?: string;
 };
 
-function HeaderLivestreamButton({
-  uploadProps,
-  doBeginPublish,
-}: {
-  uploadProps: { requiresAuth: boolean };
-  doBeginPublish: (type: PublishType) => void;
-}) {
-  const ctx = useLivestreamPublish();
-  const isLive = ctx.state.status === 'live' || ctx.state.status === 'connecting';
-  return (
-    <Tooltip title={isLive ? __('Live') : __('Go live')}>
-      <Button
-        className={classnames('header__navigationItem--icon', {
-          'header__livestream-btn--live': isLive,
-        })}
-        {...uploadProps}
-        onClick={() => doBeginPublish(PUBLISH_TYPES.LIVESTREAM)}
-      >
-        <Icon size={18} icon={ICONS.GOLIVE} aria-hidden />
-      </Button>
-    </Tooltip>
-  );
-}
 export default function HeaderMenuButtons(props: HeaderMenuButtonProps) {
   const { authRedirect } = props;
   const dispatch = useAppDispatch();
@@ -54,18 +32,48 @@ export default function HeaderMenuButtons(props: HeaderMenuButtonProps) {
   const hasUploadActivity =
     (pipelineItems as any[]).some((item: any) => item.stage !== 'error') ||
     Object.keys(currentUploads || {}).length > 0;
-  const uploadProps = {
-    requiresAuth: !authenticated,
-  };
+
+  const ctx = useLivestreamPublish();
+  const isLive = ctx.state.status === 'live' || ctx.state.status === 'connecting';
+
   return authenticated ? (
     <div className="header__buttons">
-      <UploadManagerMenu hasActivity={hasUploadActivity} onUploadClick={() => doBeginPublish(PUBLISH_TYPES.FILE)} />
-      {livestreamEnabled && <HeaderLivestreamButton uploadProps={uploadProps} doBeginPublish={doBeginPublish} />}
-      <Tooltip title={__('Post an article')}>
-        <Button className="header__navigationItem--icon" onClick={() => doBeginPublish(PUBLISH_TYPES.POST)}>
-          <Icon size={18} icon={ICONS.POST} aria-hidden />
-        </Button>
-      </Tooltip>
+      {hasUploadActivity && (
+        <UploadManagerMenu hasActivity={hasUploadActivity} onUploadClick={() => doBeginPublish(PUBLISH_TYPES.FILE)} />
+      )}
+      <Menu>
+        <Tooltip title={__('Create')}>
+          <MenuButton
+            className={classnames('button header__navigationItem--icon', {
+              'header__livestream-btn--live': isLive,
+            })}
+          >
+            <Icon size={18} icon={ICONS.ADD} aria-hidden />
+          </MenuButton>
+        </Tooltip>
+        <MenuList className="menu__list">
+          <MenuItem className="comment__menu-option" onSelect={() => doBeginPublish(PUBLISH_TYPES.FILE)}>
+            <div className="menu__link">
+              <Icon aria-hidden icon={ICONS.PUBLISH} />
+              {__('Upload a video')}
+            </div>
+          </MenuItem>
+          {livestreamEnabled && (
+            <MenuItem className="comment__menu-option" onSelect={() => doBeginPublish(PUBLISH_TYPES.LIVESTREAM)}>
+              <div className="menu__link">
+                <Icon aria-hidden icon={isLive ? ICONS.GOLIVE : ICONS.VIDEO} />
+                {isLive ? __('Livestream settings') : __('Start a livestream')}
+              </div>
+            </MenuItem>
+          )}
+          <MenuItem className="comment__menu-option" onSelect={() => doBeginPublish(PUBLISH_TYPES.POST)}>
+            <div className="menu__link">
+              <Icon aria-hidden icon={ICONS.POST} />
+              {__('Post an article')}
+            </div>
+          </MenuItem>
+        </MenuList>
+      </Menu>
     </div>
   ) : (
     <>


### PR DESCRIPTION
## Fixes

Issue Number: -

<!-- Tip:
 - Add keywords to directly close the Issue when the PR is merged.
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

<img width="1366" height="168" alt="image" src="https://github.com/user-attachments/assets/9fbe91d2-4b53-4809-af0b-4e9ad1b14323" />

## What is the new behavior?

<img width="1366" height="73" alt="image" src="https://github.com/user-attachments/assets/8cc7c9f1-f585-40a7-8316-68eda3773a24" />

## Other information

This PR is meant to be a long side w/ #3562 (as in my opinion, there's now too many buttons over at the right header) and maybe #3565 (as it wouldn't look "clean" if that PR is merged and this is rejected, UX leader?) 

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
