### PR TITLE
Fix blocked channels still showing up in replies

### DIFF
--- a/tests/unit/comment-block-filter.test.ts
+++ b/tests/unit/comment-block-filter.test.ts
@@ -1,0 +1,72 @@
+import { beforeAll, describe, expect, it } from 'vite-plus/test';
+
+let selectRepliesForParentId: any;
+let selectTopLevelCommentsForUri: any;
+
+const BLOCKED_URL = 'lbry://@Blocked#a';
+const FRIEND_URL = 'lbry://@Friend#b';
+const CLAIM_ID = 'claim1';
+const PARENT_ID = 'parent1';
+
+const reply = (comment_id: string, channel_url: string, channel_id: string) => ({
+  comment_id,
+  channel_url,
+  channel_id,
+  claim_id: CLAIM_ID,
+  parent_id: PARENT_ID,
+  body: 'hi',
+});
+
+const makeState = (moderationBlockList: Array<string>) => ({
+  claims: {
+    byId: {},
+    pendingById: {},
+    myClaims: [],
+    myChannelClaimsById: {},
+    resolvingUris: [],
+    claimsByUri: {},
+  },
+  comments: {
+    commentById: {
+      r1: reply('r1', BLOCKED_URL, 'blockedid'),
+      r2: reply('r2', FRIEND_URL, 'friendid'),
+    },
+    repliesByParentId: { [PARENT_ID]: ['r1', 'r2'] },
+    moderationBlockList,
+    moderationDelegatorsById: {},
+  },
+  blocked: { blockedChannels: [], geoBlockedList: {} },
+  blacklist: { blackListedOutpointMap: {} },
+  filtered: { filteredOutpointMap: {} },
+  settings: { clientSettings: {}, daemonSettings: {} },
+  user: { locale: undefined },
+});
+
+beforeAll(async () => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { i18n_messages: {}, navigator: { language: 'en' } },
+  });
+
+  const comments = await import('../../ui/redux/selectors/comments');
+  selectRepliesForParentId = comments.selectRepliesForParentId;
+  selectTopLevelCommentsForUri = comments.selectTopLevelCommentsForUri;
+});
+
+describe('personal block list filtering', () => {
+  it('hides replies from a blocked channel', () => {
+    const state = makeState([BLOCKED_URL]);
+    const replies = selectRepliesForParentId(state, PARENT_ID);
+    expect(replies.map((c: any) => c.comment_id)).toEqual(['r2']);
+  });
+
+  it('keeps replies when nothing is blocked', () => {
+    const state = makeState([]);
+    const replies = selectRepliesForParentId(state, PARENT_ID);
+    expect(replies.map((c: any) => c.comment_id)).toEqual(['r1', 'r2']);
+  });
+
+  it('exports the top-level selector it shares filtering with', () => {
+    expect(typeof selectTopLevelCommentsForUri).toBe('function');
+  });
+});

--- a/ui/redux/selectors/comments.ts
+++ b/ui/redux/selectors/comments.ts
@@ -262,15 +262,16 @@ export const selectRepliesForParentId = (createCachedSelector as any)(
   selectCommentsById,
   ...filterCommentsDepValues,
   (id: string, repliesByParentId: any, commentsById: any, ...filterInputs: any[]) => {
-    // const claimId = byUri[uri]; // just parentId (id)
     const replyIdsForParent = repliesByParentId[id] || EMPTY_ARRAY;
     if (!replyIdsForParent.length) return EMPTY_ARRAY;
     const comments = [];
     replyIdsForParent.forEach((cid) => {
       comments.push(commentsById[cid]);
     });
-    // const comments = byParentId && byParentId[id];
-    return filterComments(comments, undefined, filterInputs);
+    // Replies are keyed by parent id rather than claim, but the comments carry
+    // the claim they belong to. Pass it along so `filterComments` can tell
+    // whether the content is mine.
+    return filterComments(comments, comments.find((c) => c && c.claim_id)?.claim_id, filterInputs);
   }
 )((state, id: string) => String(id));
 
@@ -354,13 +355,14 @@ const filterComments = (comments: Array<CommentData>, claimId: string | undefine
           }
         }
 
-        if (claimId) {
-          const claimIdIsMine = myClaimIds && myClaimIds.size > 0 && myClaimIds.includes(claimId);
+        // An unknown claim is not a claim of mine, so it must not skip the block
+        // check -- gating the whole branch on `claimId` let blocked channels
+        // through wherever the caller had no claim to hand, replies included.
+        const claimIdIsMine = Boolean(claimId) && myClaimIds && myClaimIds.size > 0 && myClaimIds.includes(claimId);
 
-          if (!claimIdIsMine && !amDelegatedMod) {
-            if (personalBlockList.includes(comment.channel_url)) {
-              return false;
-            }
+        if (!claimIdIsMine && !amDelegatedMod) {
+          if (personalBlockList.includes(comment.channel_url)) {
+            return false;
           }
         }
 


### PR DESCRIPTION
## Fixes

Issue Number:

Reported by a viewer: they blocked a channel, received the confirmation, and the blocked account went on replying to their comment. They asked us to confirm the block had actually been applied.

## What is the current behavior?

Blocking a channel hides its top-level comments but not its replies. A blocked person can keep replying to you and you still see it.

`filterComments` only consults the personal block list from inside a truthiness guard on the claim id:

```js
if (claimId) {
  const claimIdIsMine = ...;
  if (!claimIdIsMine && !amDelegatedMod) {
    if (personalBlockList.includes(comment.channel_url)) return false;
  }
}
```

`selectRepliesForParentId` passes no claim id, because replies are keyed by parent id rather than by claim, so every reply skipped the check entirely. `selectCommentsForUri` and `selectTopLevelCommentsForUri` both pass one, which is why blocking looked like it worked everywhere else.

Mute is unaffected: that check sits outside the guard, along with the blacklist, mature and geo checks. Only blocking had the hole.

## What is the new behavior?

The guard existed only to compute `claimIdIsMine`, and an unknown claim is not one of mine, so it falls through to the block check rather than skipping it. The flag is computed defensively and the check runs unconditionally.

The replies selector also passes the claim id its own comments carry, so the `claimIdIsMine` exemption is accurate for replies on your own content.

Replies from a blocked channel are now filtered out the same way top-level comments already were.

## Other information

Adds `tests/unit/comment-block-filter.test.ts`, run with `npx vp test tests/unit`. Verified it fails against unpatched code with exactly the reported symptom — `['r1','r2']` instead of `['r2']`, the blocked channel's reply still present — and passes with the fix. Full unit suite green at 13 tests.

Notes for review:

- `claimIdIsMine` is inert today. `myClaimIds` is an array while the check reads `.size`, so it is always `false`. Left alone here, because making it work would start showing blocked channels' comments on your own uploads, which is a behaviour change that deserves its own decision.
- Server-side enforcement is out of scope. This only fixes what the app displays. Whether commentron should also refuse the reply is a separate question, and a personal block conventionally covers your own content rather than your comments under someone else's video.
- Separately, `doCommentModToggleBlock` can report success having blocked nothing: rejections matching `validation is disallowed for non controlling channels` are dropped from `failures`, and if every `channelSignName` returns null the request list is empty, both landing on `BLOCK_COMPLETE` and a "Channel blocked." toast. There is also an index mismatch at the `failures.push`, where `channelSignatures[index]` indexes the unfiltered array. Not touched here.

## PR Checklist

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
