### PR TITLE
Persist the chosen video quality and stop fetching it twice

### DIFF
--- a/tests/unit/video-quality-level.test.ts
+++ b/tests/unit/video-quality-level.test.ts
@@ -1,0 +1,82 @@
+import { beforeAll, describe, expect, it } from 'vite-plus/test';
+
+let getInitialQualityLevelIndex: any;
+let getQualityHeight: any;
+let snapHeight: any;
+
+// Landscape ladder, as an hls manifest usually orders it: lowest bitrate first.
+const LADDER = [
+  { width: 256, height: 144, bitrate: 200_000 },
+  { width: 640, height: 360, bitrate: 800_000 },
+  { width: 854, height: 480, bitrate: 1_400_000 },
+  { width: 1280, height: 720, bitrate: 2_800_000 },
+  { width: 1920, height: 1080, bitrate: 5_000_000 },
+];
+
+beforeAll(async () => {
+  const quality = await import('../../ui/component/viewers/videoViewer/internal/quality');
+  getInitialQualityLevelIndex = quality.getInitialQualityLevelIndex;
+  getQualityHeight = quality.getQualityHeight;
+  snapHeight = quality.snapHeight;
+});
+
+describe('getInitialQualityLevelIndex', () => {
+  it('picks the highest level at or below the requested height', () => {
+    expect(getInitialQualityLevelIndex(LADDER, '480')).toBe(2);
+    expect(getInitialQualityLevelIndex(LADDER, '720')).toBe(3);
+  });
+
+  it('accepts a number as readily as a string', () => {
+    expect(getInitialQualityLevelIndex(LADDER, 360)).toBe(1);
+  });
+
+  it('picks an exact match rather than the next one down', () => {
+    expect(getInitialQualityLevelIndex(LADDER, '1080')).toBe(4);
+  });
+
+  it('falls back to the lowest level when every level exceeds the request', () => {
+    expect(getInitialQualityLevelIndex(LADDER, '90')).toBe(0);
+  });
+
+  it('measures portrait levels by their shorter side', () => {
+    // A 1080x1920 vertical video is 1080p, so asking for 720 must step down.
+    const portrait = [
+      { width: 360, height: 640, bitrate: 500_000 },
+      { width: 720, height: 1280, bitrate: 2_000_000 },
+      { width: 1080, height: 1920, bitrate: 4_000_000 },
+    ];
+    expect(getInitialQualityLevelIndex(portrait, '720')).toBe(1);
+    expect(getInitialQualityLevelIndex(portrait, '360')).toBe(0);
+  });
+
+  it('returns null for preferences that are not a pixel height', () => {
+    expect(getInitialQualityLevelIndex(LADDER, 'auto')).toBe(null);
+    expect(getInitialQualityLevelIndex(LADDER, 'original')).toBe(null);
+    expect(getInitialQualityLevelIndex(LADDER, null)).toBe(null);
+    expect(getInitialQualityLevelIndex(LADDER, '0')).toBe(null);
+  });
+
+  it('returns null when there are no levels to choose from', () => {
+    expect(getInitialQualityLevelIndex([], '480')).toBe(null);
+    expect(getInitialQualityLevelIndex(undefined, '480')).toBe(null);
+  });
+
+  it('ignores levels carrying no usable dimensions', () => {
+    const withJunk = [{ bitrate: 100 }, { width: 640, height: 360, bitrate: 800_000 }];
+    expect(getInitialQualityLevelIndex(withJunk, '480')).toBe(1);
+  });
+});
+
+describe('quality height helpers', () => {
+  it('reads landscape height and portrait width', () => {
+    expect(getQualityHeight({ width: 1280, height: 720 })).toBe(720);
+    expect(getQualityHeight({ width: 1080, height: 1920 })).toBe(1080);
+    expect(getQualityHeight(null)).toBe(0);
+  });
+
+  it('snaps odd heights up to the nearest common rung', () => {
+    expect(snapHeight(718)).toBe(720);
+    expect(snapHeight(720)).toBe(720);
+    expect(snapHeight(1081)).toBe(1440);
+  });
+});

--- a/ui/component/viewers/videoViewer/internal/OdyseeSkin.tsx
+++ b/ui/component/viewers/videoViewer/internal/OdyseeSkin.tsx
@@ -20,13 +20,14 @@ import { icons } from 'component/common/icon-custom';
 import * as ICONS from 'constants/icons';
 import * as QUALITY_OPTIONS from 'constants/player';
 import { VIDEO_PLAYBACK_RATES } from 'constants/player';
+import { getInitialQualityLevelIndex, getQualityHeight, snapHeight } from './quality';
 import { platform } from 'util/platform';
 import { useIsMobile } from 'effects/use-screensize';
 import { isEmbedPath } from 'util/embed';
 import usePersistedState from 'effects/use-persisted-state';
 import { useAppSelector, useAppDispatch } from 'redux/hooks';
 import { selectClientSetting } from 'redux/selectors/settings';
-import { doSetClientSetting } from 'redux/actions/settings';
+import { doSetClientSetting, doSetDefaultVideoQuality } from 'redux/actions/settings';
 import * as SETTINGS from 'constants/settings';
 import {
   fullscreenElement as getFullscreenElement,
@@ -257,41 +258,6 @@ function handleSnapshotFn(media, title) {
   canvas.remove();
 }
 
-const COMMON_HEIGHTS = [144, 240, 360, 480, 720, 1080, 1440, 2160, 4320];
-function snapHeight(h) {
-  for (const c of COMMON_HEIGHTS) {
-    if (h <= c) return c;
-  }
-  return h;
-}
-
-function getQualityHeight(level) {
-  return level?.width && level?.height && level.height > level.width ? level.width : level?.height || 0;
-}
-
-function getInitialQualityLevelIndex(levels, defaultQuality) {
-  const targetHeight = Number(defaultQuality);
-  if (!Number.isFinite(targetHeight) || targetHeight <= 0 || !levels?.length) {
-    return null;
-  }
-
-  const candidates = levels
-    .map((level, index) => ({
-      index,
-      height: getQualityHeight(level),
-      bitrate: level?.bitrate || 0,
-    }))
-    .filter((level) => level.height > 0)
-    .sort((a, b) => {
-      if (b.height !== a.height) return b.height - a.height;
-      return b.bitrate - a.bitrate;
-    });
-
-  return (
-    candidates.find((level) => level.height <= targetHeight)?.index ?? candidates[candidates.length - 1]?.index ?? null
-  );
-}
-
 function useQualityLevels({
   defaultQuality,
   hasOriginalSource,
@@ -300,6 +266,7 @@ function useQualityLevels({
   onSelectAdaptiveSource,
 }) {
   const media = Player.useMedia();
+  const dispatch = useAppDispatch();
   const [levels, setLevels] = useState([]);
   const [currentLevel, setCurrentLevel] = useState(-1);
   const [activeHeight, setActiveHeight] = useState(0);
@@ -351,11 +318,19 @@ function useQualityLevels({
         const levelIndex = getInitialQualityLevelIndex(h.levels, defaultQuality);
         if (levelIndex === null) return;
 
-        h.currentLevel = levelIndex;
-        h.loadLevel = levelIndex;
-        h.nextLevel = levelIndex;
-        h.startLevel = levelIndex;
         initialQualityHlsRef.current = h;
+
+        // The player sets startLevel before the first fragment is requested, so
+        // normally there is nothing to correct here. Only force a switch if that
+        // did not take -- assigning currentLevel discards whatever is already
+        // buffered and fetches it again, which is the download-twice the setting
+        // is supposed to avoid.
+        if (h.currentLevel !== levelIndex && h.loadLevel !== levelIndex) {
+          h.currentLevel = levelIndex;
+          h.loadLevel = levelIndex;
+          h.nextLevel = levelIndex;
+        }
+
         setCurrentLevel(levelIndex);
       };
       const updateLevels = () => {
@@ -412,9 +387,30 @@ function useQualityLevels({
     };
   }, [defaultQuality, hasOriginalSource, isOriginalSourceSelected, media]);
 
+  // Picking a quality in the player is the same intent as setting it in
+  // Settings, so store it there. Without this the choice died with the player and
+  // the next video started over at whatever bandwidth suggested -- which for a
+  // metered connection meant paying for the wrong resolution on every video.
+  const persistQuality = useCallback(
+    (levelIndex: number) => {
+      if (levelIndex === -2) {
+        dispatch(doSetDefaultVideoQuality(QUALITY_OPTIONS.ORIGINAL));
+        return;
+      }
+      if (levelIndex === -1) {
+        dispatch(doSetDefaultVideoQuality(QUALITY_OPTIONS.AUTO));
+        return;
+      }
+      const height = getQualityHeight(levels[levelIndex]);
+      if (height > 0) dispatch(doSetDefaultVideoQuality(String(snapHeight(height))));
+    },
+    [dispatch, levels]
+  );
+
   const selectQuality = useCallback(
     (levelIndex) => {
       userSelectedQualityRef.current = true;
+      persistQuality(levelIndex);
       if (levelIndex === -2) {
         if (!hasOriginalSource) return;
         if (onSelectOriginalSource) onSelectOriginalSource();
@@ -432,7 +428,7 @@ function useQualityLevels({
       hls.currentLevel = levelIndex;
       setCurrentLevel(levelIndex);
     },
-    [hasOriginalSource, media, onSelectAdaptiveSource, onSelectOriginalSource]
+    [hasOriginalSource, media, onSelectAdaptiveSource, onSelectOriginalSource, persistQuality]
   );
 
   const autoLabel = activeHeight > 0 ? `${__('Auto')} (${snapHeight(activeHeight)}p)` : __('Auto');

--- a/ui/component/viewers/videoViewer/internal/quality.ts
+++ b/ui/component/viewers/videoViewer/internal/quality.ts
@@ -1,0 +1,47 @@
+// Shared between the player, which needs to pick a level before the first
+// fragment loads, and the skin, which labels the quality menu.
+
+const COMMON_HEIGHTS = [144, 240, 360, 480, 720, 1080, 1440, 2160, 4320];
+
+export function snapHeight(h: number) {
+  for (const c of COMMON_HEIGHTS) {
+    if (h <= c) return c;
+  }
+  return h;
+}
+
+// Portrait streams (height > width) are described by their shorter dimension, so
+// a 1080x1920 vertical video reads as 1080p rather than 1920p.
+export function getQualityHeight(level: any) {
+  return level?.width && level?.height && level.height > level.width ? level.width : level?.height || 0;
+}
+
+/**
+ * Index of the highest level at or below `defaultQuality`, or the lowest level
+ * available when every level is above it. Returns null when the preference is
+ * not a pixel height (auto, original) or no levels carry usable dimensions.
+ */
+export function getInitialQualityLevelIndex(levels: any, defaultQuality: any): number | null {
+  const targetHeight = Number(defaultQuality);
+  if (!Number.isFinite(targetHeight) || targetHeight <= 0 || !levels?.length) {
+    return null;
+  }
+
+  const candidates = levels
+    .map((level: any, index: number) => ({
+      index,
+      height: getQualityHeight(level),
+      bitrate: level?.bitrate || 0,
+    }))
+    .filter((level: any) => level.height > 0)
+    .sort((a: any, b: any) => {
+      if (b.height !== a.height) return b.height - a.height;
+      return b.bitrate - a.bitrate;
+    });
+
+  return (
+    candidates.find((level: any) => level.height <= targetHeight)?.index ??
+    candidates[candidates.length - 1]?.index ??
+    null
+  );
+}

--- a/ui/component/viewers/videoViewer/internal/videojs.tsx
+++ b/ui/component/viewers/videoViewer/internal/videojs.tsx
@@ -4,6 +4,8 @@ import { Video } from '@videojs/react/video';
 import Player from './player';
 import OdyseeSkin from './OdyseeSkin';
 import { HLS_EVENT_LEVEL_LOADED, HLS_EVENT_MANIFEST_PARSED, loadHlsConstructor } from './hls';
+import { getInitialQualityLevelIndex } from './quality';
+import * as PLAYER from 'constants/player';
 import useResolvedSource from './hooks/useResolvedSource';
 import useRecsys from './hooks/useRecsys';
 import {
@@ -251,6 +253,11 @@ function VideoJsInner(props: Props) {
   const [videoElement, setVideoElement] = useState<HTMLVideoElement | null>(null);
   const [tapToUnmuteVisible, setTapToUnmuteVisible] = useState(false);
   const shouldShowTapToUnmuteRef = useRef(false);
+  // Read through a ref so the hls setup sees the current preference without
+  // taking it as an effect dependency -- that would tear down and recreate the
+  // engine every time the quality changed, which is the opposite of the point.
+  const defaultQualityRef = useRef(defaultQuality);
+  defaultQualityRef.current = defaultQuality;
   const tapToUnmuteTimeoutRef = useRef<number | null>(null);
   const [tapToRetryVisible, setTapToRetryVisible] = useState(false);
   const [p2pUiState, setP2PUiState] = useState({
@@ -777,6 +784,21 @@ function VideoJsInner(props: Props) {
       } as P2PHlsConfig) as HlsWithP2P;
 
       hls.attachMedia(media);
+
+      // Registered before loadSource so it is in place for the first manifest.
+      // startLevel governs the level of the very first fragment requested, so
+      // applying the saved quality here means it is never fetched at the
+      // bandwidth-estimated level and then fetched again after a switch. Only
+      // pixel-height preferences map to a level; auto and original are handled by
+      // the skin, which owns the source toggle.
+      hls.on(HLS_EVENT_MANIFEST_PARSED as any, () => {
+        const wanted = defaultQualityRef.current;
+        if (wanted && wanted !== PLAYER.AUTO && wanted !== PLAYER.ORIGINAL) {
+          const levelIndex = getInitialQualityLevelIndex(hls.levels, wanted);
+          if (levelIndex !== null) hls.startLevel = levelIndex;
+        }
+      });
+
       hls.loadSource(src);
       media._hls = hls;
 


### PR DESCRIPTION
## Fixes

Issue Number:

## What is the current behavior?

Choosing a lower quality uses more data instead of less.

A video starts downloading at whatever quality the connection suggests, and carries on downloading even while paused. Picking a lower quality throws that away and downloads the video again, so it gets paid for twice.

The choice is also forgotten by the next video, so the same waste happens every time.

## What is the new behavior?

A saved quality is applied before any of the video is downloaded, so nothing is fetched at the wrong quality and then discarded.

Choosing a quality in the player now saves it, the same as choosing it in Settings, so it carries over to the next video and after a restart.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
