### PR TITLE
Leave hidden channels out of recommendations and the home banner

### DIFF
--- a/ui/redux/selectors/search.ts
+++ b/ui/redux/selectors/search.ts
@@ -20,7 +20,7 @@ import { objSelectorEqualityCheck } from 'util/redux-utils';
 import { createSelector } from 'reselect';
 import { createCachedSelector } from 're-reselect';
 import { createNormalizedSearchKey, getRecommendationSearchKey, getRecommendationSearchOptions } from 'util/search';
-import { selectMutedChannels } from 'redux/selectors/blocked';
+import { selectMutedAndBlockedChannelIds } from 'redux/selectors/blocked';
 import { selectHistory } from 'redux/selectors/content';
 import * as SETTINGS from 'constants/settings';
 
@@ -130,9 +130,9 @@ const selectRecommendedContentFilteredForUri = createCachedSelector(
   selectClaimForUri,
   selectRecommendedContentRawForUri,
   selectRecClaimsByIdForUri,
-  selectMutedChannels,
+  selectMutedAndBlockedChannelIds,
   selectHideYouTubeMirrors,
-  (claim, recommendationsRaw, recClaimsByUri, blockedChannels, hideYouTubeMirrors) => {
+  (claim, recommendationsRaw, recClaimsByUri, blockedChannelIds, hideYouTubeMirrors) => {
     if (!claim || !recommendationsRaw) {
       return;
     }
@@ -146,8 +146,12 @@ const selectRecommendedContentFilteredForUri = createCachedSelector(
           return true; // Don't filter out unresolved claims (let the placeholders show)
         }
 
-        const recChannelUri = recClaim?.signing_channel?.canonical_url;
-        const isRecChannelBlocked = blockedChannels.some((blockedUri) => blockedUri.includes(recChannelUri));
+        // Compare claim ids. This used to test whether the stored url contained
+        // the recommendation's channel url, but the stored one is a permanent_url
+        // (lbry://@Name#fullid) and this one was a canonical_url (lbry://@Name:1),
+        // so the two could never match and nothing was ever filtered out.
+        const recChannelId = recClaim?.signing_channel?.claim_id;
+        const isRecChannelBlocked = Boolean(recChannelId) && blockedChannelIds.includes(recChannelId);
         let isEqualUri;
 
         try {


### PR DESCRIPTION
## Fixes

Issue Number:

<!-- Tip:
 - Add keywords to directly close the Issue when the PR is merged.
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Reported by a viewer who kept seeing channels they had hidden.

## What is the current behavior?

**Recommendations.** Hiding a channel has never kept it out of recommendations. The check meant to spot a hidden channel compared two different forms of channel address, so it could never match and no recommendation was ever dropped.

**Home banner.** Hiding a featured channel removes its videos from the banner but not the channel itself, leaving its avatar, name and a subscribe button above an empty strip. The videos disappear because each tile hides itself; the header above them has no such check.

Feeds exclude hidden channels by a separate route and do work, so hiding appears to half-work.

## What is the new behavior?

Recommendations identify the channel the same way feeds do, so hiding a channel keeps it out of recommendations too. Channels blocked from your comments are left out as well, which is what feeds already did.

The banner leaves a hidden channel's section out altogether rather than showing an empty one, and no longer fetches videos it was going to discard.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

The banner image itself is left alone. It is editorial placement rather than anything claim-driven, so whether hiding a channel should suppress a slide Odysee chose to run is a product question rather than part of this bug.

The wording is deliberately untouched too. The buttons say hide, the confirmation says muted and the settings page says blocked, but agreeing on one word means retranslating it, so it belongs in its own change.

Two things the same report mentions are still open: hiding sometimes needing a page refresh before it takes effect, and a hidden channel reappearing after a few days. Both look like they involve account settings syncing and need testing against a real synced account.

No tests added. Both changes are filter conditions with no logic left worth pinning down once the comparison is right, and reaching either from a test would need a large amount of fake search state. Type check and lint pass, unit suite unchanged.

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>
