### PR TITLE
Leave hidden channels out of the home banner

### DIFF
--- a/ui/component/featuredBanner/view.tsx
+++ b/ui/component/featuredBanner/view.tsx
@@ -124,6 +124,41 @@ export default function FeaturedBanner(props: Props) {
   const { homepageData, authenticated } = props;
   const { featured } = homepageData;
   const latestClaimCount = 3;
+  const dispatch = useAppDispatch();
+
+  // A featured slide promotes one channel, so hiding that channel has to take the
+  // whole slide with it. Dropping only the embedded claims still left the
+  // channel's own promo image rotating through, which is the thing being hidden.
+  const featuredItems: Array<any> = React.useMemo(() => featured?.items || [], [featured]);
+  const featuredChannelUris = React.useMemo(
+    () => featuredItems.map((item) => getChannelUri(item.url)),
+    [featuredItems]
+  );
+
+  // Ban state needs the channel claim, and nothing else resolves these until a
+  // slide renders -- which is too late to decide whether to render it.
+  React.useEffect(() => {
+    featuredChannelUris.forEach((uri) => {
+      if (uri) dispatch(doResolveUri(uri));
+    });
+  }, [featuredChannelUris, dispatch]);
+
+  // Reduced to a string so this selector keeps returning the same value between
+  // renders instead of a fresh array every time.
+  const hiddenFlags = useAppSelector((state) =>
+    featuredChannelUris
+      .map((uri) => {
+        if (!uri) return '0';
+        const banState = selectBanStateForUri(state, uri);
+        return banState.muted || banState.blocked ? '1' : '0';
+      })
+      .join('')
+  );
+  const visibleItems = React.useMemo(
+    () => featuredItems.filter((_, i) => hiddenFlags[i] !== '1'),
+    [featuredItems, hiddenFlags]
+  );
+  const slideCount = visibleItems.length;
   const [marginLeft, setMarginLeft] = React.useState(0);
   const [width, setWidth] = React.useState(0);
   const [index, setIndex] = React.useState(1);
@@ -135,18 +170,24 @@ export default function FeaturedBanner(props: Props) {
   const imageWidth = width >= 1600 ? 1700 : width >= 1150 ? 1150 : width >= 900 ? 900 : width >= 600 ? 600 : 400;
   const navigate = useNavigate();
   React.useEffect(() => {
-    if (featured && width) {
+    if (slideCount && index > slideCount) {
+      setIndex(1);
+    }
+  }, [index, slideCount]);
+
+  React.useEffect(() => {
+    if (featured && width && slideCount) {
       const interval = setInterval(
         () => {
           if (!pause) {
-            setIndex(index + 1 <= featured.items.length ? index + 1 : 1);
+            setIndex(index + 1 <= slideCount ? index + 1 : 1);
           }
         },
         featured.transitionTime * 1000 + 1000
       );
       return () => clearInterval(interval);
     }
-  }, [featured, marginLeft, width, pause, index]);
+  }, [featured, marginLeft, width, pause, index, slideCount]);
   React.useEffect(() => {
     if (featured && width) {
       setMarginLeft((index - 1) * (width * -1));
@@ -187,6 +228,8 @@ export default function FeaturedBanner(props: Props) {
   }
 
   if (localBannerHidden) return null;
+  // Everything featured is hidden, so there is no carousel left to draw.
+  if (!slideCount) return null;
   return (
     <div
       className="featured-banner-wrapper"
@@ -200,47 +243,45 @@ export default function FeaturedBanner(props: Props) {
           marginLeft: marginLeft,
         }}
       >
-        {featured &&
-          featured.items.map((item, i) => {
-            return (
-              <div className="featured-banner-slide" key={i} style={{ minWidth: width }}>
-                <NavLink
-                  className="featured-banner-image"
-                  onClick={(e) => handleAnchor(e, item.url)}
-                  to={getUriTo(item.url)}
-                  target={!item.url.includes('odysee.com') ? '_blank' : undefined}
-                  title={item.label}
-                >
-                  <img
-                    src={'https://thumbnails.odycdn.com/optimize/s:' + imageWidth + ':0/quality:95/plain/' + item.image}
-                    style={{ width: width }}
-                  />
-                </NavLink>
-                {getChannelUri(item.url) && (
-                  <BannerLatestClaims channelUri={getChannelUri(item.url)} count={latestClaimCount} />
-                )}
-              </div>
-            );
-          })}
+        {visibleItems.map((item, i) => {
+          return (
+            <div className="featured-banner-slide" key={item.url || i} style={{ minWidth: width }}>
+              <NavLink
+                className="featured-banner-image"
+                onClick={(e) => handleAnchor(e, item.url)}
+                to={getUriTo(item.url)}
+                target={!item.url.includes('odysee.com') ? '_blank' : undefined}
+                title={item.label}
+              >
+                <img
+                  src={'https://thumbnails.odycdn.com/optimize/s:' + imageWidth + ':0/quality:95/plain/' + item.image}
+                  style={{ width: width }}
+                />
+              </NavLink>
+              {getChannelUri(item.url) && (
+                <BannerLatestClaims channelUri={getChannelUri(item.url)} count={latestClaimCount} />
+              )}
+            </div>
+          );
+        })}
       </div>
       <div className="banner-controls">
-        <div className="banner-browse left" onClick={() => setIndex(index > 1 ? index - 1 : featured.items.length)}>
+        <div className="banner-browse left" onClick={() => setIndex(index > 1 ? index - 1 : slideCount)}>
           ‹
         </div>
-        <div className="banner-browse right" onClick={() => setIndex(index < featured.items.length ? index + 1 : 1)}>
+        <div className="banner-browse right" onClick={() => setIndex(index < slideCount ? index + 1 : 1)}>
           ›
         </div>
         <div className="banner-active-indicator">
-          {featured &&
-            featured.items.map((item, i) => {
-              return (
-                <div
-                  key={i}
-                  className={i + 1 === index ? 'banner-active-indicator-active' : ''}
-                  onClick={() => setIndex(i + 1)}
-                />
-              );
-            })}
+          {visibleItems.map((item, i) => {
+            return (
+              <div
+                key={item.url || i}
+                className={i + 1 === index ? 'banner-active-indicator-active' : ''}
+                onClick={() => setIndex(i + 1)}
+              />
+            );
+          })}
         </div>
         {authenticated && (
           <button className="banner-close-button" onClick={removeBanner} aria-label="Close banner">

--- a/ui/component/featuredBanner/view.tsx
+++ b/ui/component/featuredBanner/view.tsx
@@ -6,6 +6,7 @@ import { NavLink } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from 'redux/hooks';
 import { selectClaimForUri, selectClaimSearchByQuery } from 'redux/selectors/claims';
+import { selectBanStateForUri } from 'lbryinc';
 import { doClaimSearch, doResolveUri } from 'redux/actions/claims';
 import { createNormalizedClaimSearchKey } from 'util/claim';
 import ClaimPreviewTile from 'component/claimPreviewTile';
@@ -39,6 +40,8 @@ function BannerLatestClaims({ channelUri, count }: { channelUri: string; count: 
   const dispatch = useAppDispatch();
   const channelClaim = useAppSelector((state) => selectClaimForUri(state, channelUri));
   const channelClaimId = channelClaim?.claim_id;
+  const banState = useAppSelector((state) => selectBanStateForUri(state, channelUri));
+  const channelIsHidden = Boolean(banState.muted || banState.blocked);
 
   const searchOptions = React.useMemo(() => {
     if (!channelClaimId) return null;
@@ -64,12 +67,20 @@ function BannerLatestClaims({ channelUri, count }: { channelUri: string; count: 
   }, [channelUri, dispatch]);
 
   React.useEffect(() => {
-    if (searchOptions && !searchResult) {
+    // No point fetching claims for a channel we are about to leave out. The
+    // channel itself still resolves above, since that is what tells us it is
+    // hidden in the first place.
+    if (searchOptions && !searchResult && !channelIsHidden) {
       dispatch(doClaimSearch(searchOptions));
     }
-  }, [searchOptions, searchResult, dispatch]);
+  }, [searchOptions, searchResult, dispatch, channelIsHidden]);
 
   const channelName = channelClaim?.value?.title || channelClaim?.name?.replace('@', '') || '';
+
+  // The tiles below hide themselves for a hidden channel, but the header does
+  // not, so hiding a featured channel used to leave its avatar, name and a
+  // subscribe button sitting above an empty strip.
+  if (channelIsHidden) return null;
 
   if (resultUris.length === 0) return null;
 


### PR DESCRIPTION
## Fixes

Issue Number:

## What is the current behavior?

Hiding a featured channel does not remove it from the home banner.

Its videos disappear, because each video tile hides itself, but nothing else does. The channel's name, picture and a subscribe button stay, sitting above an empty strip. The slide itself also stays, and a featured slide is a promotional image for one channel, so the hidden channel is still on the homepage and still one click away.

## What is the new behavior?

A hidden channel's slide is left out of the banner entirely, image included.

The rotation, the arrows and the position dots all count only the slides still being shown, so nothing lands on a slide that is not there. If every featured channel is hidden, the banner does not appear at all.

## Other information

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Claim searches are skipped for muted or blocked channels.
* Featured channel headers and content are hidden when channels are unavailable.
* Featured carousels now exclude unavailable channels and stay synchronized during navigation, automatic advancement, and indicator updates.
* Empty featured sections are hidden when no visible channels remain.
* Channel details continue to resolve correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->