### PR TITLE
Fix Shorts classification when metadata probes fail

### DIFF
--- a/ui/component/claimPreviewTile/view.tsx
+++ b/ui/component/claimPreviewTile/view.tsx
@@ -113,7 +113,8 @@ function probeShortVideoFromUrl(streamingUrl: string): Promise<boolean> {
       },
       { once: true }
     );
-    video.addEventListener('error', () => finish(true), { once: true });
+    // A failed probe is not evidence that a landscape-indexed video is a Short.
+    video.addEventListener('error', () => finish(false), { once: true });
     video.src = streamingUrl;
     video.load();
   });
@@ -254,7 +255,7 @@ function ClaimPreviewTile(props: Props) {
           const fileInfo = await Lbry.get({ uri });
           url = fileInfo?.streaming_url;
         } catch {
-          setProbedChannelShort(true);
+          if (!cancelled) setProbedChannelShort(false);
           return;
         }
       }
@@ -262,7 +263,7 @@ function ClaimPreviewTile(props: Props) {
       if (cancelled) return;
 
       if (!url) {
-        setProbedChannelShort(true);
+        setProbedChannelShort(false);
         return;
       }
 

--- a/ui/page/claim/internal/claimPageComponent/internal/channelPage/view.tsx
+++ b/ui/page/claim/internal/claimPageComponent/internal/channelPage/view.tsx
@@ -131,7 +131,8 @@ function probeShortVideoFromUrl(streamingUrl: string): Promise<boolean> {
       },
       { once: true }
     );
-    video.addEventListener('error', () => finish(true), { once: true });
+    // A failed probe is not evidence that a landscape-indexed video is a Short.
+    video.addEventListener('error', () => finish(false), { once: true });
     video.src = streamingUrl;
     video.load();
   });
@@ -289,16 +290,11 @@ function ChannelPage(props: Props) {
 
               if (cancelled) return;
 
-              if (!fileInfo?.streaming_url || (await probeShortVideoFromUrl(fileInfo.streaming_url))) {
+              if (fileInfo?.streaming_url && (await probeShortVideoFromUrl(fileInfo.streaming_url))) {
                 setHasShorts(true);
                 return;
               }
-            } catch {
-              if (!cancelled) {
-                setHasShorts(true);
-              }
-              return;
-            }
+            } catch {}
           }
 
           setHasShorts(false);


### PR DESCRIPTION
## Fixes

Issue Number:

## What is the current behavior?

Landscape videos with a short duration can appear in a channel's Shorts tab when browser metadata probing or the streaming URL request fails. For example, `@SJM/P1383019` is a 1280x720 video but can be shown as a Short.

The fallback treats an unavailable streaming URL, a rejected file request, or a video metadata error as a positive Shorts classification. Intermittent request failures and rate limiting can therefore admit unconfirmed landscape videos.

## What is the new behavior?

Landscape-indexed candidates are included only when a successful browser metadata probe confirms portrait dimensions. Failed or unavailable probes are treated as unconfirmed and excluded.

Rotated mobile videos remain supported because successful metadata probing can still confirm their displayed portrait dimensions.

## Other information

## PR Checklist

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [x] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Shorts detection on claim preview tiles and channel pages.
  - Videos are no longer incorrectly identified as Shorts when probing fails or streaming information is unavailable.
  - Channel pages now display Shorts indicators only when a video is successfully confirmed as a Short.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->