### PR TITLE
Fix stuck membership management for unavailable tiers

### DIFF
--- a/ui/page/creatorMemberships/supporterArea/pledgesTab/internal/membershipRow/view.tsx
+++ b/ui/page/creatorMemberships/supporterArea/pledgesTab/internal/membershipRow/view.tsx
@@ -108,7 +108,8 @@ export default function MembershipRow(props: Props) {
   //
   //
   //
-  if (!creatorChannelClaim || !membershipSub || membershipIndex === -1) {
+  // The subscription snapshot remains manageable even if its original tier is no longer listed.
+  if (!creatorChannelClaim || !membershipSub) {
     return (
       <tr>
         <td colSpan={9}>


### PR DESCRIPTION
## Fixes

Issue Number:

<!-- Tip:
 - Add keywords to directly close the Issue when the PR is merged.
 - Skip the keyword if the Issue contains multiple items.
 - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## What is the current behavior?

A purchased channel membership remains on an infinite loading spinner when its original membership tier is no longer returned by the creator's current tier list. This makes the existing membership management and cancellation controls inaccessible.

## What is the new behavior?

Purchased memberships render from their subscription snapshot once the creator channel resolves, even when the original tier is unavailable. The existing tier lookup, membership row, renewal behavior, and cancellation UI remain unchanged.

## Other information

Validated with type-aware lint, 23 unit tests, and a production build.

<!-- If this PR contains a breaking change, please describe the impact and solution strategy for existing applications below. -->

## PR Checklist

<!-- For the checkbox formatting to work properly, make sure there are no spaces on either side of the "x" -->

<details><summary>Toggle...</summary>

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation changes
- [ ] Other - Please describe:

Please check all that apply to this PR using "x":

- [ ] I have checked that this PR is not a duplicate of an existing PR (open, closed or merged)
- [x] I have checked that this PR does not introduce a breaking change
- [ ] This PR introduces breaking changes and I have provided a detailed explanation below

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription rows now remain visible when the original membership tier is no longer listed.
  * Subscription snapshot details are displayed while membership information is unavailable, instead of showing an indefinite loading spinner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->